### PR TITLE
Change Synes label to Like

### DIFF
--- a/src/components/DailyDiscovery.jsx
+++ b/src/components/DailyDiscovery.jsx
@@ -47,7 +47,7 @@ export default function DailyDiscovery({ userId, onSelectProfile, ageRange }) {
               React.createElement(PlayCircle, { className: 'w-5 h-5' }), 'Afspil'
             ),
             React.createElement(Button, { size: 'sm', className: 'bg-pink-500 text-white flex items-center gap-1' },
-              React.createElement(Heart, { className: 'w-5 h-5' }), 'Synes'
+              React.createElement(Heart, { className: 'w-5 h-5' }), 'Like'
             )
           )
         )


### PR DESCRIPTION
## Summary
- rename the like button label on the DailyDiscovery component from *Synes* to *Like*

## Testing
- `npm install`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_686d6c8fc998832dbb374e468e9ed615