### PR TITLE
Fix manifest fetch path

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -4,7 +4,7 @@
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <meta name="theme-color" content="#ff4957" />
-  <link rel="manifest" href="/public/manifest.json" />
+  <link rel="manifest" href="manifest.json" />
   <title>VideoTinder</title>
 </head>
 <body>

--- a/src/index.js
+++ b/src/index.js
@@ -6,6 +6,6 @@ ReactDOM.render(React.createElement(App), document.getElementById('root'));
 
 if ('serviceWorker' in navigator) {
   window.addEventListener('load', () => {
-    navigator.serviceWorker.register('/public/service-worker.js');
+    navigator.serviceWorker.register('service-worker.js');
   });
 }


### PR DESCRIPTION
## Summary
- register service worker relative to page
- reference manifest file with a relative path

## Testing
- `npm install`
- `npm start` *(fails: interactive prompt, then run with `yes`)*

------
https://chatgpt.com/codex/tasks/task_e_686c3b78e8b4832dbcbf505f1017659d