### PR TITLE
Add mobile web app meta tag

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -5,6 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <meta name="theme-color" content="#ff4957" />
   <meta name="apple-mobile-web-app-capable" content="yes" />
+  <meta name="mobile-web-app-capable" content="yes" />
   <meta name="apple-mobile-web-app-status-bar-style" content="black-translucent" />
   <link rel="manifest" href="manifest.json" />
   <title>RealDating</title>


### PR DESCRIPTION
## Summary
- include `<meta name="mobile-web-app-capable" content="yes">`

## Testing
- `npm test` *(fails: Missing script)*
- `npm install`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_686d7e147254832d9b7b28a95d749738