### PR TITLE
Add back button on profile view

### DIFF
--- a/src/RealDateApp.jsx
+++ b/src/RealDateApp.jsx
@@ -62,7 +62,7 @@ export default function RealDateApp() {
         React.createElement(DailyDiscovery, { userId, onSelectProfile: selectProfile, ageRange, onOpenPremium: ()=>setTab('premium') })
       ),
       viewProfile && (
-        React.createElement(ProfileSettings, { userId: viewProfile, viewerId: userId, ageRange, onChangeAgeRange: setAgeRange, publicView: true })
+        React.createElement(ProfileSettings, { userId: viewProfile, viewerId: userId, ageRange, onChangeAgeRange: setAgeRange, publicView: true, onBack: openDailyClips })
       ),
       tab==='chat' && React.createElement(ChatScreen, { userId }),
       tab==='checkin' && React.createElement(DailyCheckIn, { userId }),

--- a/src/components/ProfileSettings.jsx
+++ b/src/components/ProfileSettings.jsx
@@ -14,7 +14,7 @@ import VideoRecorder from './VideoRecorder.jsx';
 import AudioRecorder from './AudioRecorder.jsx';
 import MatchOverlay from './MatchOverlay.jsx';
 
-export default function ProfileSettings({ userId, ageRange, onChangeAgeRange, publicView = false, onLogout = () => {}, viewerId }) {
+export default function ProfileSettings({ userId, ageRange, onChangeAgeRange, publicView = false, onLogout = () => {}, viewerId, onBack }) {
   const [profile,setProfile]=useState(null);
   const videoRef = useRef();
   const audioRef = useRef();
@@ -249,6 +249,7 @@ export default function ProfileSettings({ userId, ageRange, onChangeAgeRange, pu
       }, profile.photoURL ? 'Skift billede' : 'Upload billede')
     ),
     React.createElement(SectionTitle, { title: `${profile.name}, ${profile.age}${profile.city ? ', ' + profile.city : ''}` }),
+    publicView && onBack && React.createElement(Button, { className: 'mb-4 bg-pink-500 text-white', onClick: onBack }, 'Tilbage'),
     !publicView && React.createElement('div', { className: 'flex flex-col gap-4 mb-4' },
       React.createElement('label', null, 'By'),
       React.createElement(Input, {


### PR DESCRIPTION
## Summary
- add `onBack` prop to `ProfileSettings`
- show a back button in public profile view
- pass the openDailyClips handler when viewing another profile

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_686e89b2a1b0832db5b16a5f0949f127