### PR TITLE
Add heading for reset database section

### DIFF
--- a/src/components/AdminScreen.jsx
+++ b/src/components/AdminScreen.jsx
@@ -15,7 +15,8 @@ export default function AdminScreen({ profiles, onSwitch }) {
       React.createElement('option', { value: '' }, '-- vælg profil --'),
       profiles.map(p => React.createElement('option', { key: p.id, value: p.id }, p.name))
     ),
-    React.createElement('p', { className: 'text-gray-500 text-sm' }, 'Oplev app’en som en anden bruger.'),
-    React.createElement(Button, { className: 'mt-4 bg-pink-500 text-white px-4 py-2 rounded', onClick: seedData }, 'Reset database')
+    React.createElement('p', { className: 'text-gray-500 text-sm mb-4' }, 'Oplev app’en som en anden bruger.'),
+    React.createElement(SectionTitle, { title: 'Reset database' }),
+    React.createElement(Button, { className: 'mt-2 bg-pink-500 text-white px-4 py-2 rounded', onClick: seedData }, 'Reset database')
   );
 }


### PR DESCRIPTION
## Summary
- improve AdminScreen UI
- add a `SectionTitle` above the "Reset database" button

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_686d852b148c832da97e2f1478337043