### PR TITLE
Display app version and bump automatically

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "scripts": {
     "start": "npx serve .",
     "dev": "parcel public/index.html",
+    "prebuild": "node scripts/bump-version.js",
     "build": "parcel build public/index.html --dist-dir dist --public-url ./"
   },
   "dependencies": {

--- a/scripts/bump-version.js
+++ b/scripts/bump-version.js
@@ -1,0 +1,18 @@
+const fs = require('fs');
+const path = require('path');
+
+const pkgPath = path.join(__dirname, '..', 'package.json');
+const pkg = JSON.parse(fs.readFileSync(pkgPath, 'utf8'));
+
+const parts = pkg.version.split('.').map(n => parseInt(n, 10) || 0);
+if (parts.length < 3) {
+  while (parts.length < 3) parts.push(0);
+}
+parts[2] += 1; // bump patch version
+pkg.version = parts.join('.');
+
+fs.writeFileSync(pkgPath, JSON.stringify(pkg, null, 2) + '\n');
+
+const versionFile = path.join(__dirname, '..', 'src', 'version.js');
+fs.writeFileSync(versionFile, `export default '${pkg.version}';\n`);
+console.log('Version bumped to', pkg.version);

--- a/src/components/AboutScreen.jsx
+++ b/src/components/AboutScreen.jsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { Card } from './ui/card.js';
 import { Button } from './ui/button.js';
+import version from '../version.js';
 
 export default function AboutScreen({ onOpenAdmin }) {
   return React.createElement(Card, { className: 'p-6 m-4 shadow-xl bg-white/90' },
@@ -9,6 +10,7 @@ export default function AboutScreen({ onOpenAdmin }) {
       'Velkommen til en ny måde at date på. Her handler det ikke om hurtige swipes, men om at tage sig tid til at lære hinanden at kende. '
       + 'RealDate er for dig, der søger noget ægte og meningsfuldt. Tag det stille og roligt, og find den forbindelse, der virkelig betyder noget.'
     ),
+    React.createElement('p', { className: 'text-gray-500 text-sm text-center mb-4' }, `Version ${version}`),
     onOpenAdmin && React.createElement(Button, { className: 'bg-blue-500 hover:bg-blue-600 text-white mt-4', onClick: onOpenAdmin }, 'Admin')
   );
 }

--- a/src/version.js
+++ b/src/version.js
@@ -1,0 +1,1 @@
+export default '1.0.0';


### PR DESCRIPTION
## Summary
- add `prebuild` script to auto increment version and write `src/version.js`
- show the version number on the About page

## Testing
- `npm install`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_686e9abf7804832d9633770413796f4d