### PR TITLE
Update upload-artifact action version

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -18,7 +18,7 @@ jobs:
           cache: 'npm'
       - run: npm ci
       - run: npm run build
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         with:
           name: dist
           path: dist

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+node_modules/
+dist/
+.parcel-cache/


### PR DESCRIPTION
## Summary
- ignore build artifacts and node modules
- update GitHub Actions workflow to use `actions/upload-artifact@v4`

## Testing
- `npm ci`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_686d6329b7a8832d97d068e5f5ce27ae