### PR TITLE
Add Snapchat-style audio recorder

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "realdate",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "realdate",
-      "version": "1.0.0",
+      "version": "1.0.1",
       "dependencies": {
         "firebase": "^9.23.0",
         "lucide-react": "^0.322.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "realdate",
-  "version": "1.0.0",
+  "version": "1.0.2",
   "description": "A minimal React PWA for swiping short videos and speed dating.",
   "scripts": {
     "start": "npx serve .",

--- a/src/components/ProfileSettings.jsx
+++ b/src/components/ProfileSettings.jsx
@@ -12,6 +12,7 @@ import { useCollection, db, storage, getDoc, doc, updateDoc, setDoc, deleteDoc, 
 import PurchaseOverlay from './PurchaseOverlay.jsx';
 import AudioRecorder from "./AudioRecorder.jsx";
 import AudioContextRecorder from "./AudioContextRecorder.jsx";
+import SnapAudioRecorder from "./SnapAudioRecorder.jsx";
 import MatchOverlay from './MatchOverlay.jsx';
 
 export default function ProfileSettings({ userId, ageRange, onChangeAgeRange, publicView = false, onLogout = () => {}, viewerId, onBack }) {
@@ -23,6 +24,7 @@ export default function ProfileSettings({ userId, ageRange, onChangeAgeRange, pu
   const captureRef = useRef();
   const [showRecorderA, setShowRecorderA] = useState(false);
   const [showRecorderB, setShowRecorderB] = useState(false);
+  const [showSnapRecorder, setShowSnapRecorder] = useState(false);
   const [showSub, setShowSub] = useState(false);
   const [distanceRange, setDistanceRange] = useState([10,25]);
   const currentUserId = viewerId || userId;
@@ -142,7 +144,7 @@ export default function ProfileSettings({ userId, ageRange, onChangeAgeRange, pu
     const file = e.target.files[0];
     if(!file) return;
     if(!(await checkDuration(file))){
-      alert("Lydklip mu00E5 hu00F8jest vu00E6re 10 sekunder");
+      alert("Lydklip må højest være 10 sekunder");
       return;
     }
     uploadFile(file, "audioClips");
@@ -150,7 +152,7 @@ export default function ProfileSettings({ userId, ageRange, onChangeAgeRange, pu
 
   const handleRecordedA = async file => {
     if(!(await checkDuration(file))){
-      alert("Lydklip mu00E5 hu00F8jest vu00E6re 10 sekunder");
+      alert("Lydklip må højest være 10 sekunder");
       return;
     }
     setShowRecorderA(false);
@@ -159,12 +161,21 @@ export default function ProfileSettings({ userId, ageRange, onChangeAgeRange, pu
 
   const handleRecordedB = async file => {
     if(!(await checkDuration(file))){
-      alert("Lydklip mu00E5 hu00F8jest vu00E6re 10 sekunder");
+      alert("Lydklip må højest være 10 sekunder");
       return;
     }
     setShowRecorderB(false);
     uploadFile(file, "audioClips");
   };
+  const handleSnapRecorded = async file => {
+    if(!(await checkDuration(file))){
+      alert("Lydklip må højest være 10 sekunder");
+      return;
+    }
+    setShowSnapRecorder(false);
+    uploadFile(file, "audioClips");
+  };
+
 
   const handleCityChange = async e => {
     const city = e.target.value;
@@ -364,6 +375,11 @@ export default function ProfileSettings({ userId, ageRange, onChangeAgeRange, pu
         disabled: maxAudios
       }, 'Optag (Capture)'),
       React.createElement(Button, {
+        className: `mb-2 flex items-center justify-center ${maxAudios ? 'bg-gray-300 text-gray-500 cursor-not-allowed' : 'bg-pink-500 text-white'}`,
+        onClick: () => { if(!maxAudios) setShowSnapRecorder(true); },
+        disabled: maxAudios
+      }, React.createElement(Mic, { className: 'w-4 h-4' })),
+      React.createElement(Button, {
         className: `mb-4 ${maxAudios ? 'bg-gray-300 text-gray-500 cursor-not-allowed' : 'bg-pink-500 text-white'}`,
         onClick: () => {
           if(!maxAudios) setShowRecorderB(true);
@@ -371,7 +387,8 @@ export default function ProfileSettings({ userId, ageRange, onChangeAgeRange, pu
         disabled: maxAudios
       }, 'Optag (WAV)'),
       showRecorderA && React.createElement(AudioRecorder, { onCancel: () => setShowRecorderA(false), onRecorded: handleRecordedA }),
-      showRecorderB && React.createElement(AudioContextRecorder, { onCancel: () => setShowRecorderB(false), onRecorded: handleRecordedB })
+      showRecorderB && React.createElement(AudioContextRecorder, { onCancel: () => setShowRecorderB(false), onRecorded: handleRecordedB }),
+      showSnapRecorder && React.createElement(SnapAudioRecorder, { onCancel: () => setShowSnapRecorder(false), onRecorded: handleSnapRecorded })
     )
   );
 

--- a/src/components/SnapAudioRecorder.jsx
+++ b/src/components/SnapAudioRecorder.jsx
@@ -1,0 +1,83 @@
+import React, { useEffect, useRef, useState } from 'react';
+import { Mic } from 'lucide-react';
+
+export default function SnapAudioRecorder({ onCancel, onRecorded }) {
+  const streamRef = useRef();
+  const recorderRef = useRef();
+  const chunksRef = useRef([]);
+  const timeoutRef = useRef();
+  const [recording, setRecording] = useState(false);
+  const [progress, setProgress] = useState(0);
+
+  useEffect(() => {
+    navigator.mediaDevices.getUserMedia({ audio: true }).then(stream => {
+      streamRef.current = stream;
+      start();
+    });
+    return () => {
+      if(streamRef.current){
+        streamRef.current.getTracks().forEach(t => t.stop());
+      }
+    };
+  }, []);
+
+  const start = () => {
+    if(!streamRef.current) return;
+    const recorder = new MediaRecorder(streamRef.current);
+    recorderRef.current = recorder;
+    chunksRef.current = [];
+    recorder.ondataavailable = e => chunksRef.current.push(e.data);
+    recorder.onstop = () => {
+      const blob = new Blob(chunksRef.current, { type: recorder.mimeType });
+      const file = new File([blob], `audio-${Date.now()}.webm`, { type: blob.type });
+      onRecorded && onRecorded(file);
+    };
+    recorder.start();
+    setRecording(true);
+    const startTime = Date.now();
+    const tick = () => {
+      const elapsed = Date.now() - startTime;
+      setProgress(Math.min(elapsed / 10000, 1));
+      if(elapsed >= 10000){
+        stop();
+      } else {
+        timeoutRef.current = requestAnimationFrame(tick);
+      }
+    };
+    timeoutRef.current = requestAnimationFrame(tick);
+  };
+
+  const stop = () => {
+    if(recorderRef.current){
+      recorderRef.current.stop();
+      cancelAnimationFrame(timeoutRef.current);
+      timeoutRef.current = null;
+      setRecording(false);
+    }
+  };
+
+  const cancel = () => {
+    stop();
+    onCancel && onCancel();
+  };
+
+  const radius = 45;
+  const circumference = 2 * Math.PI * radius;
+  const offset = circumference * (1 - progress);
+
+  return React.createElement('div', { className:'fixed inset-0 z-50 flex items-center justify-center bg-black/60' },
+    React.createElement('div', { className:'relative w-32 h-32' },
+      React.createElement('svg', { className:'absolute inset-0 w-full h-full rotate-animation', viewBox:'0 0 100 100' },
+        React.createElement('circle', { cx:'50', cy:'50', r:radius, stroke:'#e5e7eb', strokeWidth:'5', fill:'none' }),
+        React.createElement('circle', {
+          cx:'50', cy:'50', r:radius, stroke:'#ff4895', strokeWidth:'5', fill:'none',
+          strokeDasharray:circumference, strokeDashoffset:offset
+        })
+      ),
+      React.createElement('button', { onClick: recording ? stop : start, className:'absolute inset-0 flex items-center justify-center text-pink-500 bg-white rounded-full' },
+        React.createElement(Mic, { className:'w-8 h-8' })
+      ),
+      React.createElement('button', { onClick: cancel, className:'absolute -bottom-10 left-1/2 -translate-x-1/2 text-white' }, 'Annuller')
+    )
+  );
+}

--- a/src/style.css
+++ b/src/style.css
@@ -88,3 +88,12 @@ button.btn-outline-red {
   left: 1rem;
 
 }
+
+/* Simple rotation animation used for the Snapchat-style recorder */
+.rotate-animation {
+  animation: spin 1s linear infinite;
+}
+@keyframes spin {
+  from { transform: rotate(0deg); }
+  to { transform: rotate(360deg); }
+}

--- a/src/version.js
+++ b/src/version.js
@@ -1,1 +1,1 @@
-export default '1.0.0';
+export default '1.0.2';


### PR DESCRIPTION
## Summary
- create `SnapAudioRecorder` for a circular recording widget
- animate it with new `.rotate-animation` CSS
- allow profiles to trigger this recorder via a mic button
- track `showSnapRecorder` state in profile settings

## Testing
- `npm install`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_686fff7c94e4832dba6e745ae10059f6