### PR TITLE
Fix: empty daily clip list shows placeholder

### DIFF
--- a/src/components/DailyDiscovery.jsx
+++ b/src/components/DailyDiscovery.jsx
@@ -29,7 +29,7 @@ export default function DailyDiscovery({ userId, onSelectProfile, ageRange }) {
     React.createElement(SectionTitle, { title: 'Dagens klip' }),
     React.createElement('p', { className: 'text-center text-gray-500 mb-4' }, `Nye klip om ${hoursUntil} timer`),
     React.createElement('ul', { className: 'space-y-4' },
-      filtered.map(c => (
+      filtered.length ? filtered.map(c => (
         React.createElement('li', {
           key: c.id,
           className: 'p-4 bg-pink-50 rounded-lg cursor-pointer shadow flex flex-col',
@@ -51,7 +51,8 @@ export default function DailyDiscovery({ userId, onSelectProfile, ageRange }) {
             )
           )
         )
-      ))
+      )) :
+        React.createElement('li', { className: 'text-center text-gray-500' }, 'Ingen profiler fundet')
     )
   );
 }


### PR DESCRIPTION
## Summary
- show a fallback message when no profiles are found in the DailyDiscovery view

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_686d89c5d8c0832daa7d9312d4090d50