### PR TITLE
Fix upload video/audio on profile page

### DIFF
--- a/src/components/ProfileSettings.jsx
+++ b/src/components/ProfileSettings.jsx
@@ -250,7 +250,6 @@ export default function ProfileSettings({ userId, ageRange, onChangeAgeRange, pu
       React.createElement('input', {
         type: 'file',
         accept: 'video/*',
-        capture: 'environment',
         ref: videoRef,
         onChange: handleVideoChange,
         className: 'hidden'
@@ -293,7 +292,6 @@ export default function ProfileSettings({ userId, ageRange, onChangeAgeRange, pu
       React.createElement('input', {
         type: 'file',
         accept: 'audio/*',
-        capture: 'user',
         ref: audioRef,
         onChange: handleAudioChange,
         className: 'hidden'


### PR DESCRIPTION
## Summary
- remove `capture` attribute from video/audio upload inputs so mobile browsers open the file picker

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_686ec714973c832da08b0df97159df6d