### PR TITLE
Add purchase overlays for daily clips and subscription

### DIFF
--- a/src/components/DailyDiscovery.jsx
+++ b/src/components/DailyDiscovery.jsx
@@ -4,6 +4,7 @@ import { Card } from './ui/card.js';
 import { Button } from './ui/button.js';
 import SectionTitle from './SectionTitle.jsx';
 import { useCollection } from '../firebase.js';
+import PurchaseOverlay from './PurchaseOverlay.jsx';
 
 export default function DailyDiscovery({ userId, onSelectProfile, ageRange }) {
   const profiles = useCollection('profiles');
@@ -17,6 +18,7 @@ export default function DailyDiscovery({ userId, onSelectProfile, ageRange }) {
   const nameMap = Object.fromEntries(profiles.map(p => [p.id, p.name]));
 
   const [hoursUntil, setHoursUntil] = useState(0);
+  const [showPurchase, setShowPurchase] = useState(false);
   useEffect(() => {
     const now = new Date();
     const next = new Date(now);
@@ -54,6 +56,17 @@ export default function DailyDiscovery({ userId, onSelectProfile, ageRange }) {
         )
       )) :
         React.createElement('li', { className: 'text-center text-gray-500' }, 'Ingen profiler fundet')
+    ),
+    React.createElement(Button, {
+      className: 'mt-4 w-full bg-pink-500 text-white',
+      onClick: () => setShowPurchase(true)
+    }, 'Hent flere...'),
+    showPurchase && React.createElement(PurchaseOverlay, {
+      title: 'Flere klip',
+      price: '9 kr',
+      onClose: () => setShowPurchase(false)
+    },
+      React.createElement('p', { className: 'text-center text-sm mb-2' }, 'Få 3 ekstra klip i dag')
     )
   );
 }

--- a/src/components/ProfileSettings.jsx
+++ b/src/components/ProfileSettings.jsx
@@ -7,6 +7,7 @@ import { Button } from './ui/button.js';
 import { Textarea } from './ui/textarea.js';
 import SectionTitle from './SectionTitle.jsx';
 import { db, storage, getDoc, doc, updateDoc, ref, uploadBytes, getDownloadURL } from '../firebase.js';
+import PurchaseOverlay from './PurchaseOverlay.jsx';
 
 export default function ProfileSettings({ userId, ageRange, onChangeAgeRange, publicView = false, onLogout = () => {} }) {
   const [profile,setProfile]=useState(null);
@@ -20,6 +21,7 @@ export default function ProfileSettings({ userId, ageRange, onChangeAgeRange, pu
   const [videoRecording, setVideoRecording] = useState(false);
   const [audioRecording, setAudioRecording] = useState(false);
   const [replaceTarget, setReplaceTarget] = useState(null); // {field, index}
+  const [showSub, setShowSub] = useState(false);
 
   useEffect(()=>{if(!userId)return;getDoc(doc(db,'profiles',userId)).then(s=>s.exists()&&setProfile({id:s.id,...s.data()}));},[userId]);
   if(!profile) return React.createElement('p', null, 'Indlæser profil...');
@@ -229,9 +231,26 @@ export default function ProfileSettings({ userId, ageRange, onChangeAgeRange, pu
         className: 'mt-4 bg-pink-500 text-white px-4 py-2 rounded',
         onClick: saveChanges
       }, 'Gem ændringer'),
+    !publicView && React.createElement(Button, {
+        className: 'mt-2 w-full bg-pink-500 text-white',
+        onClick: () => setShowSub(true)
+      }, 'K\u00f8b abonnement'),
     !publicView && React.createElement('button', {
         className: 'mt-2 bg-gray-200 text-gray-700 px-4 py-2 rounded',
         onClick: onLogout
-      }, 'Logout')
+      }, 'Logout'),
+    showSub && React.createElement(PurchaseOverlay, {
+        title: 'M\u00e5nedligt abonnement',
+        price: '59 kr/md',
+        onClose: () => setShowSub(false)
+      },
+        React.createElement('ul', { className: 'list-disc list-inside text-sm space-y-1' },
+          React.createElement('li', null, '🎞️ Flere daglige klip: Se fx 6 i stedet for 3 kandidater om dagen'),
+          React.createElement('li', null, '🔁 Se tidligere klip igen ("Fortryd swipe")'),
+          React.createElement('li', null, '🧠 Indsigt i hvem der har liket dig'),
+          React.createElement('li', null, '📝 Udfoldede profiler – adgang til længere refleksioner, flere videoer'),
+          React.createElement('li', null, '🎙️ Profilbooster: Få dit klip vist tidligere på dagen')
+        )
+      )
     );
 }

--- a/src/components/PurchaseOverlay.jsx
+++ b/src/components/PurchaseOverlay.jsx
@@ -1,0 +1,15 @@
+import React from 'react';
+import { Card } from './ui/card.js';
+import { Button } from './ui/button.js';
+
+export default function PurchaseOverlay({ title, price, children, onClose }) {
+  return React.createElement('div', { className: 'fixed inset-0 z-50 bg-black/50 flex items-center justify-center' },
+    React.createElement(Card, { className: 'bg-white p-6 rounded shadow-xl max-w-sm w-full' },
+      React.createElement('h2', { className: 'text-xl font-semibold mb-4 text-pink-600 text-center' }, title),
+      children,
+      price && React.createElement('p', { className: 'text-center font-bold my-4' }, price),
+      React.createElement(Button, { className: 'w-full bg-pink-500 text-white mb-2' }, 'Køb'),
+      React.createElement(Button, { className: 'w-full', onClick: onClose }, 'Luk')
+    )
+  );
+}


### PR DESCRIPTION
## Summary
- design simple overlay component for in-app purchases
- show **Hent flere...** button on daily clips page with overlay for buying extra clips
- allow buying a monthly subscription from profile page with overlay listing benefits

## Testing
- `npm test` *(fails: Missing script)*
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_686df1325e9c832dae455cd899eb0d51