### PR TITLE
Set default profile selection

### DIFF
--- a/src/components/WelcomeScreen.jsx
+++ b/src/components/WelcomeScreen.jsx
@@ -1,9 +1,15 @@
-import React, { useState } from 'react';
+import React, { useState, useEffect } from 'react';
 import { Card } from './ui/card.js';
 import { Button } from './ui/button.js';
 
 export default function WelcomeScreen({ profiles = [], onLogin }) {
-  const [selected, setSelected] = useState('');
+  const [selected, setSelected] = useState(profiles[0]?.id || '');
+
+  useEffect(() => {
+    if (!selected && profiles.length) {
+      setSelected(profiles[0].id);
+    }
+  }, [profiles, selected]);
   return React.createElement(Card, { className: 'p-6 m-4 shadow-xl bg-white/90' },
     React.createElement('h1', { className: 'text-3xl font-bold mb-4 text-pink-600 text-center' }, 'Om RealDate'),
     React.createElement('p', { className: 'mb-4 text-gray-700' },


### PR DESCRIPTION
## Summary
- choose the first profile automatically when loading the login page

## Testing
- `npm test` *(fails: Missing script)*
- `npm run lint` *(fails: Missing script)*
- `npm run build` *(fails: parcel not found)*

------
https://chatgpt.com/codex/tasks/task_e_686fe27a7d68832daf6e1a914cfa9d1a