### PR TITLE
Fix profile overlay not closing

### DIFF
--- a/src/RealDatingApp.jsx
+++ b/src/RealDatingApp.jsx
@@ -54,7 +54,7 @@ export default function RealDatingApp() {
         React.createElement(DailyDiscovery, { userId, onSelectProfile: selectProfile, ageRange })
       ),
       viewProfile && (
-        React.createElement(ProfileSettings, { userId: viewProfile, ageRange, onChangeAgeRange: setAgeRange, publicView: true })
+        React.createElement(ProfileSettings, { userId: viewProfile, ageRange, onChangeAgeRange: setAgeRange, publicView: true, onClose: ()=>setViewProfile(null) })
       ),
       tab==='chat' && React.createElement(ChatScreen, { userId }),
       tab==='checkin' && React.createElement(DailyCheckIn, { userId }),

--- a/src/components/ProfileSettings.jsx
+++ b/src/components/ProfileSettings.jsx
@@ -8,7 +8,7 @@ import { Textarea } from './ui/textarea.js';
 import SectionTitle from './SectionTitle.jsx';
 import { db, storage, getDoc, doc, updateDoc, ref, uploadBytes, getDownloadURL } from '../firebase.js';
 
-export default function ProfileSettings({ userId, ageRange, onChangeAgeRange, publicView = false, onLogout = () => {} }) {
+export default function ProfileSettings({ userId, ageRange, onChangeAgeRange, publicView = false, onLogout = () => {}, onClose = null }) {
   const [profile,setProfile]=useState(null);
   const videoRef = useRef();
   const audioRef = useRef();
@@ -129,6 +129,7 @@ export default function ProfileSettings({ userId, ageRange, onChangeAgeRange, pu
   };
 
   return React.createElement(Card, { className: 'p-6 m-4 shadow-xl bg-white/90' },
+    publicView && onClose && React.createElement(Button, { className: 'mb-4 bg-gray-200 text-gray-700 px-4 py-2 rounded', onClick: onClose }, 'Luk'),
     React.createElement(SectionTitle, { title: `${profile.name}, ${profile.age}` }),
     !publicView && React.createElement(SectionTitle, { title: 'Aldersinterval' }),
     !publicView && React.createElement('div', { className: 'flex flex-col gap-4 mb-4' },


### PR DESCRIPTION
## Summary
- let `ProfileSettings` accept an optional `onClose` callback
- pass `onClose` to candidate profile view
- show a "Luk" button when viewing another profile

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_686deb3a0c38832d96ccda7befb79aee