### PR TITLE
Limit audio and video clips to 10 seconds

### DIFF
--- a/FEATURES.txt
+++ b/FEATURES.txt
@@ -5,6 +5,7 @@ Calendar interface for daily reflection notes
 Profile settings with age range filtering
 Ability to upload or record video clips
 Ability to upload or record audio clips
+Video/audio duration limited to 10 seconds
 Offline support via service worker caching
 PWA manifest for standalone installation
 

--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ and simple profile management powered by Firebase.
 * Profile pictures cached for offline viewing
 * Premium page showing who liked you (subscription required)
 * Seed data includes 11 mandlige profiler der matcher standardbrugeren så du kan teste premium og ekstra klip
+* Video- og lydklip begrænset til 10 sekunder
 
 
 ## Getting Started

--- a/src/components/AudioRecorder.jsx
+++ b/src/components/AudioRecorder.jsx
@@ -6,6 +6,7 @@ export default function AudioRecorder({ onCancel, onRecorded }) {
   const streamRef = useRef();
   const recorderRef = useRef();
   const chunksRef = useRef([]);
+  const timeoutRef = useRef();
   const [recording, setRecording] = useState(false);
 
   useEffect(() => {
@@ -31,12 +32,15 @@ export default function AudioRecorder({ onCancel, onRecorded }) {
       onRecorded && onRecorded(file);
     };
     recorder.start();
+    timeoutRef.current = setTimeout(() => stop(), 10000);
     setRecording(true);
   };
 
   const stop = () => {
     if(recorderRef.current){
       recorderRef.current.stop();
+      clearTimeout(timeoutRef.current);
+      timeoutRef.current = null;
       setRecording(false);
     }
   };

--- a/src/components/ProfileSettings.jsx
+++ b/src/components/ProfileSettings.jsx
@@ -71,6 +71,20 @@ export default function ProfileSettings({ userId, ageRange, onChangeAgeRange, pu
 
   const handlePhotoChange = e => uploadPhoto(e.target.files[0]);
 
+  const checkDuration = file => new Promise(resolve => {
+    const el = document.createElement(file.type.startsWith('audio') ? 'audio' : 'video');
+    el.preload = 'metadata';
+    el.src = URL.createObjectURL(file);
+    el.onloadedmetadata = () => {
+      URL.revokeObjectURL(el.src);
+      resolve(el.duration <= 10);
+    };
+    el.onerror = () => {
+      URL.revokeObjectURL(el.src);
+      resolve(true);
+    };
+  });
+
   const replaceFile = async (file, field, index) => {
     if(!file) return;
     const storageRef = ref(storage, `profiles/${userId}/${field}-${Date.now()}-${file.name}`);
@@ -97,8 +111,13 @@ export default function ProfileSettings({ userId, ageRange, onChangeAgeRange, pu
     }
   };
 
-  const handleVideoChange = e => {
+  const handleVideoChange = async e => {
     const file = e.target.files[0];
+    if(!file) return;
+    if(!(await checkDuration(file))){
+      alert('Video må højest være 10 sekunder');
+      return;
+    }
     if(replaceTarget && replaceTarget.field==='videoClips'){
       replaceFile(file,'videoClips',replaceTarget.index);
       setReplaceTarget(null);
@@ -107,8 +126,13 @@ export default function ProfileSettings({ userId, ageRange, onChangeAgeRange, pu
     }
   };
 
-  const handleAudioChange = e => {
+  const handleAudioChange = async e => {
     const file = e.target.files[0];
+    if(!file) return;
+    if(!(await checkDuration(file))){
+      alert('Lydklip må højest være 10 sekunder');
+      return;
+    }
     if(replaceTarget && replaceTarget.field==='audioClips'){
       replaceFile(file,'audioClips',replaceTarget.index);
       setReplaceTarget(null);

--- a/src/components/VideoRecorder.jsx
+++ b/src/components/VideoRecorder.jsx
@@ -7,6 +7,7 @@ export default function VideoRecorder({ onCancel, onRecorded }) {
   const streamRef = useRef();
   const recorderRef = useRef();
   const chunksRef = useRef([]);
+  const timeoutRef = useRef();
   const [recording, setRecording] = useState(false);
 
   useEffect(() => {
@@ -33,12 +34,15 @@ export default function VideoRecorder({ onCancel, onRecorded }) {
       onRecorded && onRecorded(file);
     };
     recorder.start();
+    timeoutRef.current = setTimeout(() => stop(), 10000);
     setRecording(true);
   };
 
   const stop = () => {
     if(recorderRef.current){
       recorderRef.current.stop();
+      clearTimeout(timeoutRef.current);
+      timeoutRef.current = null;
       setRecording(false);
     }
   };


### PR DESCRIPTION
## Summary
- stop video and audio recordings automatically after 10s
- validate duration before uploading recorded files
- document the 10 second limit

## Testing
- `npm install`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_686ed1c7d608832db6e40b9cec5c366b