### PR TITLE
Enable month navigation for reflection calendar

### DIFF
--- a/src/components/DailyCheckIn.jsx
+++ b/src/components/DailyCheckIn.jsx
@@ -7,7 +7,15 @@ import { useCollection, db, doc, setDoc } from '../firebase.js';
 
 export default function DailyCheckIn({ userId }) {
   const refs = useCollection('reflections','userId',userId);
-  const days = Array.from({length:30},(_,i)=>i+1);
+  const [month,setMonth]=useState(()=>{
+    const d=new Date();
+    d.setDate(1);
+    return d;
+  });
+  const daysInMonth=new Date(month.getFullYear(),month.getMonth()+1,0).getDate();
+  const days=Array.from({length:daysInMonth},(_,i)=>i+1);
+  const monthStr = month.toISOString().slice(0,7);
+  const monthRefs = refs.filter(r => (r.date || '').startsWith(monthStr));
   const [text,setText]=useState('');
 
   const save = async () => {
@@ -22,19 +30,41 @@ export default function DailyCheckIn({ userId }) {
 
   return React.createElement(Card, { className: 'p-6 m-4 shadow-xl bg-white/90' },
     React.createElement(SectionTitle, { title: 'Dagens refleksion' }),
+    React.createElement('div', { className: 'flex justify-between items-center mb-2' },
+      React.createElement(Button, {
+        size: 'sm',
+        variant: 'outline',
+        onClick: () => {
+          const d = new Date(month);
+          d.setMonth(d.getMonth() - 1);
+          setMonth(d);
+        }
+      }, '<'),
+      React.createElement('span', { className: 'font-medium' },
+        month.toLocaleString('default', { month: 'long', year: 'numeric' })
+      ),
+      React.createElement(Button, {
+        size: 'sm',
+        variant: 'outline',
+        onClick: () => {
+          const d = new Date(month);
+          d.setMonth(d.getMonth() + 1);
+          setMonth(d);
+        }
+      }, '>')
+    ),
     React.createElement('div', { className: 'grid grid-cols-7 gap-1 mb-4' },
       days.map(day => (
         React.createElement('div', {
           key: day,
-          className: `p-2 text-center text-sm ${refs.some(r=>parseInt((r.date||'').split('-')[2],10)===day)?'bg-pink-200 rounded':''}`
+          className: `p-2 text-center text-sm ${monthRefs.some(r=>parseInt(r.date.split('-')[2],10)===day)?'bg-pink-200 rounded':''}`
         }, day)
       ))
     ),
     React.createElement('ul', { className: 'list-disc list-inside mb-4' },
-      refs.map(r => {
-        const d = r.date || r.id.split('-')[1];
-        const formatted = d ? d : 'Ukendt dato';
-        return React.createElement('li', { key: r.id }, `${formatted}: ${r.text}`);
+      monthRefs.map(r => {
+        const d = parseInt(r.date.split('-')[2],10);
+        return React.createElement('li', { key: r.id }, `${d}: ${r.text}`);
       })
     ),
     React.createElement(Textarea, {


### PR DESCRIPTION
## Summary
- add state for currently viewed month in DailyCheckIn
- allow navigating between months
- show only reflections from the selected month
- shorten listed dates to only the day of the month

## Testing
- `npm install`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_686e6585cd00832db1127ed79aac967a