### PR TITLE
Disable looping in video playback

### DIFF
--- a/src/components/VideoCard.js
+++ b/src/components/VideoCard.js
@@ -32,7 +32,7 @@ export default function VideoCard({ src, onSwipeLeft, onSwipeRight }) {
     React.createElement('video', {
       src: src,
       autoPlay: true,
-      loop: true,
+      // Remove the loop attribute so each video plays once
       muted: true,
       playsInline: true,
       width: 300,


### PR DESCRIPTION
## Summary
- remove the `loop` attribute from the video element to stop looping

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_686c422eecb4832dbfd01770ef129954