### PR TITLE
Fix GitHub Pages asset paths

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "start": "npx serve .",
     "dev": "parcel public/index.html",
-    "build": "parcel build public/index.html --dist-dir dist"
+    "build": "parcel build public/index.html --dist-dir dist --public-url ./"
   },
   "dependencies": {
     "firebase": "^9.23.0",


### PR DESCRIPTION
## Summary
- ensure parcel uses relative URLs when building for Pages

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_686d69249bac832dbc78d877c48a5d61