### PR TITLE
Enable offline caching for profile images

### DIFF
--- a/FEATURES.txt
+++ b/FEATURES.txt
@@ -7,6 +7,8 @@ Ability to upload or record audio clips
 Offline support via service worker caching
 PWA manifest for standalone installation
 
+Profile pictures cached for offline viewing
+
 Admin mode
 Seed data loader for test accounts and clips
 Switch between user profiles 

--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ and simple profile management powered by Firebase.
 * Basic chat between matched profiles
 * Calendar for daily reflections
 * Minimal profile settings and admin mode
+* Profile pictures cached for offline viewing
 
 
 ## Getting Started

--- a/public/service-worker.js
+++ b/public/service-worker.js
@@ -1,6 +1,7 @@
 // Bump the cache name whenever cached files change to ensure
 // clients receive the latest versions.
 const CACHE_NAME = 'videotinder-v2';
+const IMAGE_CACHE = 'image-cache-v1';
 const URLS_TO_CACHE = [
   '/',
   '/public/index.html',
@@ -30,6 +31,21 @@ self.addEventListener('activate', event => {
 });
 
 self.addEventListener('fetch', event => {
+  if (event.request.destination === 'image') {
+    event.respondWith(
+      caches.open(IMAGE_CACHE).then(cache =>
+        cache.match(event.request).then(response => {
+          if (response) return response;
+          return fetch(event.request)
+            .then(networkResponse => {
+              cache.put(event.request, networkResponse.clone());
+              return networkResponse;
+            });
+        })
+      )
+    );
+    return;
+  }
   event.respondWith(
     caches.match(event.request).then(response => {
       return response || fetch(event.request);


### PR DESCRIPTION
## Summary
- cache image requests in the service worker
- document that profile pictures are cached offline

## Testing
- `npm install`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_686e08475600832da4272005b0837d2b