### PR TITLE
Clean up storage when deleting videos

### DIFF
--- a/src/components/ProfileSettings.jsx
+++ b/src/components/ProfileSettings.jsx
@@ -7,7 +7,7 @@ import { Button } from './ui/button.js';
 import { Textarea } from './ui/textarea.js';
 import SectionTitle from './SectionTitle.jsx';
 import VideoPreview from './VideoPreview.jsx';
-import { db, storage, getDoc, doc, updateDoc, ref, uploadBytes, getDownloadURL, listAll } from '../firebase.js';
+import { db, storage, getDoc, doc, updateDoc, ref, uploadBytes, getDownloadURL, listAll, deleteObject } from '../firebase.js';
 import PurchaseOverlay from './PurchaseOverlay.jsx';
 
 export default function ProfileSettings({ userId, ageRange, onChangeAgeRange, publicView = false, onLogout = () => {} }) {
@@ -69,9 +69,17 @@ export default function ProfileSettings({ userId, ageRange, onChangeAgeRange, pu
 
   const deleteFile = async (field, index) => {
     const updated = [...(profile[field] || [])];
+    const url = updated[index];
     updated.splice(index, 1);
     await updateDoc(doc(db,'profiles',userId), { [field]: updated });
     setProfile({...profile, [field]: updated});
+    if(url){
+      try {
+        await deleteObject(ref(storage, url));
+      } catch(err){
+        console.error('Failed to delete file', err);
+      }
+    }
   };
 
   const handleVideoChange = e => {

--- a/src/firebase.js
+++ b/src/firebase.js
@@ -18,7 +18,8 @@ import {
   ref,
   uploadBytes,
   getDownloadURL,
-  listAll
+  listAll,
+  deleteObject
 } from 'firebase/storage';
 
 const firebaseConfig = {
@@ -60,7 +61,8 @@ export {
   ref,
   uploadBytes,
   getDownloadURL,
-  listAll
+  listAll,
+  deleteObject
 };
 
 export { storage };


### PR DESCRIPTION
## Summary
- export `deleteObject` from firebase helpers
- remove clips from Firebase Storage when deleted in profile settings

## Testing
- `npm install`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_686e5f84adb4832d911925d8c8934f59