### PR TITLE
Swap order of admin buttons

### DIFF
--- a/src/components/AdminScreen.jsx
+++ b/src/components/AdminScreen.jsx
@@ -38,12 +38,12 @@ export default function AdminScreen({ profiles, onSwitch, currentUserId }) {
       profiles.map(p => React.createElement('option', { key: p.id, value: p.id }, p.name))
     ),
     React.createElement('p', { className: 'text-gray-500 text-sm mb-4' }, 'Oplev app\u2019en som en anden bruger.'),
-    React.createElement('h3', { className: 'text-xl font-semibold mb-2 text-pink-600' }, 'Reset database'),
-    React.createElement(Button, { className: 'mt-2 bg-pink-500 text-white px-4 py-2 rounded', onClick: seedData }, 'Reset database'),
     React.createElement('h3', { className: 'text-xl font-semibold mb-2 mt-4 text-pink-600' }, 'Firestore info'),
     React.createElement(Button, { className: 'mt-2 bg-pink-500 text-white px-4 py-2 rounded', onClick: showFirestoreInfo }, 'Show credentials'),
     firestoreInfo && React.createElement('pre', { className: 'mt-2 bg-gray-100 p-2 rounded whitespace-pre-wrap text-xs' },
       JSON.stringify(firestoreInfo.config, null, 2) + '\nStatus: ' + firestoreInfo.status
-    )
+    ),
+    React.createElement('h3', { className: 'text-xl font-semibold mb-2 text-pink-600' }, 'Reset database'),
+    React.createElement(Button, { className: 'mt-2 bg-pink-500 text-white px-4 py-2 rounded', onClick: seedData }, 'Reset database')
   );
 }


### PR DESCRIPTION
## Summary
- reorder `Firestore info` and `Reset database` sections in `AdminScreen`

## Testing
- `npm test` *(fails: Missing script)*
- `npm install`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_686e3a882db8832d858754aea5726008