### PR TITLE
Fix seedData reference

### DIFF
--- a/src/RealDatingApp.jsx
+++ b/src/RealDatingApp.jsx
@@ -7,7 +7,6 @@ import DailyCheckIn from './components/DailyCheckIn.jsx';
 import ProfileSettings from './components/ProfileSettings.jsx';
 import AdminScreen from './components/AdminScreen.jsx';
 import { useCollection } from './firebase.js';
-import seedData from './seedData.js';
 
 
 export default function RealDatingApp() {
@@ -19,7 +18,11 @@ export default function RealDatingApp() {
   const [viewProfile,setViewProfile]=useState(null);
 
 
-  useEffect(()=>{seedData();},[]);
+  useEffect(()=>{
+    import('./seedData.js')
+      .then(m => m.default())
+      .catch(err => console.error('Failed to seed database', err));
+  },[]);
   useEffect(()=>{
     if(!loggedIn){
       setUserId(null);


### PR DESCRIPTION
## Summary
- load seedData dynamically in `RealDatingApp` so the module isn't required at build time

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_686d81ec320c832d9e69d062a8e865db