### PR TITLE
Add small video preview with fullscreen option

### DIFF
--- a/src/components/ProfileSettings.jsx
+++ b/src/components/ProfileSettings.jsx
@@ -6,6 +6,7 @@ import { Card } from './ui/card.js';
 import { Button } from './ui/button.js';
 import { Textarea } from './ui/textarea.js';
 import SectionTitle from './SectionTitle.jsx';
+import VideoPreview from './VideoPreview.jsx';
 import { db, storage, getDoc, doc, updateDoc, ref, uploadBytes, getDownloadURL } from '../firebase.js';
 import PurchaseOverlay from './PurchaseOverlay.jsx';
 
@@ -185,11 +186,7 @@ export default function ProfileSettings({ userId, ageRange, onChangeAgeRange, pu
     React.createElement('div', { className: 'flex flex-col gap-2 mb-4' },
       (profile.videoClips || []).map((url,i) =>
         React.createElement('div', { key: i, className:'flex flex-col mb-2' },
-          React.createElement('video', {
-            src: url,
-            controls: true,
-            className: 'w-full rounded'
-          }),
+          React.createElement(VideoPreview, { src: url }),
           !publicView && React.createElement(Button, {
             className:'mt-1 bg-pink-500 text-white',
             onClick:()=>{setReplaceTarget({field:'videoClips',index:i}); videoRef.current && videoRef.current.click();}

--- a/src/components/VideoPreview.jsx
+++ b/src/components/VideoPreview.jsx
@@ -1,0 +1,28 @@
+import React, { useRef } from 'react';
+import { Button } from './ui/button.js';
+
+export default function VideoPreview({ src }) {
+  const videoRef = useRef(null);
+  const openFullscreen = () => {
+    const el = videoRef.current;
+    if (!el) return;
+    if (el.requestFullscreen) {
+      el.requestFullscreen();
+    } else if (el.webkitRequestFullscreen) {
+      el.webkitRequestFullscreen();
+    }
+  };
+
+  return React.createElement('div', { className: 'flex flex-col items-start' },
+    React.createElement('video', {
+      ref: videoRef,
+      src,
+      controls: true,
+      className: 'w-40 rounded'
+    }),
+    React.createElement(Button, {
+      className: 'mt-1 bg-pink-500 text-white',
+      onClick: openFullscreen
+    }, 'Fuldskærm')
+  );
+}


### PR DESCRIPTION
## Summary
- add a new `VideoPreview` component that renders a small video and a fullscreen button
- use `VideoPreview` in `ProfileSettings` to shrink uploaded clips

## Testing
- `npm install`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_686e09d486e4832da63434720600a9ee