### PR TITLE
Remove save button on profile page

### DIFF
--- a/src/components/ProfileSettings.jsx
+++ b/src/components/ProfileSettings.jsx
@@ -382,10 +382,6 @@ export default function ProfileSettings({ userId, ageRange, onChangeAgeRange, pu
         onChange: publicView ? undefined : handleClipChange
       })
     ),
-    !publicView && React.createElement('button', {
-        className: 'mt-4 bg-pink-500 text-white px-4 py-2 rounded',
-        onClick: saveChanges
-      }, 'Gem ændringer'),
     !publicView && React.createElement(Button, {
         className: 'mt-2 bg-blue-500 text-white w-full',
         onClick: recoverMissing


### PR DESCRIPTION
## Summary
- remove `Gem ændringer` button from profile settings

## Testing
- `npm ci`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_686ee9b2d93c832d8f10d38a5be042bb