### PR TITLE
Add Freja text at bottom of About screen

### DIFF
--- a/src/components/AboutScreen.jsx
+++ b/src/components/AboutScreen.jsx
@@ -11,6 +11,7 @@ export default function AboutScreen({ onOpenAdmin }) {
       + 'RealDate er for dig, der søger noget ægte og meningsfuldt. Tag det stille og roligt, og find den forbindelse, der virkelig betyder noget.'
     ),
     React.createElement('p', { className: 'text-gray-500 text-sm text-center mb-4' }, `Version ${version}`),
-    onOpenAdmin && React.createElement(Button, { className: 'bg-blue-500 hover:bg-blue-600 text-white mt-4', onClick: onOpenAdmin }, 'Admin')
+    onOpenAdmin && React.createElement(Button, { className: 'bg-blue-500 hover:bg-blue-600 text-white mt-4', onClick: onOpenAdmin }, 'Admin'),
+    React.createElement('p', { className: 'text-center mt-4 text-gray-700' }, 'Freja')
   );
 }


### PR DESCRIPTION
## Summary
- show a Freja credit line at the end of the About screen

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_686fc7f78658832d87d37ada9a0134f9