### PR TITLE
Shrink profile video previews

### DIFF
--- a/src/components/VideoPreview.jsx
+++ b/src/components/VideoPreview.jsx
@@ -4,6 +4,6 @@ export default function VideoPreview({ src }) {
   return React.createElement('video', {
     src,
     controls: true,
-    className: 'w-32 rounded'
+    className: 'w-8 rounded'
   });
 }


### PR DESCRIPTION
## Summary
- adjust VideoPreview width to be smaller on profile page

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_686e9449ac78832db8d4feb64133ee74