### PR TITLE
Add more male profiles for premium limit test

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ and simple profile management powered by Firebase.
 * Minimal profile settings and admin mode
 * Profile pictures cached for offline viewing
 * Premium page showing who liked you (subscription required)
+* Seed data includes 11 mandlige profiler der matcher standardbrugeren så du kan teste premium og ekstra klip
 
 
 ## Getting Started

--- a/src/seedData.js
+++ b/src/seedData.js
@@ -14,7 +14,15 @@ export default async function seedData() {
     {id:'103',name:'Emma',age:41,gender:'Kvinde',interest:'Mand',audioClips:[],videoClips:['/sample1.mp4'],clip:'Musikalsk sjæl.'},
     {id:'104',name:'Peter',age:45,gender:'Mand',interest:'Kvinde',audioClips:[],videoClips:['/sample1.mp4'],clip:'Cykler i weekenden.'},
     {id:'105',name:'Lars',age:52,gender:'Mand',interest:'Kvinde',audioClips:[],videoClips:['/sample1.mp4'],clip:'Madglad iværksætter.'},
-    {id:'106',name:'Henrik',age:40,gender:'Mand',interest:'Kvinde',audioClips:[],videoClips:['/sample1.mp4'],clip:'Naturligvis fotograf.'}
+    {id:'106',name:'Henrik',age:40,gender:'Mand',interest:'Kvinde',audioClips:[],videoClips:['/sample1.mp4'],clip:'Naturligvis fotograf.'},
+    {id:'107',name:'Anders',age:38,gender:'Mand',interest:'Kvinde',audioClips:[],videoClips:['/sample1.mp4'],clip:'Løber maraton.'},
+    {id:'108',name:'Johan',age:42,gender:'Mand',interest:'Kvinde',audioClips:[],videoClips:['/sample1.mp4'],clip:'Historieinteresseret.'},
+    {id:'109',name:'Morten',age:50,gender:'Mand',interest:'Kvinde',audioClips:[],videoClips:['/sample1.mp4'],clip:'Friluftsmenneske.'},
+    {id:'110',name:'Ole',age:47,gender:'Mand',interest:'Kvinde',audioClips:[],videoClips:['/sample1.mp4'],clip:'Nyder god kaffe.'},
+    {id:'111',name:'Jørgen',age:53,gender:'Mand',interest:'Kvinde',audioClips:[],videoClips:['/sample1.mp4'],clip:'Glad for sejlsport.'},
+    {id:'112',name:'Frederik',age:39,gender:'Mand',interest:'Kvinde',audioClips:[],videoClips:['/sample1.mp4'],clip:'Spiller guitar.'},
+    {id:'113',name:'Christian',age:44,gender:'Mand',interest:'Kvinde',audioClips:[],videoClips:['/sample1.mp4'],clip:'Kunstnerisk sjæl.'},
+    {id:'114',name:'Thomas',age:41,gender:'Mand',interest:'Kvinde',audioClips:[],videoClips:['/sample1.mp4'],clip:'Eventyrlysten.'}
   ];
   await Promise.all(testUsers.map(u => setDoc(doc(db, 'profiles', u.id), u)));
   await Promise.all([


### PR DESCRIPTION
## Summary
- expand seed data with 8 more male profiles
- document that seed data now contains 11 matching profiles for the default user

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_686e64978498832daf096ebdb7e38d58