### PR TITLE
Add reset button to Admin

### DIFF
--- a/src/components/AdminScreen.jsx
+++ b/src/components/AdminScreen.jsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import { Card } from './ui/card.js';
+import { Button } from './ui/button.js';
 import SectionTitle from './SectionTitle.jsx';
 
 export default function AdminScreen({ profiles, onSwitch }) {
@@ -13,6 +14,7 @@ export default function AdminScreen({ profiles, onSwitch }) {
       React.createElement('option', { value: '' }, '-- vælg profil --'),
       profiles.map(p => React.createElement('option', { key: p.id, value: p.id }, p.name))
     ),
-    React.createElement('p', { className: 'text-gray-500 text-sm' }, 'Oplev app’en som en anden bruger.')
+    React.createElement('p', { className: 'text-gray-500 text-sm' }, 'Oplev app’en som en anden bruger.'),
+    React.createElement(Button, { className: 'mt-4 bg-pink-500 text-white px-4 py-2 rounded' }, 'Reset database')
   );
 }


### PR DESCRIPTION
## Summary
- add `Button` import in AdminScreen
- add a new "Reset database" button on the admin screen

## Testing
- `npm install`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_686d733450f4832dace68dddbdddec3e