### PR TITLE
Expand gradient background

### DIFF
--- a/src/RealDatingApp.jsx
+++ b/src/RealDatingApp.jsx
@@ -48,7 +48,7 @@ export default function RealDatingApp() {
 
 
 
-  return React.createElement('div', { className: 'flex flex-col min-h-screen w-full bg-gradient-to-br from-pink-100 to-white' },
+  return React.createElement('div', { className: 'flex flex-col min-h-screen w-screen bg-gradient-to-br from-pink-100 to-white' },
 
     React.createElement('div', { className: 'flex-1' },
 

--- a/src/style.css
+++ b/src/style.css
@@ -7,13 +7,10 @@
 
 body {
   font-family: sans-serif;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  background: var(--background-color);
+  background: linear-gradient(to bottom right, #fce7f3, #ffffff);
   color: var(--text-color);
-  height: 100vh;
   margin: 0;
+  min-height: 100vh;
 }
 
 .app {


### PR DESCRIPTION
## Summary
- ensure the body spans the full page with a gradient background
- stretch the main app container to the full viewport width

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_686d7976ac08832d946c2e97c25417a8