### PR TITLE
Add FaceTime-style speed date screen

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,8 @@ VideoTinder is a minimal progressive web app (PWA) dating prototype. Instead of 
 
 * Swipe left/right on short videos
 * Offline support via service worker
-* Invite to video speed date (placeholder)
+* Invite to video speed date
+* New FaceTime-style speed date screen
 
 ## Getting Started
 

--- a/src/App.js
+++ b/src/App.js
@@ -1,5 +1,6 @@
 import React, { useState } from 'https://cdn.skypack.dev/react';
 import VideoCard from './components/VideoCard.js';
+import SpeedDate from './components/SpeedDate.js';
 
 const sampleVideos = [
   'sample1.mp4',
@@ -9,16 +10,25 @@ const sampleVideos = [
 
 export default function App() {
   const [videos, setVideos] = useState(sampleVideos);
+  const [showSpeedDate, setShowSpeedDate] = useState(false);
 
   const handleSwipe = (direction) => {
     setVideos(videos.slice(1));
   };
 
   const inviteToSpeedDate = () => {
-    alert('Speed date invitation sent!');
+    setShowSpeedDate(true);
+  };
+
+  const endSpeedDate = () => {
+    setShowSpeedDate(false);
   };
 
   const current = videos[0];
+
+  if (showSpeedDate) {
+    return React.createElement(SpeedDate, { onEnd: endSpeedDate });
+  }
 
   return React.createElement(
     'div',

--- a/src/components/SpeedDate.js
+++ b/src/components/SpeedDate.js
@@ -1,0 +1,28 @@
+import React from 'https://cdn.skypack.dev/react';
+
+export default function SpeedDate({ onEnd }) {
+  const videoSrc = 'sample1.mp4';
+  return React.createElement(
+    'div',
+    { className: 'speed-date' },
+    React.createElement('video', {
+      src: videoSrc,
+      autoPlay: true,
+      muted: true,
+      playsInline: true,
+      className: 'remote-video',
+    }),
+    React.createElement('video', {
+      src: videoSrc,
+      autoPlay: true,
+      muted: true,
+      playsInline: true,
+      className: 'local-video',
+    }),
+    React.createElement(
+      'button',
+      { onClick: onEnd, className: 'end-call-button' },
+      'End Call'
+    )
+  );
+}

--- a/src/style.css
+++ b/src/style.css
@@ -40,3 +40,31 @@ button {
 button:hover {
   opacity: 0.9;
 }
+
+.speed-date {
+  position: relative;
+  width: 100%;
+  height: 100vh;
+  background: black;
+}
+
+.remote-video {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+}
+
+.local-video {
+  position: absolute;
+  bottom: 1rem;
+  right: 1rem;
+  width: 30%;
+  border: 2px solid white;
+  border-radius: 8px;
+}
+
+.end-call-button {
+  position: absolute;
+  bottom: 1rem;
+  left: 1rem;
+}


### PR DESCRIPTION
## Summary
- add new `SpeedDate` component with FaceTime-style layout
- toggle to the speed date screen from `App` when inviting
- style the speed date view
- document the new screen in README

## Testing
- `npm install`
- `npm start` *(fails: prompts for package installation)*

------
https://chatgpt.com/codex/tasks/task_e_686c43ae0110832db64becd6d782cdc3