### PR TITLE
Move user picker to login page

### DIFF
--- a/src/RealDateApp.jsx
+++ b/src/RealDateApp.jsx
@@ -49,7 +49,7 @@ export default function RealDateApp() {
   },[loggedIn, profiles, userId]);
 
 
-  if(!loggedIn) return React.createElement(WelcomeScreen, { onNext: ()=>setLoggedIn(true) });
+  if(!loggedIn) return React.createElement(WelcomeScreen, { profiles, onLogin: id=>{ setUserId(id); setLoggedIn(true); } });
   const selectProfile=id=>{setViewProfile(id); setTab('discovery');};
 
 
@@ -68,7 +68,7 @@ export default function RealDateApp() {
       tab==='checkin' && React.createElement(DailyCheckIn, { userId }),
       tab==='profile' && React.createElement(ProfileSettings, { userId, ageRange, onChangeAgeRange: setAgeRange, onLogout: ()=>{setLoggedIn(false); setTab('discovery'); setViewProfile(null);} }),
       tab==='premium' && React.createElement(PremiumFeatures, { userId, onBack: ()=>setTab('discovery'), onSelectProfile: selectProfile }),
-      tab==='admin' && React.createElement(AdminScreen, { profiles, onSwitch: setUserId, currentUserId: userId, onOpenDiscovery: openDailyClips }),
+      tab==='admin' && React.createElement(AdminScreen, { onOpenDiscovery: openDailyClips }),
       tab==='about' && React.createElement(AboutScreen, { onOpenAdmin: ()=>setTab('admin') })
     ),
     React.createElement('div', { className: 'p-4 bg-white shadow-inner flex justify-around fixed bottom-0 left-0 right-0' },

--- a/src/components/AdminScreen.jsx
+++ b/src/components/AdminScreen.jsx
@@ -5,7 +5,7 @@ import SectionTitle from './SectionTitle.jsx';
 import seedData from '../seedData.js';
 import { db, collection, getDocs } from '../firebase.js';
 
-export default function AdminScreen({ profiles, onSwitch, currentUserId, onOpenDiscovery }) {
+export default function AdminScreen({ onOpenDiscovery }) {
   const [firestoreInfo, setFirestoreInfo] = useState(null);
 
   const showFirestoreInfo = async () => {
@@ -28,16 +28,6 @@ export default function AdminScreen({ profiles, onSwitch, currentUserId, onOpenD
 
   return React.createElement(Card, { className: 'p-6 m-4 shadow-xl bg-white/90' },
     React.createElement(SectionTitle, { title: 'Administration' }),
-    React.createElement('h3', { className: 'text-xl font-semibold mb-2 text-pink-600' }, 'Skift profil'),
-    React.createElement('select', {
-      className: 'border p-2 mb-4 w-full',
-      onChange: e=>onSwitch(e.target.value),
-      value: currentUserId || ''
-    },
-      React.createElement('option', { value: '' }, '-- vælg profil --'),
-      profiles.map(p => React.createElement('option', { key: p.id, value: p.id }, p.name))
-    ),
-    React.createElement('p', { className: 'text-gray-500 text-sm mb-4' }, 'Oplev app\u2019en som en anden bruger.'),
     onOpenDiscovery && React.createElement(Button, { className: 'mb-4 bg-pink-500 text-white px-4 py-2 rounded', onClick: onOpenDiscovery }, 'G\u00e5 til Dagens klip'),
     React.createElement('h3', { className: 'text-xl font-semibold mb-2 mt-4 text-pink-600' }, 'Firestore info'),
     React.createElement(Button, { className: 'mt-2 bg-pink-500 text-white px-4 py-2 rounded', onClick: showFirestoreInfo }, 'Show credentials'),

--- a/src/components/WelcomeScreen.jsx
+++ b/src/components/WelcomeScreen.jsx
@@ -1,8 +1,9 @@
-import React from 'react';
+import React, { useState } from 'react';
 import { Card } from './ui/card.js';
 import { Button } from './ui/button.js';
 
-export default function WelcomeScreen({ onNext }) {
+export default function WelcomeScreen({ profiles = [], onLogin }) {
+  const [selected, setSelected] = useState('');
   return React.createElement(Card, { className: 'p-6 m-4 shadow-xl bg-white/90' },
     React.createElement('h1', { className: 'text-3xl font-bold mb-4 text-pink-600 text-center' }, 'Om RealDate'),
     React.createElement('p', { className: 'mb-4 text-gray-700' },
@@ -10,6 +11,18 @@ export default function WelcomeScreen({ onNext }) {
       + 'Her handler det ikke om hurtige swipes.'
       + 'RealDate er for dig, der søger noget ægte og meningsfuldt.'
     ),
-    React.createElement(Button, { onClick: onNext, className: 'bg-pink-500 hover:bg-pink-600 text-white mt-4' }, 'Login')
+    React.createElement('select', {
+      className: 'border p-2 mb-4 w-full',
+      onChange: e => setSelected(e.target.value),
+      value: selected || ''
+    },
+      React.createElement('option', { value: '' }, '-- v\u00e6lg bruger --'),
+      profiles.map(p => React.createElement('option', { key: p.id, value: p.id }, p.name))
+    ),
+    React.createElement(Button, {
+      onClick: () => selected && onLogin(selected),
+      className: 'bg-pink-500 hover:bg-pink-600 text-white mt-4',
+      disabled: !selected
+    }, 'Login')
   );
 }


### PR DESCRIPTION
## Summary
- let users choose a profile on the login screen
- remove profile switcher from admin
- update app to use the new login handler

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_686fd97654a8832d97861611e7899483