### PR TITLE
Adjust admin UI layout and add reset

### DIFF
--- a/src/RealDatingApp.jsx
+++ b/src/RealDatingApp.jsx
@@ -42,6 +42,7 @@ export default function RealDatingApp() {
 
   if(step===0) return React.createElement(WelcomeScreen, { onNext: ()=>setStep(1) });
   const selectProfile=id=>{setViewProfile(id); setTab('discovery');};
+  const handleReset=()=>{seedData();};
 
   return React.createElement('div', { className: 'flex flex-col min-h-screen bg-gradient-to-br from-pink-100 to-white' },
     React.createElement('div', { className: 'flex-1' },
@@ -52,7 +53,9 @@ export default function RealDatingApp() {
         React.createElement(ProfileSettings, { userId: viewProfile, ageRange, onChangeAgeRange: setAgeRange })
       ),
       tab==='chat' && React.createElement(ChatScreen, { userId }),
-      tab==='checkin' && React.createElement(DailyCheckIn, { userId })
+      tab==='checkin' && React.createElement(DailyCheckIn, { userId }),
+      tab==='profile' && React.createElement(ProfileSettings, { userId, ageRange, onChangeAgeRange: setAgeRange }),
+      tab==='admin' && React.createElement(AdminScreen, { profiles, onSwitch: setUserId, onReset: handleReset })
     ),
     React.createElement('div', { className: 'p-4 bg-white shadow-inner flex justify-around' },
       React.createElement(HomeIcon, { className: 'w-8 h-8 text-pink-600', onClick: ()=>{setTab('discovery'); setViewProfile(null);} }),
@@ -60,8 +63,6 @@ export default function RealDatingApp() {
       React.createElement(CalendarDays, { className: 'w-8 h-8 text-pink-600', onClick: ()=>setTab('checkin') }),
       React.createElement(UserIcon, { className: 'w-8 h-8 text-pink-600', onClick: ()=>setTab('profile') }),
       React.createElement(Sparkles, { className: 'w-8 h-8 text-pink-600', onClick: ()=>setTab('admin') })
-    ),
-    tab==='profile' && React.createElement(ProfileSettings, { userId, ageRange, onChangeAgeRange: setAgeRange }),
-    tab==='admin' && React.createElement(AdminScreen, { profiles, onSwitch: setUserId })
+    )
   );
 }

--- a/src/components/AdminScreen.jsx
+++ b/src/components/AdminScreen.jsx
@@ -1,8 +1,9 @@
 import React from 'react';
 import { Card } from './ui/card.js';
+import { Button } from './ui/button.js';
 import SectionTitle from './SectionTitle.jsx';
 
-export default function AdminScreen({ profiles, onSwitch }) {
+export default function AdminScreen({ profiles, onSwitch, onReset }) {
   return React.createElement(Card, { className: 'p-6 m-4 shadow-xl bg-white/90' },
     React.createElement(SectionTitle, { title: 'Admin: Skift profil' }),
     React.createElement('select', {
@@ -13,6 +14,7 @@ export default function AdminScreen({ profiles, onSwitch }) {
       React.createElement('option', { value: '' }, '-- vælg profil --'),
       profiles.map(p => React.createElement('option', { key: p.id, value: p.id }, p.name))
     ),
-    React.createElement('p', { className: 'text-gray-500 text-sm' }, 'Oplev app’en som en anden bruger.')
+    React.createElement('p', { className: 'text-gray-500 text-sm mb-4' }, 'Oplev app’en som en anden bruger.'),
+    React.createElement(Button, { className: 'bg-red-500 text-white', onClick: onReset }, 'Reset database')
   );
 }


### PR DESCRIPTION
## Summary
- ensure navigation stays at bottom on the admin page
- add ability to reset database from admin screen

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_686d6d3d1194832dbde9a899caab79b7