### PR TITLE
Change admin access location

### DIFF
--- a/src/RealDatingApp.jsx
+++ b/src/RealDatingApp.jsx
@@ -1,5 +1,5 @@
 import React, { useState, useEffect } from 'react';
-import { Home as HomeIcon, User as UserIcon, MessageCircle as ChatIcon, CalendarDays, Sparkles, Info as InfoIcon } from 'lucide-react';
+import { Home as HomeIcon, User as UserIcon, MessageCircle as ChatIcon, CalendarDays, Info as InfoIcon } from 'lucide-react';
 import WelcomeScreen from './components/WelcomeScreen.jsx';
 import DailyDiscovery from './components/DailyDiscovery.jsx';
 import ChatScreen from './components/ChatScreen.jsx';
@@ -60,15 +60,14 @@ export default function RealDatingApp() {
       tab==='checkin' && React.createElement(DailyCheckIn, { userId }),
       tab==='profile' && React.createElement(ProfileSettings, { userId, ageRange, onChangeAgeRange: setAgeRange, onLogout: ()=>{setLoggedIn(false); setTab('discovery'); setViewProfile(null);} }),
       tab==='admin' && React.createElement(AdminScreen, { profiles, onSwitch: setUserId, currentUserId: userId }),
-      tab==='about' && React.createElement(AboutScreen, null)
+      tab==='about' && React.createElement(AboutScreen, { onOpenAdmin: ()=>setTab('admin') })
     ),
     React.createElement('div', { className: 'p-4 bg-white shadow-inner flex justify-around fixed bottom-0 left-0 right-0' },
       React.createElement(HomeIcon, { className: 'w-8 h-8 text-pink-600', onClick: ()=>{setTab('discovery'); setViewProfile(null);} }),
       React.createElement(ChatIcon, { className: 'w-8 h-8 text-pink-600', onClick: ()=>setTab('chat') }),
       React.createElement(CalendarDays, { className: 'w-8 h-8 text-pink-600', onClick: ()=>setTab('checkin') }),
       React.createElement(UserIcon, { className: 'w-8 h-8 text-pink-600', onClick: ()=>setTab('profile') }),
-      React.createElement(Sparkles, { className: 'w-8 h-8 text-pink-600', onClick: ()=>setTab('admin') }),
       React.createElement(InfoIcon, { className: 'w-8 h-8 text-pink-600', onClick: ()=>setTab('about') })
-    )
+      )
   );
 }

--- a/src/components/AboutScreen.jsx
+++ b/src/components/AboutScreen.jsx
@@ -1,12 +1,14 @@
 import React from 'react';
 import { Card } from './ui/card.js';
+import { Button } from './ui/button.js';
 
-export default function AboutScreen() {
+export default function AboutScreen({ onOpenAdmin }) {
   return React.createElement(Card, { className: 'p-6 m-4 shadow-xl bg-white/90' },
     React.createElement('h1', { className: 'text-3xl font-bold mb-4 text-pink-600 text-center' }, 'Om RealDating'),
     React.createElement('p', { className: 'mb-4 text-gray-700' },
       'Velkommen til en ny måde at date på. Her handler det ikke om hurtige swipes, men om at tage sig tid til at lære hinanden at kende. '
       + 'RealDating er for dig, der søger noget ægte og meningsfuldt. Tag det stille og roligt, og find den forbindelse, der virkelig betyder noget.'
-    )
+    ),
+    onOpenAdmin && React.createElement(Button, { className: 'bg-pink-500 hover:bg-pink-600 text-white mt-4', onClick: onOpenAdmin }, 'Admin')
   );
 }


### PR DESCRIPTION
## Summary
- move the admin page navigation from the bottom bar to the About page
- add a hidden admin access button on the About page

## Testing
- `npm test` *(fails: Missing script)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_686defa428a8832da65abd5b4d0895e1