### PR TITLE
Stop db reset on startup

### DIFF
--- a/src/RealDatingApp.jsx
+++ b/src/RealDatingApp.jsx
@@ -28,11 +28,7 @@ export default function RealDatingApp() {
   }, [loggedIn]);
 
 
-  useEffect(()=>{
-    import('./seedData.js')
-      .then(m => m.default())
-      .catch(err => console.error('Failed to seed database', err));
-  },[]);
+  // Removed automatic seeding of the database on app startup.
   useEffect(()=>{
     if(!loggedIn){
       setUserId(null);


### PR DESCRIPTION
## Summary
- remove automatic call to `seedData` on app startup

## Testing
- `npm run build`
- `npm test` *(fails: Missing script `test`)*

------
https://chatgpt.com/codex/tasks/task_e_686de780c918832da46677ada745f8b0