### PR TITLE
Handle cache errors in service worker

### DIFF
--- a/public/service-worker.js
+++ b/public/service-worker.js
@@ -8,9 +8,13 @@ const URLS_TO_CACHE = [
 
 self.addEventListener('install', event => {
   event.waitUntil(
-    caches.open(CACHE_NAME).then(cache => {
-      return cache.addAll(URLS_TO_CACHE);
-    })
+    caches
+      .open(CACHE_NAME)
+      .then(cache => cache.addAll(URLS_TO_CACHE))
+      .catch(err => {
+        // Avoid uncaught promise rejections if a file fails to cache
+        console.error('Precache failed', err);
+      })
   );
 });
 


### PR DESCRIPTION
## Summary
- handle failures when caching files during service worker installation

## Testing
- `python3 -m http.server 8000` && `curl -I http://localhost:8000/public/index.html`


------
https://chatgpt.com/codex/tasks/task_e_686c4262e230832d866fe8f89df4c16f