### PR TITLE
Fix audio duration check

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ and simple profile management powered by Firebase.
 * Premium page showing who liked you (subscription required)
 * Seed data includes 11 mandlige profiler der matcher standardbrugeren så du kan teste premium og ekstra klip
 * Video- og lydklip begrænset til 10 sekunder
+  (optagelser lidt over 10s accepteres for at håndtere kodningsforsinkelser)
 * Animation med nedtælling viser hvor lang tid der er tilbage under lydoptagelse
 
 

--- a/src/components/ProfileSettings.jsx
+++ b/src/components/ProfileSettings.jsx
@@ -71,13 +71,19 @@ export default function ProfileSettings({ userId, ageRange, onChangeAgeRange, pu
 
   const handlePhotoChange = e => uploadPhoto(e.target.files[0]);
 
+  // Allow a small tolerance when validating clip length because the
+  // MediaRecorder output can be slightly longer than the requested
+  // duration due to encoding overhead.
   const checkDuration = file => new Promise(resolve => {
-    const el = document.createElement(file.type.startsWith('audio') ? 'audio' : 'video');
+    const el = document.createElement(
+      file.type.startsWith('audio') ? 'audio' : 'video'
+    );
     el.preload = 'metadata';
     el.src = URL.createObjectURL(file);
     el.onloadedmetadata = () => {
       URL.revokeObjectURL(el.src);
-      resolve(el.duration <= 10);
+      const max = 10.5; // accept files up to ~0.5s over the 10s limit
+      resolve(el.duration <= max);
     };
     el.onerror = () => {
       URL.revokeObjectURL(el.src);


### PR DESCRIPTION
## Summary
- allow small tolerance for recorded clip length to avoid false failure
- mention the duration tolerance in README

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_687029927af8832d96e4f6d006cf5021