### PR TITLE
Add signup screen

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@ VideoTinder is a minimal progressive web app (PWA) dating prototype. Instead of 
 
 * Swipe left/right on short videos
 * Offline support via service worker
+* Simple sign-up form
 * Invite to video speed date (placeholder)
 
 ## Getting Started
@@ -19,5 +20,6 @@ VideoTinder is a minimal progressive web app (PWA) dating prototype. Instead of 
    npm start
    ```
 3. Open `public/index.html` in your browser.
+4. Sign up with your name to start swiping.
 
 Since dependencies are loaded from CDNs, no build step is required.

--- a/src/App.js
+++ b/src/App.js
@@ -1,5 +1,6 @@
 import React, { useState } from 'https://cdn.skypack.dev/react';
 import VideoCard from './components/VideoCard.js';
+import SignUp from './components/SignUp.js';
 
 const sampleVideos = [
   'sample1.mp4',
@@ -8,6 +9,13 @@ const sampleVideos = [
 ];
 
 export default function App() {
+  const [signedUp, setSignedUp] = useState(() => {
+    try {
+      return Boolean(localStorage.getItem('name'));
+    } catch {
+      return false;
+    }
+  });
   const [videos, setVideos] = useState(sampleVideos);
 
   const handleSwipe = (direction) => {
@@ -19,6 +27,10 @@ export default function App() {
   };
 
   const current = videos[0];
+
+  if (!signedUp) {
+    return React.createElement(SignUp, { onSignUp: () => setSignedUp(true) });
+  }
 
   return React.createElement(
     'div',

--- a/src/components/SignUp.js
+++ b/src/components/SignUp.js
@@ -1,0 +1,34 @@
+import React, { useState } from 'https://cdn.skypack.dev/react';
+
+export default function SignUp({ onSignUp }) {
+  const [name, setName] = useState('');
+
+  const handleSubmit = (e) => {
+    e.preventDefault();
+    if (name.trim()) {
+      try {
+        localStorage.setItem('name', name.trim());
+      } catch (err) {
+        // ignore storage errors
+      }
+      onSignUp();
+    }
+  };
+
+  return React.createElement(
+    'form',
+    { onSubmit: handleSubmit, className: 'signup-form' },
+    React.createElement('h2', null, 'Sign Up'),
+    React.createElement('input', {
+      type: 'text',
+      placeholder: 'Your name',
+      value: name,
+      onChange: (e) => setName(e.target.value),
+    }),
+    React.createElement(
+      'button',
+      { type: 'submit' },
+      'Sign Up'
+    )
+  );
+}

--- a/src/style.css
+++ b/src/style.css
@@ -40,3 +40,15 @@ button {
 button:hover {
   opacity: 0.9;
 }
+
+.signup-form {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+  align-items: center;
+}
+
+.signup-form input {
+  padding: 0.5rem;
+  font-size: 1rem;
+}


### PR DESCRIPTION
## Summary
- add a simple sign-up form component
- show sign-up screen until user registers
- style the form and update documentation

## Testing
- `npm install`


------
https://chatgpt.com/codex/tasks/task_e_686c43c44b2c832d81e90d19d7353a8f