### PR TITLE
Show placeholder media icons on profile page

### DIFF
--- a/src/components/ProfileSettings.jsx
+++ b/src/components/ProfileSettings.jsx
@@ -42,9 +42,19 @@ export default function ProfileSettings({ userId, ageRange, onChangeAgeRange }) 
       )
     ),
     React.createElement(SectionTitle, { title: 'Video-klip' }),
-    React.createElement('div', { className: 'flex space-x-4 mb-4' }, (profile.videoClips||[]).slice(0,3).map((_,i)=>React.createElement(CameraIcon,{key:i,className:'w-10 h-10'}))),
+    React.createElement('div', { className: 'flex space-x-4 mb-4' },
+      Array.from({length:3}).map((_,i)=>{
+        const hasClip=(profile.videoClips||[])[i];
+        return React.createElement(CameraIcon,{key:i,className:`w-10 h-10 ${hasClip?'':'opacity-50 text-gray-400'}`});
+      })
+    ),
     React.createElement(SectionTitle, { title: 'Lyd-klip' }),
-    React.createElement('div', { className: 'flex space-x-4 mb-4' }, (profile.audioClips||[]).slice(0,3).map((_,i)=>React.createElement(Mic,{key:i,className:'w-10 h-10'}))),
+    React.createElement('div', { className: 'flex space-x-4 mb-4' },
+      Array.from({length:3}).map((_,i)=>{
+        const hasClip=(profile.audioClips||[])[i];
+        return React.createElement(Mic,{key:i,className:`w-10 h-10 ${hasClip?'':'opacity-50 text-gray-400'}`});
+      })
+    ),
     React.createElement(SectionTitle, { title: 'Om mig' }),
       React.createElement(Textarea, { readOnly: true }, profile.clip),
       React.createElement('button', {


### PR DESCRIPTION
## Summary
- always display 3 icons for videos and audio in profile settings
- fade icons when there are no clips in the database

## Testing
- `npm install`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_686d742e46e4832db7f738a1f93dad76