### PR TITLE
Implement drag-based swiping

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ VideoTinder is a minimal progressive web app (PWA) dating prototype. Instead of 
 
 ## Features
 
-* Swipe left/right on short videos
+* Drag left/right on short videos to swipe like Tinder
 * Offline support via service worker
 * Invite to video speed date (placeholder)
 

--- a/src/components/VideoCard.js
+++ b/src/components/VideoCard.js
@@ -1,24 +1,31 @@
-import React, { useRef } from 'https://cdn.skypack.dev/react';
+import React, { useRef, useState } from 'https://cdn.skypack.dev/react';
 
 export default function VideoCard({ src, onSwipeLeft, onSwipeRight }) {
   const ref = useRef(null);
-  let startX = null;
+  const startX = useRef(null);
+  const [offset, setOffset] = useState(0);
 
-  const handleTouchStart = (e) => {
-    const touch = e.touches[0];
-    startX = touch.clientX;
+  const handlePointerDown = (e) => {
+    startX.current = e.clientX;
   };
 
-  const handleTouchEnd = (e) => {
-    if (startX === null) return;
-    const touch = e.changedTouches[0];
-    const diffX = touch.clientX - startX;
-    if (diffX > 50) {
+  const handlePointerMove = (e) => {
+    if (startX.current === null) return;
+    const diffX = e.clientX - startX.current;
+    setOffset(diffX);
+  };
+
+  const handlePointerUp = (e) => {
+    if (startX.current === null) return;
+    const diffX = e.clientX - startX.current;
+    if (diffX > 100) {
       onSwipeRight();
-    } else if (diffX < -50) {
+    } else if (diffX < -100) {
       onSwipeLeft();
+    } else {
+      setOffset(0);
     }
-    startX = null;
+    startX.current = null;
   };
 
   return React.createElement(
@@ -26,8 +33,11 @@ export default function VideoCard({ src, onSwipeLeft, onSwipeRight }) {
     {
       ref: ref,
       className: 'video-card',
-      onTouchStart: handleTouchStart,
-      onTouchEnd: handleTouchEnd,
+      style: { transform: `translateX(${offset}px)` },
+      onPointerDown: handlePointerDown,
+      onPointerMove: handlePointerMove,
+      onPointerUp: handlePointerUp,
+      onPointerCancel: handlePointerUp,
     },
     React.createElement('video', {
       src: src,

--- a/src/style.css
+++ b/src/style.css
@@ -25,6 +25,8 @@ body {
   box-shadow: 0 2px 8px rgba(0, 0, 0, 0.1);
   border-radius: 8px;
   overflow: hidden;
+  touch-action: pan-y;
+  transition: transform 0.3s ease-out;
 }
 
 button {


### PR DESCRIPTION
## Summary
- add Tinder-style drag interactions in `VideoCard`
- animate card movement via CSS
- mention drag swiping in README

## Testing
- `npm start` *(fails: needs serve package)*

------
https://chatgpt.com/codex/tasks/task_e_686c437b2b74832d8ef278be1dca7d4a