### PR TITLE
Remove standalone clips collection

### DIFF
--- a/FEATURES.txt
+++ b/FEATURES.txt
@@ -10,7 +10,7 @@ PWA manifest for standalone installation
 Profile pictures cached for offline viewing
 
 Admin mode
-Seed data loader for test accounts and clips
+Seed data loader for test profiles with sample clips
 Switch between user profiles 
 Reset database from 
 Show Firestore credentials status

--- a/src/components/DailyDiscovery.jsx
+++ b/src/components/DailyDiscovery.jsx
@@ -10,13 +10,12 @@ export default function DailyDiscovery({ userId, onSelectProfile, ageRange }) {
   const profiles = useCollection('profiles');
   const user = profiles.find(p => p.id === userId) || {};
   const interest = user.interest;
-  const allClips = useCollection('clips', 'gender', interest);
   const limit = user.subscriptionActive ? 6 : 3;
-  const filtered = allClips.filter(c => {
-    const profile = profiles.find(p => p.id === c.profileId);
-    return profile && profile.age >= ageRange[0] && profile.age <= ageRange[1];
-  }).slice(0, limit);
-  const nameMap = Object.fromEntries(profiles.map(p => [p.id, p.name]));
+  const filtered = profiles.filter(p =>
+    p.gender === interest &&
+    p.age >= ageRange[0] &&
+    p.age <= ageRange[1]
+  ).slice(0, limit);
   const likes = useCollection('likes','userId',userId);
 
   const [hoursUntil, setHoursUntil] = useState(0);
@@ -44,22 +43,22 @@ export default function DailyDiscovery({ userId, onSelectProfile, ageRange }) {
     React.createElement('p', { className: 'text-center text-gray-500 mb-4' }, `Nye klip om ${hoursUntil} timer`),
     React.createElement('p', { className: 'text-center text-gray-500 mb-4' }, `Tag dig god tid til at lytte til og se dagens klip`),
     React.createElement('ul', { className: 'space-y-4' },
-      filtered.length ? filtered.map(c => (
+      filtered.length ? filtered.map(p => (
         React.createElement('li', {
-          key: c.id,
+          key: p.id,
           className: 'p-4 bg-pink-50 rounded-lg cursor-pointer shadow flex flex-col relative',
-          onClick: () => onSelectProfile(c.profileId)
+          onClick: () => onSelectProfile(p.id)
         },
-          likes.some(l=>l.profileId===c.profileId) &&
+          likes.some(l=>l.profileId===p.id) &&
             React.createElement(Heart,{className:'w-6 h-6 text-pink-500 absolute top-2 right-2'}),
           React.createElement('div', { className: 'flex items-center gap-4 mb-2' },
-            (profiles.find(p=>p.id===c.profileId)?.photoURL ?
-              React.createElement('img', { src: profiles.find(p=>p.id===c.profileId)?.photoURL, className: 'w-10 h-10 rounded-full object-cover' }) :
+            (p.photoURL ?
+              React.createElement('img', { src: p.photoURL, className: 'w-10 h-10 rounded-full object-cover' }) :
               React.createElement(User, { className: 'w-10 h-10 text-pink-500' })
             ),
             React.createElement('div', null,
-              React.createElement('p', { className: 'font-medium' }, `${nameMap[c.profileId]} (${profiles.find(p=>p.id===c.profileId)?.age})`),
-              c.text && React.createElement('p', { className: 'text-sm text-gray-500' }, `“${c.text}”`)
+              React.createElement('p', { className: 'font-medium' }, `${p.name} (${p.age})`),
+              p.clip && React.createElement('p', { className: 'text-sm text-gray-500' }, `“${p.clip}”`)
             )
           ),
           React.createElement('div', { className: 'flex gap-2 mt-2' },
@@ -69,10 +68,10 @@ export default function DailyDiscovery({ userId, onSelectProfile, ageRange }) {
             React.createElement(Button, {
               size: 'sm',
               className: 'bg-pink-500 text-white flex items-center gap-1',
-              onClick: e => {e.stopPropagation(); toggleLike(c.profileId);}
+              onClick: e => {e.stopPropagation(); toggleLike(p.id);}
             },
               React.createElement(Heart, { className: 'w-5 h-5' }),
-              likes.some(l=>l.profileId===c.profileId) ? 'Unlike' : 'Like'
+              likes.some(l=>l.profileId===p.id) ? 'Unlike' : 'Like'
             )
           )
         )

--- a/src/seedData.js
+++ b/src/seedData.js
@@ -1,29 +1,20 @@
 import { db, collection, getDocs, deleteDoc, doc, setDoc } from './firebase.js';
 
 export default async function seedData() {
-  const cols = ['profiles', 'clips', 'matches', 'reflections'];
+  const cols = ['profiles', 'matches', 'reflections'];
   for (const c of cols) {
     const snap = await getDocs(collection(db, c));
     await Promise.all(snap.docs.map(d => deleteDoc(d.ref)));
   }
   const testUsers = [
-    {id:'101',name:'Maria',age:49,gender:'Kvinde',interest:'Mand',audioClips:[],videoClips:[],clip:'Elsker bøger og gåture.',subscriptionActive:true},
-    {id:'102',name:'Sofie',age:35,gender:'Kvinde',interest:'Mand',audioClips:[],videoClips:[],clip:'Yoga-entusiast.'},
-    {id:'103',name:'Emma',age:41,gender:'Kvinde',interest:'Mand',audioClips:[],videoClips:[],clip:'Musikalsk sjæl.'},
-    {id:'104',name:'Peter',age:45,gender:'Mand',interest:'Kvinde',audioClips:[],videoClips:[],clip:'Cykler i weekenden.'},
-    {id:'105',name:'Lars',age:52,gender:'Mand',interest:'Kvinde',audioClips:[],videoClips:[],clip:'Madglad iværksætter.'},
-    {id:'106',name:'Henrik',age:40,gender:'Mand',interest:'Kvinde',audioClips:[],videoClips:[],clip:'Naturligvis fotograf.'}
+    {id:'101',name:'Maria',age:49,gender:'Kvinde',interest:'Mand',audioClips:[],videoClips:['/sample1.mp4'],clip:'Elsker bøger og gåture.',subscriptionActive:true},
+    {id:'102',name:'Sofie',age:35,gender:'Kvinde',interest:'Mand',audioClips:[],videoClips:['/sample1.mp4'],clip:'Yoga-entusiast.'},
+    {id:'103',name:'Emma',age:41,gender:'Kvinde',interest:'Mand',audioClips:[],videoClips:['/sample1.mp4'],clip:'Musikalsk sjæl.'},
+    {id:'104',name:'Peter',age:45,gender:'Mand',interest:'Kvinde',audioClips:[],videoClips:['/sample1.mp4'],clip:'Cykler i weekenden.'},
+    {id:'105',name:'Lars',age:52,gender:'Mand',interest:'Kvinde',audioClips:[],videoClips:['/sample1.mp4'],clip:'Madglad iværksætter.'},
+    {id:'106',name:'Henrik',age:40,gender:'Mand',interest:'Kvinde',audioClips:[],videoClips:['/sample1.mp4'],clip:'Naturligvis fotograf.'}
   ];
   await Promise.all(testUsers.map(u => setDoc(doc(db, 'profiles', u.id), u)));
-  const testClips = [
-    {id:'c1',profileId:'101',gender:'Kvinde',text:'Bøger er mit frirum.'},
-    {id:'c2',profileId:'104',gender:'Mand',text:'Cykler hver dag.'},
-    {id:'c3',profileId:'105',gender:'Mand',text:'Elsker at lave mad.'},
-    {id:'c4',profileId:'106',gender:'Mand',text:'Fotograferer naturen.'},
-    {id:'c5',profileId:'104',gender:'Mand',text:'Elsker naturen.'},
-    {id:'c6',profileId:'105',gender:'Mand',text:'Søger eventyr.'}
-  ];
-  await Promise.all(testClips.map(c => setDoc(doc(db,'clips',c.id), c)));
   await setDoc(doc(db,'matches','m1'),{
     id:'m1',
     userId:'101',


### PR DESCRIPTION
## Summary
- drop the old `clips` collection from the seed data
- store sample video clips inside user profiles
- update daily discovery screen to read clips from profiles
- document updated seed behavior

## Testing
- `npm install`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_686e5b7f19a0832d85d9f76464402bc0