### PR TITLE
Add minimal React PWA dating app prototype

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,20 @@
 # VideoTinder
+
+VideoTinder is a minimal progressive web app (PWA) dating prototype. Instead of photos, users swipe through short 5‑second videos. A button allows inviting matches to a quick speed date.
+
+## Features
+
+* Swipe left/right on short videos
+* Offline support via service worker
+* Invite to video speed date (placeholder)
+
+## Getting Started
+
+1. Install dependencies
+   ```bash
+   npm install
+   ```
+2. Start a simple web server from the project root (for example using `npx serve`).
+3. Open `public/index.html` in your browser.
+
+Since dependencies are loaded from CDNs, no build step is required.

--- a/package.json
+++ b/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "videotinder",
+  "version": "1.0.0",
+  "description": "A minimal React PWA for swiping short videos and speed dating.",
+  "scripts": {
+    "start": "npx serve -s ."
+  },
+  "dependencies": {
+    "react": "^17.0.0",
+    "react-dom": "^17.0.0"
+  }
+}

--- a/public/index.html
+++ b/public/index.html
@@ -1,0 +1,16 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <meta name="theme-color" content="#ff4957" />
+  <link rel="manifest" href="manifest.json" />
+  <title>VideoTinder</title>
+</head>
+<body>
+  <noscript>You need to enable JavaScript to run this app.</noscript>
+  <link rel="stylesheet" href="../src/style.css" />
+  <div id="root"></div>
+  <script type="module" src="../src/index.js"></script>
+</body>
+</html>

--- a/public/manifest.json
+++ b/public/manifest.json
@@ -1,0 +1,10 @@
+{
+  "name": "VideoTinder",
+  "short_name": "VTinder",
+  "start_url": ".",
+  "display": "standalone",
+  "background_color": "#ffffff",
+  "theme_color": "#ff4957",
+  "description": "Swipe short videos and connect for a speed date",
+  "icons": []
+}

--- a/public/service-worker.js
+++ b/public/service-worker.js
@@ -1,0 +1,21 @@
+const CACHE_NAME = 'videotinder-v1';
+const URLS_TO_CACHE = [
+  '/',
+  '/public/index.html',
+];
+
+self.addEventListener('install', event => {
+  event.waitUntil(
+    caches.open(CACHE_NAME).then(cache => {
+      return cache.addAll(URLS_TO_CACHE);
+    })
+  );
+});
+
+self.addEventListener('fetch', event => {
+  event.respondWith(
+    caches.match(event.request).then(response => {
+      return response || fetch(event.request);
+    })
+  );
+});

--- a/src/App.js
+++ b/src/App.js
@@ -1,0 +1,37 @@
+import React, { useState } from 'https://cdn.skypack.dev/react';
+import VideoCard from './components/VideoCard.js';
+
+const sampleVideos = [
+  'sample1.mp4',
+  'sample2.mp4',
+  'sample3.mp4',
+];
+
+export default function App() {
+  const [videos, setVideos] = useState(sampleVideos);
+
+  const handleSwipe = (direction) => {
+    setVideos(videos.slice(1));
+  };
+
+  const inviteToSpeedDate = () => {
+    alert('Speed date invitation sent!');
+  };
+
+  const current = videos[0];
+
+  return (
+    <div className="app">
+      {current ? (
+        <VideoCard
+          src={current}
+          onSwipeLeft={() => handleSwipe('left')}
+          onSwipeRight={() => handleSwipe('right')}
+        />
+      ) : (
+        <p>No more videos</p>
+      )}
+      <button onClick={inviteToSpeedDate}>Invite to Speed Date</button>
+    </div>
+  );
+}

--- a/src/components/VideoCard.js
+++ b/src/components/VideoCard.js
@@ -1,0 +1,29 @@
+import React, { useRef } from 'https://cdn.skypack.dev/react';
+
+export default function VideoCard({ src, onSwipeLeft, onSwipeRight }) {
+  const ref = useRef(null);
+  let startX = null;
+
+  const handleTouchStart = (e) => {
+    const touch = e.touches[0];
+    startX = touch.clientX;
+  };
+
+  const handleTouchEnd = (e) => {
+    if (startX === null) return;
+    const touch = e.changedTouches[0];
+    const diffX = touch.clientX - startX;
+    if (diffX > 50) {
+      onSwipeRight();
+    } else if (diffX < -50) {
+      onSwipeLeft();
+    }
+    startX = null;
+  };
+
+  return (
+    <div ref={ref} className="video-card" onTouchStart={handleTouchStart} onTouchEnd={handleTouchEnd}>
+      <video src={src} autoPlay loop muted playsInline width="300" height="500" />
+    </div>
+  );
+}

--- a/src/index.js
+++ b/src/index.js
@@ -1,0 +1,12 @@
+import React from 'https://cdn.skypack.dev/react';
+import ReactDOM from 'https://cdn.skypack.dev/react-dom';
+import App from './App.js';
+import './style.css';
+
+ReactDOM.render(React.createElement(App), document.getElementById('root'));
+
+if ('serviceWorker' in navigator) {
+  window.addEventListener('load', () => {
+    navigator.serviceWorker.register('/public/service-worker.js');
+  });
+}

--- a/src/style.css
+++ b/src/style.css
@@ -1,0 +1,17 @@
+body {
+  font-family: sans-serif;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: #f5f5f5;
+  height: 100vh;
+  margin: 0;
+}
+
+.app {
+  text-align: center;
+}
+
+.video-card {
+  margin-bottom: 1rem;
+}


### PR DESCRIPTION
## Summary
- initialize package.json with React deps
- add public files for PWA
- add React components for video swiping and speed date invite
- document setup and features in README

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_686bb51451d0832d925a6f4d703bc6fa