### PR TITLE
Fix profile navigation and allow saving settings

### DIFF
--- a/src/RealDatingApp.jsx
+++ b/src/RealDatingApp.jsx
@@ -52,7 +52,9 @@ export default function RealDatingApp() {
         React.createElement(ProfileSettings, { userId: viewProfile, ageRange, onChangeAgeRange: setAgeRange })
       ),
       tab==='chat' && React.createElement(ChatScreen, { userId }),
-      tab==='checkin' && React.createElement(DailyCheckIn, { userId })
+      tab==='checkin' && React.createElement(DailyCheckIn, { userId }),
+      tab==='profile' && React.createElement(ProfileSettings, { userId, ageRange, onChangeAgeRange: setAgeRange }),
+      tab==='admin' && React.createElement(AdminScreen, { profiles, onSwitch: setUserId })
     ),
     React.createElement('div', { className: 'p-4 bg-white shadow-inner flex justify-around' },
       React.createElement(HomeIcon, { className: 'w-8 h-8 text-pink-600', onClick: ()=>{setTab('discovery'); setViewProfile(null);} }),
@@ -60,8 +62,6 @@ export default function RealDatingApp() {
       React.createElement(CalendarDays, { className: 'w-8 h-8 text-pink-600', onClick: ()=>setTab('checkin') }),
       React.createElement(UserIcon, { className: 'w-8 h-8 text-pink-600', onClick: ()=>setTab('profile') }),
       React.createElement(Sparkles, { className: 'w-8 h-8 text-pink-600', onClick: ()=>setTab('admin') })
-    ),
-    tab==='profile' && React.createElement(ProfileSettings, { userId, ageRange, onChangeAgeRange: setAgeRange }),
-    tab==='admin' && React.createElement(AdminScreen, { profiles, onSwitch: setUserId })
+    )
   );
 }

--- a/src/components/ProfileSettings.jsx
+++ b/src/components/ProfileSettings.jsx
@@ -3,12 +3,16 @@ import { Mic, Camera as CameraIcon } from 'lucide-react';
 import { Card } from './ui/card.js';
 import { Textarea } from './ui/textarea.js';
 import SectionTitle from './SectionTitle.jsx';
-import { db, getDoc, doc } from '../firebase.js';
+import { db, getDoc, doc, updateDoc } from '../firebase.js';
 
 export default function ProfileSettings({ userId, ageRange, onChangeAgeRange }) {
   const [profile,setProfile]=useState(null);
   useEffect(()=>{if(!userId)return;getDoc(doc(db,'profiles',userId)).then(s=>s.exists()&&setProfile({id:s.id,...s.data()}));},[userId]);
   if(!profile) return React.createElement('p', null, 'Indlæser profil...');
+
+  const saveChanges = async () => {
+    await updateDoc(doc(db,'profiles',userId), { ageRange });
+  };
 
   return React.createElement(Card, { className: 'p-6 m-4 shadow-xl bg-white/90' },
     React.createElement(SectionTitle, { title: `${profile.name}, ${profile.age}` }),
@@ -42,6 +46,10 @@ export default function ProfileSettings({ userId, ageRange, onChangeAgeRange }) 
     React.createElement(SectionTitle, { title: 'Lyd-klip' }),
     React.createElement('div', { className: 'flex space-x-4 mb-4' }, (profile.audioClips||[]).slice(0,3).map((_,i)=>React.createElement(Mic,{key:i,className:'w-10 h-10'}))),
     React.createElement(SectionTitle, { title: 'Om mig' }),
-    React.createElement(Textarea, { readOnly: true }, profile.clip)
-  );
+      React.createElement(Textarea, { readOnly: true }, profile.clip),
+      React.createElement('button', {
+        className: 'mt-4 bg-pink-500 text-white px-4 py-2 rounded',
+        onClick: saveChanges
+      }, 'Gem ændringer')
+    );
 }


### PR DESCRIPTION
## Summary
- keep navigation below profile by rendering the ProfileSettings/Admin screens inside the main content container
- add a save button on the profile screen to persist the selected age range

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_686d6cfe5d48832d865f2e7b7980d48f