### PR TITLE
Add about page accessible from navigation

### DIFF
--- a/src/RealDatingApp.jsx
+++ b/src/RealDatingApp.jsx
@@ -1,11 +1,12 @@
 import React, { useState, useEffect } from 'react';
-import { Home as HomeIcon, User as UserIcon, MessageCircle as ChatIcon, CalendarDays, Sparkles } from 'lucide-react';
+import { Home as HomeIcon, User as UserIcon, MessageCircle as ChatIcon, CalendarDays, Sparkles, Info as InfoIcon } from 'lucide-react';
 import WelcomeScreen from './components/WelcomeScreen.jsx';
 import DailyDiscovery from './components/DailyDiscovery.jsx';
 import ChatScreen from './components/ChatScreen.jsx';
 import DailyCheckIn from './components/DailyCheckIn.jsx';
 import ProfileSettings from './components/ProfileSettings.jsx';
 import AdminScreen from './components/AdminScreen.jsx';
+import AboutScreen from './components/AboutScreen.jsx';
 import { useCollection } from './firebase.js';
 
 
@@ -58,14 +59,16 @@ export default function RealDatingApp() {
       tab==='chat' && React.createElement(ChatScreen, { userId }),
       tab==='checkin' && React.createElement(DailyCheckIn, { userId }),
       tab==='profile' && React.createElement(ProfileSettings, { userId, ageRange, onChangeAgeRange: setAgeRange, onLogout: ()=>{setLoggedIn(false); setTab('discovery'); setViewProfile(null);} }),
-      tab==='admin' && React.createElement(AdminScreen, { profiles, onSwitch: setUserId, currentUserId: userId })
+      tab==='admin' && React.createElement(AdminScreen, { profiles, onSwitch: setUserId, currentUserId: userId }),
+      tab==='about' && React.createElement(AboutScreen, null)
     ),
     React.createElement('div', { className: 'p-4 bg-white shadow-inner flex justify-around fixed bottom-0 left-0 right-0' },
       React.createElement(HomeIcon, { className: 'w-8 h-8 text-pink-600', onClick: ()=>{setTab('discovery'); setViewProfile(null);} }),
       React.createElement(ChatIcon, { className: 'w-8 h-8 text-pink-600', onClick: ()=>setTab('chat') }),
       React.createElement(CalendarDays, { className: 'w-8 h-8 text-pink-600', onClick: ()=>setTab('checkin') }),
       React.createElement(UserIcon, { className: 'w-8 h-8 text-pink-600', onClick: ()=>setTab('profile') }),
-      React.createElement(Sparkles, { className: 'w-8 h-8 text-pink-600', onClick: ()=>setTab('admin') })
+      React.createElement(Sparkles, { className: 'w-8 h-8 text-pink-600', onClick: ()=>setTab('admin') }),
+      React.createElement(InfoIcon, { className: 'w-8 h-8 text-pink-600', onClick: ()=>setTab('about') })
     )
   );
 }

--- a/src/components/AboutScreen.jsx
+++ b/src/components/AboutScreen.jsx
@@ -1,0 +1,11 @@
+import React from 'react';
+import { Card } from './ui/card.js';
+
+export default function AboutScreen() {
+  return React.createElement(Card, { className: 'p-6 m-4 shadow-xl bg-white/90' },
+    React.createElement('h1', { className: 'text-3xl font-bold mb-4 text-pink-600 text-center' }, 'Om RealDating'),
+    React.createElement('p', { className: 'mb-4 text-gray-700' }, '🎧 Udforsk klip fra andre brugere.'),
+    React.createElement('p', { className: 'mb-4 text-gray-700' }, '💬 Chat kun med aktive matches.'),
+    React.createElement('p', { className: 'mb-4 text-gray-700' }, '📅 Gem dine refleksioner i kalenderen.')
+  );
+}


### PR DESCRIPTION
## Summary
- create `AboutScreen` component reusing intro content
- link about screen in bottom navigation with an info icon

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_686d87a2c578832db6abb0e27550074d