### PR TITLE
Fix unreadable unmatch button

### DIFF
--- a/src/components/ChatScreen.jsx
+++ b/src/components/ChatScreen.jsx
@@ -99,8 +99,7 @@ export default function ChatScreen({ userId }) {
             React.createElement(ChatIcon, null)
           ),
           React.createElement(Button, {
-            variant: 'outline',
-            className: 'border-red-500 text-red-500',
+            className: 'btn-outline-red',
             onClick: unmatch
           }, 'Unmatch')
         )

--- a/src/style.css
+++ b/src/style.css
@@ -40,6 +40,13 @@ button:hover {
   opacity: 0.9;
 }
 
+/* Outline style for destructive actions like unmatching */
+button.btn-outline-red {
+  background-color: transparent;
+  color: #ef4444;
+  border: 1px solid #ef4444;
+}
+
 
 .signup-form {
   display: flex;


### PR DESCRIPTION
## Summary
- add `btn-outline-red` style for outline buttons
- use the new class on the Unmatch button

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_686e778ebbe8832d87ebe26a4a089c68