### PR TITLE
Add match/unmatch on public profile

### DIFF
--- a/src/RealDatingApp.jsx
+++ b/src/RealDatingApp.jsx
@@ -62,7 +62,7 @@ export default function RealDatingApp() {
         React.createElement(DailyDiscovery, { userId, onSelectProfile: selectProfile, ageRange, onOpenPremium: ()=>setTab('premium') })
       ),
       viewProfile && (
-        React.createElement(ProfileSettings, { userId: viewProfile, ageRange, onChangeAgeRange: setAgeRange, publicView: true })
+        React.createElement(ProfileSettings, { userId: viewProfile, viewerId: userId, ageRange, onChangeAgeRange: setAgeRange, publicView: true })
       ),
       tab==='chat' && React.createElement(ChatScreen, { userId }),
       tab==='checkin' && React.createElement(DailyCheckIn, { userId }),


### PR DESCRIPTION
## Summary
- pass logged-in user id to public profile view
- implement like/unlike logic in `ProfileSettings`
- show match overlay and match/unmatch button when viewing another profile

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_686e81c171e0832d8b4b17323948c64f