### PR TITLE
Add premium feature page

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ and simple profile management powered by Firebase.
 * Calendar for daily reflections
 * Minimal profile settings and admin mode
 * Profile pictures cached for offline viewing
+* Premium page showing who liked you (subscription required)
 
 
 ## Getting Started

--- a/src/RealDatingApp.jsx
+++ b/src/RealDatingApp.jsx
@@ -5,6 +5,7 @@ import DailyDiscovery from './components/DailyDiscovery.jsx';
 import ChatScreen from './components/ChatScreen.jsx';
 import DailyCheckIn from './components/DailyCheckIn.jsx';
 import ProfileSettings from './components/ProfileSettings.jsx';
+import PremiumFeatures from './components/PremiumFeatures.jsx';
 import AdminScreen from './components/AdminScreen.jsx';
 import AboutScreen from './components/AboutScreen.jsx';
 import { useCollection } from './firebase.js';
@@ -65,7 +66,8 @@ export default function RealDatingApp() {
       ),
       tab==='chat' && React.createElement(ChatScreen, { userId }),
       tab==='checkin' && React.createElement(DailyCheckIn, { userId }),
-      tab==='profile' && React.createElement(ProfileSettings, { userId, ageRange, onChangeAgeRange: setAgeRange, onLogout: ()=>{setLoggedIn(false); setTab('discovery'); setViewProfile(null);} }),
+      tab==='profile' && React.createElement(ProfileSettings, { userId, ageRange, onChangeAgeRange: setAgeRange, onLogout: ()=>{setLoggedIn(false); setTab('discovery'); setViewProfile(null);}, onOpenPremium: ()=>setTab('premium') }),
+      tab==='premium' && React.createElement(PremiumFeatures, { userId, onBack: ()=>setTab('profile'), onSelectProfile: selectProfile }),
       tab==='admin' && React.createElement(AdminScreen, { profiles, onSwitch: setUserId, currentUserId: userId, onOpenDiscovery: openDailyClips }),
       tab==='about' && React.createElement(AboutScreen, { onOpenAdmin: ()=>setTab('admin') })
     ),

--- a/src/components/PremiumFeatures.jsx
+++ b/src/components/PremiumFeatures.jsx
@@ -1,0 +1,32 @@
+import React from 'react';
+import { Card } from './ui/card.js';
+import { Button } from './ui/button.js';
+import SectionTitle from './SectionTitle.jsx';
+import { useCollection } from '../firebase.js';
+import { User as UserIcon } from 'lucide-react';
+
+export default function PremiumFeatures({ userId, onBack, onSelectProfile }) {
+  const likes = useCollection('likes', 'profileId', userId);
+  const profiles = useCollection('profiles');
+  const likedProfiles = profiles.filter(p => likes.some(l => l.userId === p.id));
+
+  return React.createElement(Card, { className: 'p-6 m-4 shadow-xl bg-white/90' },
+    React.createElement(SectionTitle, { title: 'Premium' }),
+    React.createElement(Button, { className: 'mb-4 bg-pink-500 text-white', onClick: onBack }, 'Tilbage'),
+    React.createElement('ul', { className: 'space-y-4' },
+      likedProfiles.length ? likedProfiles.map(p => (
+        React.createElement('li', {
+          key: p.id,
+          className: 'flex items-center gap-4 bg-pink-50 p-2 rounded cursor-pointer',
+          onClick: () => onSelectProfile(p.id)
+        },
+          p.photoURL ?
+            React.createElement('img', { src: p.photoURL, className: 'w-10 h-10 rounded-full object-cover' }) :
+            React.createElement(UserIcon, { className: 'w-10 h-10 text-pink-500' }),
+          React.createElement('span', null, `${p.name} (${p.age})`)
+        )
+      )) :
+        React.createElement('li', { className: 'text-gray-500 text-center' }, 'Ingen har liket dig endnu')
+    )
+  );
+}

--- a/src/components/ProfileSettings.jsx
+++ b/src/components/ProfileSettings.jsx
@@ -10,7 +10,7 @@ import VideoPreview from './VideoPreview.jsx';
 import { db, storage, getDoc, doc, updateDoc, ref, uploadBytes, getDownloadURL, listAll } from '../firebase.js';
 import PurchaseOverlay from './PurchaseOverlay.jsx';
 
-export default function ProfileSettings({ userId, ageRange, onChangeAgeRange, publicView = false, onLogout = () => {} }) {
+export default function ProfileSettings({ userId, ageRange, onChangeAgeRange, publicView = false, onLogout = () => {}, onOpenPremium = () => {} }) {
   const [profile,setProfile]=useState(null);
   const videoRef = useRef();
   const audioRef = useRef();
@@ -314,6 +314,10 @@ export default function ProfileSettings({ userId, ageRange, onChangeAgeRange, pu
         className: 'mt-2 w-full bg-pink-500 text-white',
         onClick: () => setShowSub(true)
       }, 'K\u00f8b abonnement'),
+    !publicView && profile.subscriptionActive && React.createElement(Button, {
+        className: 'mt-2 w-full bg-pink-500 text-white',
+        onClick: onOpenPremium
+      }, 'Premium'),
     !publicView && React.createElement('button', {
         className: 'mt-2 bg-gray-200 text-gray-700 px-4 py-2 rounded',
         onClick: onLogout

--- a/src/seedData.js
+++ b/src/seedData.js
@@ -1,7 +1,7 @@
 import { db, collection, getDocs, deleteDoc, doc, setDoc } from './firebase.js';
 
 export default async function seedData() {
-  const cols = ['profiles', 'matches', 'reflections'];
+  const cols = ['profiles', 'matches', 'reflections', 'likes'];
   for (const c of cols) {
     const snap = await getDocs(collection(db, c));
     await Promise.all(snap.docs.map(d => deleteDoc(d.ref)));
@@ -32,6 +32,11 @@ export default async function seedData() {
       unreadByUser:true,
       unreadByProfile:false
     })
+  ]);
+  await Promise.all([
+    setDoc(doc(db,'likes','101-104'),{id:'101-104',userId:'101',profileId:'104'}),
+    setDoc(doc(db,'likes','104-101'),{id:'104-101',userId:'104',profileId:'101'}),
+    setDoc(doc(db,'likes','105-101'),{id:'105-101',userId:'105',profileId:'101'})
   ]);
   const today = new Date();
   const toDateString = d => d.toISOString().split('T')[0];


### PR DESCRIPTION
## Summary
- include likes in seed data
- show premium button in profile settings when subscribed
- add PremiumFeatures screen listing profiles that liked the user
- connect premium screen in navigation
- document premium page in README

## Testing
- `npm install`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_686e60bac700832db9c6d976083f6427