### PR TITLE
Use env vars for Firebase config

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,6 @@
+FIREBASE_API_KEY=your_api_key
+FIREBASE_AUTH_DOMAIN=your_auth_domain
+FIREBASE_PROJECT_ID=your_project_id
+FIREBASE_STORAGE_BUCKET=your_storage_bucket
+FIREBASE_MESSAGING_SENDER_ID=your_messaging_sender_id
+FIREBASE_APP_ID=your_app_id

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 node_modules/
 dist/
 .parcel-cache/
+.env

--- a/README.md
+++ b/README.md
@@ -14,16 +14,17 @@ and simple profile management powered by Firebase.
 
 ## Getting Started
 
-1. Install dependencies
+1. Copy `.env.example` to `.env` and fill in your Firebase credentials.
+2. Install dependencies
    ```bash
    npm install
    ```
-2. Start the development server:
+3. Start the development server:
    ```bash
    npm run dev
    ```
-3. Open the provided local URL (typically http://localhost:1234) in your browser.
-4. Sign up with your name to start swiping.
+4. Open the provided local URL (typically http://localhost:1234) in your browser.
+5. Sign up with your name to start swiping.
 
 To create a production build run:
 ```bash

--- a/src/firebase.js
+++ b/src/firebase.js
@@ -15,12 +15,12 @@ import {
 } from 'firebase/firestore';
 
 const firebaseConfig = {
-  apiKey: 'AIzaSyBzhR7SOvS63dNS7fcF9OmyAEryfmHwbIY',
-  authDomain: 'videotinder-38b8b.firebaseapp.com',
-  projectId: 'videotinder-38b8b',
-  storageBucket: 'videotinder-38b8b.firebasestorage.app',
-  messagingSenderId: '1025473667340',
-  appId: '1:1025473667340:web:757da72042b702a5966929'
+  apiKey: process.env.FIREBASE_API_KEY,
+  authDomain: process.env.FIREBASE_AUTH_DOMAIN,
+  projectId: process.env.FIREBASE_PROJECT_ID,
+  storageBucket: process.env.FIREBASE_STORAGE_BUCKET,
+  messagingSenderId: process.env.FIREBASE_MESSAGING_SENDER_ID,
+  appId: process.env.FIREBASE_APP_ID
 };
 const app = initializeApp(firebaseConfig);
 export const db = getFirestore(app);


### PR DESCRIPTION
## Summary
- use environment variables for Firebase configuration
- ignore `.env` files
- document environment setup

## Testing
- `npm test` *(fails: Missing script `test`)*

------
https://chatgpt.com/codex/tasks/task_e_686d82f64e34832d821bfa8e6e43d032