### PR TITLE
Add .env creation step

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -23,6 +23,16 @@ jobs:
         with:
           node-version: 18
           cache: 'npm'
+      - name: Create .env file
+        run: |
+          cat <<'EOF' > .env
+          FIREBASE_API_KEY=${{ secrets.FIREBASE_API_KEY }}
+          FIREBASE_AUTH_DOMAIN=${{ secrets.FIREBASE_AUTH_DOMAIN }}
+          FIREBASE_PROJECT_ID=${{ secrets.FIREBASE_PROJECT_ID }}
+          FIREBASE_STORAGE_BUCKET=${{ secrets.FIREBASE_STORAGE_BUCKET }}
+          FIREBASE_MESSAGING_SENDER_ID=${{ secrets.FIREBASE_MESSAGING_SENDER_ID }}
+          FIREBASE_APP_ID=${{ secrets.FIREBASE_APP_ID }}
+          EOF
       - run: npm ci
       - run: npm run build
       - uses: actions/upload-pages-artifact@v3

--- a/README.md
+++ b/README.md
@@ -31,3 +31,18 @@ To create a production build run:
 npm run build
 ```
 The compiled files will be placed in the `dist` folder. When changes are pushed to `main`, a GitHub Actions workflow builds the project and deploys the contents of `dist` to GitHub Pages automatically.
+
+## GitHub Pages Deployment
+
+Before the workflow can build the site, you must provide your Firebase credentials as repository secrets. Define these secrets in **Settings > Secrets and variables**:
+
+```
+FIREBASE_API_KEY
+FIREBASE_AUTH_DOMAIN
+FIREBASE_PROJECT_ID
+FIREBASE_STORAGE_BUCKET
+FIREBASE_MESSAGING_SENDER_ID
+FIREBASE_APP_ID
+```
+
+During the build job, these secrets are written to a `.env` file so Parcel can embed the Firebase config.


### PR DESCRIPTION
## Summary
- create `.env` during the GitHub Actions build using secrets
- document required repository secrets in README

## Testing
- `npm ci`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_686d93ba523c832da5c3174e1301df43