### PR TITLE
Move premium feature button

### DIFF
--- a/src/RealDatingApp.jsx
+++ b/src/RealDatingApp.jsx
@@ -59,14 +59,14 @@ export default function RealDatingApp() {
     React.createElement('div', { className: 'flex-1' },
 
       tab==='discovery' && !viewProfile && (
-        React.createElement(DailyDiscovery, { userId, onSelectProfile: selectProfile, ageRange })
+        React.createElement(DailyDiscovery, { userId, onSelectProfile: selectProfile, ageRange, onOpenPremium: ()=>setTab('premium') })
       ),
       viewProfile && (
         React.createElement(ProfileSettings, { userId: viewProfile, ageRange, onChangeAgeRange: setAgeRange, publicView: true })
       ),
       tab==='chat' && React.createElement(ChatScreen, { userId }),
       tab==='checkin' && React.createElement(DailyCheckIn, { userId }),
-      tab==='profile' && React.createElement(ProfileSettings, { userId, ageRange, onChangeAgeRange: setAgeRange, onLogout: ()=>{setLoggedIn(false); setTab('discovery'); setViewProfile(null);}, onOpenPremium: ()=>setTab('premium') }),
+      tab==='profile' && React.createElement(ProfileSettings, { userId, ageRange, onChangeAgeRange: setAgeRange, onLogout: ()=>{setLoggedIn(false); setTab('discovery'); setViewProfile(null);} }),
       tab==='premium' && React.createElement(PremiumFeatures, { userId, onBack: ()=>setTab('profile'), onSelectProfile: selectProfile }),
       tab==='admin' && React.createElement(AdminScreen, { profiles, onSwitch: setUserId, currentUserId: userId, onOpenDiscovery: openDailyClips }),
       tab==='about' && React.createElement(AboutScreen, { onOpenAdmin: ()=>setTab('admin') })

--- a/src/components/DailyDiscovery.jsx
+++ b/src/components/DailyDiscovery.jsx
@@ -1,5 +1,5 @@
 import React, { useState, useEffect } from 'react';
-import { User, PlayCircle, Heart } from 'lucide-react';
+import { User, PlayCircle, Heart, Star } from 'lucide-react';
 import { Card } from './ui/card.js';
 import { Button } from './ui/button.js';
 import SectionTitle from './SectionTitle.jsx';
@@ -8,7 +8,7 @@ import PurchaseOverlay from './PurchaseOverlay.jsx';
 import MatchOverlay from './MatchOverlay.jsx';
 import InfoOverlay from './InfoOverlay.jsx';
 
-export default function DailyDiscovery({ userId, onSelectProfile, ageRange }) {
+export default function DailyDiscovery({ userId, onSelectProfile, ageRange, onOpenPremium }) {
   const profiles = useCollection('profiles');
   const user = profiles.find(p => p.id === userId) || {};
   const interest = user.interest;
@@ -82,6 +82,13 @@ export default function DailyDiscovery({ userId, onSelectProfile, ageRange }) {
 
   return React.createElement(Card, { className: 'p-6 m-4 shadow-xl bg-white/90' },
     React.createElement(SectionTitle, { title: 'Dagens klip' }),
+    hasSubscription && React.createElement(Button, {
+      className: 'mb-4 w-full bg-yellow-400 text-white flex items-center gap-2',
+      onClick: onOpenPremium
+    },
+      React.createElement(Star, { className: 'w-4 h-4' }),
+      'Premium feature: Se hvem der har liket dig'
+    ),
     React.createElement('p', { className: 'text-center text-gray-500 mb-4' }, `Nye klip om ${hoursUntil} timer`),
     React.createElement('p', { className: 'text-center text-gray-500 mb-4' }, `Tag dig god tid til at lytte til og se dagens klip`),
     React.createElement('ul', { className: 'space-y-4' },

--- a/src/components/ProfileSettings.jsx
+++ b/src/components/ProfileSettings.jsx
@@ -10,7 +10,7 @@ import VideoPreview from './VideoPreview.jsx';
 import { db, storage, getDoc, doc, updateDoc, ref, uploadBytes, getDownloadURL, listAll, deleteObject } from '../firebase.js';
 import PurchaseOverlay from './PurchaseOverlay.jsx';
 
-export default function ProfileSettings({ userId, ageRange, onChangeAgeRange, publicView = false, onLogout = () => {}, onOpenPremium = () => {} }) {
+export default function ProfileSettings({ userId, ageRange, onChangeAgeRange, publicView = false, onLogout = () => {} }) {
   const [profile,setProfile]=useState(null);
   const videoRef = useRef();
   const audioRef = useRef();
@@ -333,14 +333,10 @@ export default function ProfileSettings({ userId, ageRange, onChangeAgeRange, pu
       }, subscriptionActive
         ? `Abonnement aktivt til ${new Date(profile.subscriptionExpires).toLocaleDateString('da-DK')}`
         : `Abonnement udløb ${new Date(profile.subscriptionExpires).toLocaleDateString('da-DK')}`),
-    !publicView && React.createElement(Button, {
+    !publicView && !subscriptionActive && React.createElement(Button, {
         className: 'mt-2 w-full bg-pink-500 text-white',
         onClick: () => setShowSub(true)
       }, 'K\u00f8b abonnement'),
-    !publicView && profile.subscriptionActive && React.createElement(Button, {
-        className: 'mt-2 w-full bg-pink-500 text-white',
-        onClick: onOpenPremium
-      }, 'Premium'),
     !publicView && React.createElement('button', {
         className: 'mt-2 bg-gray-200 text-gray-700 px-4 py-2 rounded',
         onClick: onLogout


### PR DESCRIPTION
## Summary
- move premium feature button from profile page to daily discovery card
- hide 'Køb abonnement' button when subscription already active
- clean up unused premium button props

## Testing
- `npm run build` *(fails: parcel not found)*

------
https://chatgpt.com/codex/tasks/task_e_686e7bc3ab40832dadff4a974fa2c618