### PR TITLE
Remove redundant interest info

### DIFF
--- a/src/components/ProfileSettings.jsx
+++ b/src/components/ProfileSettings.jsx
@@ -189,9 +189,6 @@ export default function ProfileSettings({ userId, ageRange, onChangeAgeRange, pu
       }, profile.photoURL ? 'Skift billede' : 'Upload billede')
     ),
     React.createElement(SectionTitle, { title: `${profile.name}, ${profile.age}${profile.city ? ', ' + profile.city : ''}` }),
-    !publicView && React.createElement('p', { className: 'text-center mb-2' },
-      `Interesseret i ${profile.interest === 'Mand' ? 'Mænd' : 'Kvinder'} mellem ${ageRange[0]} og ${ageRange[1]} og i en afstand mellem ${distanceRange[0]} og ${distanceRange[1]} km`
-    ),
     !publicView && React.createElement('div', { className: 'flex flex-col gap-4 mb-4' },
       React.createElement('label', null, 'By'),
       React.createElement(Input, {


### PR DESCRIPTION
## Summary
- remove the paragraph showing selected age and distance criteria on ProfileSettings page

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_686e82a7ad7c832db1978c38789c547b