### PR TITLE
Fix manifest 404

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -4,7 +4,7 @@
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <meta name="theme-color" content="#ff4957" />
-  <link rel="manifest" href="manifest.json" />
+  <link rel="manifest" href="/public/manifest.json" />
   <title>VideoTinder</title>
 </head>
 <body>


### PR DESCRIPTION
## Summary
- fix path to manifest.json in index.html to avoid 404 errors

## Testing
- `npm install` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_686c255faff0832d8edcb7a47ac05002