### PR TITLE
Implement reflection saving feature

### DIFF
--- a/src/components/DailyCheckIn.jsx
+++ b/src/components/DailyCheckIn.jsx
@@ -1,13 +1,21 @@
-import React from 'react';
+import React, { useState } from 'react';
 import { Card } from './ui/card.js';
 import { Button } from './ui/button.js';
 import { Textarea } from './ui/textarea.js';
 import SectionTitle from './SectionTitle.jsx';
-import { useCollection } from '../firebase.js';
+import { useCollection, db, doc, setDoc } from '../firebase.js';
 
 export default function DailyCheckIn({ userId }) {
   const refs = useCollection('reflections','userId',userId);
   const days = Array.from({length:30},(_,i)=>i+1);
+  const [text,setText]=useState('');
+
+  const save = async () => {
+    if(!text.trim()) return;
+    const id = Date.now().toString();
+    await setDoc(doc(db,'reflections',id),{id,userId,day:refs.length+1,text:text.trim()});
+    setText('');
+  };
 
   return React.createElement(Card, { className: 'p-6 m-4 shadow-xl bg-white/90' },
     React.createElement(SectionTitle, { title: 'Dagens refleksion' }),
@@ -22,7 +30,16 @@ export default function DailyCheckIn({ userId }) {
     React.createElement('ul', { className: 'list-disc list-inside mb-4' },
       refs.map(r => React.createElement('li', { key: r.id }, `Dag ${r.day}: ${r.text}`))
     ),
-    React.createElement(Textarea, { placeholder: 'Del din refleksion...', className: 'mb-4' }),
-    React.createElement(Button, { className: 'bg-pink-500 text-white' }, 'Gem refleksion')
+    React.createElement(Textarea, {
+      placeholder: 'Del din refleksion...',
+      className: 'mb-4',
+      value: text,
+      onChange: e => setText(e.target.value)
+    }),
+    React.createElement(Button, {
+      className: 'bg-pink-500 text-white',
+      disabled: !text.trim(),
+      onClick: save
+    }, 'Gem refleksion')
   );
 }


### PR DESCRIPTION
## Summary
- allow saving daily reflections to Firestore
- disable save button until text is entered

## Testing
- `npm run build` *(fails: parcel not found)*

------
https://chatgpt.com/codex/tasks/task_e_686d6cba8144832d8eb45e4d1b7747b1