### PR TITLE
Fix date parsing for check-in and expand seed reflections

### DIFF
--- a/src/components/DailyCheckIn.jsx
+++ b/src/components/DailyCheckIn.jsx
@@ -26,14 +26,14 @@ export default function DailyCheckIn({ userId }) {
       days.map(day => (
         React.createElement('div', {
           key: day,
-          className: `p-2 text-center text-sm ${refs.some(r=>new Date(r.date).getDate()===day)?'bg-pink-200 rounded':''}`
+          className: `p-2 text-center text-sm ${refs.some(r=>parseInt((r.date||'').split('-')[2],10)===day)?'bg-pink-200 rounded':''}`
         }, day)
       ))
     ),
     React.createElement('ul', { className: 'list-disc list-inside mb-4' },
       refs.map(r => {
         const d = r.date || r.id.split('-')[1];
-        const formatted = d ? new Date(d).toISOString().split('T')[0] : 'Ukendt dato';
+        const formatted = d ? d : 'Ukendt dato';
         return React.createElement('li', { key: r.id }, `${formatted}: ${r.text}`);
       })
     ),

--- a/src/seedData.js
+++ b/src/seedData.js
@@ -32,6 +32,17 @@ export default async function seedData() {
     unreadByUser:false,
     unreadByProfile:true
   });
-  const date = new Date().toISOString().split('T')[0];
-  await setDoc(doc(db,'reflections','r1'),{id:'r1',userId:'101',date,text:'Mødte Peter i dag.'});
+  const today = new Date();
+  const toDateString = d => d.toISOString().split('T')[0];
+  const refDates = [0, 1, 2].map(offset => {
+    const dt = new Date(today);
+    dt.setDate(today.getDate() - offset);
+    return toDateString(dt);
+  });
+  const reflections = [
+    { id: 'r1', userId: '101', date: refDates[0], text: 'Mødte Peter i dag.' },
+    { id: 'r2', userId: '101', date: refDates[1], text: 'Dejlig dag på arbejdet.' },
+    { id: 'r3', userId: '101', date: refDates[2], text: 'Tog på vandretur.' }
+  ];
+  await Promise.all(reflections.map(r => setDoc(doc(db,'reflections',r.id), r)));
 }


### PR DESCRIPTION
## Summary
- show reflection days without timezone problems
- seed Firestore with several reflection entries

## Testing
- `npm install`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_686e58361d20832d8dccfd9dbc28e9a4