### PR TITLE
Fix daily clips limit

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ and simple profile management powered by Firebase.
 
 ## Features
 
-* Daily discovery of short video clips
+* Daily discovery of short video clips (up to 3 or 6 with subscription)
 * Basic chat between matched profiles
 * Calendar for daily reflections
 * Minimal profile settings and admin mode

--- a/src/components/DailyDiscovery.jsx
+++ b/src/components/DailyDiscovery.jsx
@@ -11,10 +11,11 @@ export default function DailyDiscovery({ userId, onSelectProfile, ageRange }) {
   const user = profiles.find(p => p.id === userId) || {};
   const interest = user.interest;
   const allClips = useCollection('clips', 'gender', interest);
+  const limit = user.subscriptionActive ? 6 : 3;
   const filtered = allClips.filter(c => {
     const profile = profiles.find(p => p.id === c.profileId);
     return profile && profile.age >= ageRange[0] && profile.age <= ageRange[1];
-  }).slice(0, 3);
+  }).slice(0, limit);
   const nameMap = Object.fromEntries(profiles.map(p => [p.id, p.name]));
   const likes = useCollection('likes','userId',userId);
 

--- a/src/components/ProfileSettings.jsx
+++ b/src/components/ProfileSettings.jsx
@@ -25,6 +25,12 @@ export default function ProfileSettings({ userId, ageRange, onChangeAgeRange, pu
   const [replaceTarget, setReplaceTarget] = useState(null); // {field, index}
   const [showSub, setShowSub] = useState(false);
 
+  const handlePurchase = async () => {
+    await updateDoc(doc(db, 'profiles', userId), { subscriptionActive: true });
+    setProfile({ ...profile, subscriptionActive: true });
+    setShowSub(false);
+  };
+
   useEffect(()=>{if(!userId)return;getDoc(doc(db,'profiles',userId)).then(s=>s.exists()&&setProfile({id:s.id,...s.data()}));},[userId]);
   if(!profile) return React.createElement('p', null, 'Indlæser profil...');
 
@@ -277,7 +283,8 @@ export default function ProfileSettings({ userId, ageRange, onChangeAgeRange, pu
     showSub && React.createElement(PurchaseOverlay, {
         title: 'M\u00e5nedligt abonnement',
         price: '59 kr/md',
-        onClose: () => setShowSub(false)
+        onClose: () => setShowSub(false),
+        onBuy: handlePurchase
       },
         React.createElement('ul', { className: 'list-disc list-inside text-sm space-y-1' },
           React.createElement('li', null, '🎞️ Flere daglige klip: Se fx 6 i stedet for 3 kandidater om dagen'),

--- a/src/components/PurchaseOverlay.jsx
+++ b/src/components/PurchaseOverlay.jsx
@@ -2,13 +2,13 @@ import React from 'react';
 import { Card } from './ui/card.js';
 import { Button } from './ui/button.js';
 
-export default function PurchaseOverlay({ title, price, children, onClose }) {
+export default function PurchaseOverlay({ title, price, children, onClose, onBuy }) {
   return React.createElement('div', { className: 'fixed inset-0 z-50 bg-black/50 flex items-center justify-center' },
     React.createElement(Card, { className: 'bg-white p-6 rounded shadow-xl max-w-sm w-full' },
       React.createElement('h2', { className: 'text-xl font-semibold mb-4 text-pink-600 text-center' }, title),
       children,
       price && React.createElement('p', { className: 'text-center font-bold my-4' }, price),
-      React.createElement(Button, { className: 'w-full bg-pink-500 text-white mb-2' }, 'Køb'),
+      React.createElement(Button, { className: 'w-full bg-pink-500 text-white mb-2', onClick: onBuy }, 'Køb'),
       React.createElement(Button, { className: 'w-full', onClick: onClose }, 'Luk')
     )
   );

--- a/src/seedData.js
+++ b/src/seedData.js
@@ -7,7 +7,7 @@ export default async function seedData() {
     await Promise.all(snap.docs.map(d => deleteDoc(d.ref)));
   }
   const testUsers = [
-    {id:'101',name:'Maria',age:49,gender:'Kvinde',interest:'Mand',audioClips:[],videoClips:[],clip:'Elsker bøger og gåture.'},
+    {id:'101',name:'Maria',age:49,gender:'Kvinde',interest:'Mand',audioClips:[],videoClips:[],clip:'Elsker bøger og gåture.',subscriptionActive:true},
     {id:'102',name:'Sofie',age:35,gender:'Kvinde',interest:'Mand',audioClips:[],videoClips:[],clip:'Yoga-entusiast.'},
     {id:'103',name:'Emma',age:41,gender:'Kvinde',interest:'Mand',audioClips:[],videoClips:[],clip:'Musikalsk sjæl.'},
     {id:'104',name:'Peter',age:45,gender:'Mand',interest:'Kvinde',audioClips:[],videoClips:[],clip:'Cykler i weekenden.'},
@@ -19,7 +19,9 @@ export default async function seedData() {
     {id:'c1',profileId:'101',gender:'Kvinde',text:'Bøger er mit frirum.'},
     {id:'c2',profileId:'104',gender:'Mand',text:'Cykler hver dag.'},
     {id:'c3',profileId:'105',gender:'Mand',text:'Elsker at lave mad.'},
-    {id:'c4',profileId:'106',gender:'Mand',text:'Fotograferer naturen.'}
+    {id:'c4',profileId:'106',gender:'Mand',text:'Fotograferer naturen.'},
+    {id:'c5',profileId:'104',gender:'Mand',text:'Elsker naturen.'},
+    {id:'c6',profileId:'105',gender:'Mand',text:'Søger eventyr.'}
   ];
   await Promise.all(testClips.map(c => setDoc(doc(db,'clips',c.id), c)));
   await setDoc(doc(db,'matches','m1'),{


### PR DESCRIPTION
## Summary
- increase number of profiles shown in DailyDiscovery if the user has an active subscription
- let users purchase a subscription in ProfileSettings
- wire PurchaseOverlay buy button
- expand seed data with a subscription flag and extra clips
- document clip limits in README

## Testing
- `npm install`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_686e50c9f294832d898d30dcd5e56159