### PR TITLE
Add countdown & preview for video recording

### DIFF
--- a/FEATURES.txt
+++ b/FEATURES.txt
@@ -6,7 +6,7 @@ Profile settings with age range filtering
 Ability to upload or record video clips
 Ability to upload or record audio clips
 Video/audio duration limited to 10 seconds
-Animated countdown shown while recording audio
+Animated countdown shown while recording audio or video
 Offline support via service worker caching
 PWA manifest for standalone installation
 

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ and simple profile management powered by Firebase.
 * Seed data includes 11 mandlige profiler der matcher standardbrugeren så du kan teste premium og ekstra klip
 * Video- og lydklip begrænset til 10 sekunder
   (optagelser lidt over 10s accepteres for at håndtere kodningsforsinkelser)
-* Animation med nedtælling viser hvor lang tid der er tilbage under lydoptagelse
+* Animation med nedtælling viser hvor lang tid der er tilbage under lyd- og videooptagelse
 
 
 ## Getting Started

--- a/src/components/ProfileSettings.jsx
+++ b/src/components/ProfileSettings.jsx
@@ -11,6 +11,7 @@ import VideoPreview from './VideoPreview.jsx';
 import { useCollection, db, storage, getDoc, doc, updateDoc, setDoc, deleteDoc, ref, uploadBytes, getDownloadURL, listAll, deleteObject } from '../firebase.js';
 import PurchaseOverlay from './PurchaseOverlay.jsx';
 import SnapAudioRecorder from "./SnapAudioRecorder.jsx";
+import SnapVideoRecorder from "./SnapVideoRecorder.jsx";
 import MatchOverlay from './MatchOverlay.jsx';
 
 export default function ProfileSettings({ userId, ageRange, onChangeAgeRange, publicView = false, onLogout = () => {}, viewerId, onBack }) {
@@ -20,6 +21,7 @@ export default function ProfileSettings({ userId, ageRange, onChangeAgeRange, pu
   const photoRef = useRef();
 
   const [showSnapRecorder, setShowSnapRecorder] = useState(false);
+  const [showSnapVideoRecorder, setShowSnapVideoRecorder] = useState(false);
   const [showSub, setShowSub] = useState(false);
   const [distanceRange, setDistanceRange] = useState([10,25]);
   const currentUserId = viewerId || userId;
@@ -149,6 +151,15 @@ export default function ProfileSettings({ userId, ageRange, onChangeAgeRange, pu
     }
     setShowSnapRecorder(false);
     uploadFile(file, "audioClips");
+  };
+
+  const handleVideoRecorded = async file => {
+    if(!(await checkDuration(file))){
+      alert('Video må højest være 10 sekunder');
+      return;
+    }
+    setShowSnapVideoRecorder(false);
+    uploadFile(file, 'videoClips');
   };
 
 
@@ -286,13 +297,21 @@ export default function ProfileSettings({ userId, ageRange, onChangeAgeRange, pu
         onChange: handleVideoChange,
         className: 'hidden'
       }),
-      React.createElement(Button, {
-        className: `mb-4 ${maxVideos ? 'bg-gray-300 text-gray-500 cursor-not-allowed' : 'bg-pink-500 text-white'}`,
-        onClick: () => {
-          if(!maxVideos && videoRef.current) videoRef.current.click();
-        },
-        disabled: maxVideos
-      }, 'Upload video'),
+      React.createElement('div', { className:'flex gap-2 mb-4' },
+        React.createElement(Button, {
+          className: `${maxVideos ? 'bg-gray-300 text-gray-500 cursor-not-allowed' : 'bg-pink-500 text-white'}`,
+          onClick: () => {
+            if(!maxVideos && videoRef.current) videoRef.current.click();
+          },
+          disabled: maxVideos
+        }, 'Upload video'),
+        React.createElement(Button, {
+          className: `${maxVideos ? 'bg-gray-300 text-gray-500 cursor-not-allowed' : 'bg-pink-500 text-white'}`,
+          onClick: () => { if(!maxVideos) setShowSnapVideoRecorder(true); },
+          disabled: maxVideos
+        }, React.createElement(CameraIcon, { className:'w-4 h-4' }))
+      ),
+      showSnapVideoRecorder && React.createElement(SnapVideoRecorder, { onCancel: () => setShowSnapVideoRecorder(false), onRecorded: handleVideoRecorded }),
     )
   );
 

--- a/src/components/SnapVideoRecorder.jsx
+++ b/src/components/SnapVideoRecorder.jsx
@@ -1,0 +1,95 @@
+import React, { useEffect, useRef, useState } from 'react';
+import { Camera as CameraIcon } from 'lucide-react';
+
+export default function SnapVideoRecorder({ onCancel, onRecorded }) {
+  const streamRef = useRef();
+  const recorderRef = useRef();
+  const chunksRef = useRef([]);
+  const timeoutRef = useRef();
+  const videoRef = useRef();
+  const [recording, setRecording] = useState(false);
+  const [progress, setProgress] = useState(0);
+  const startTimeRef = useRef(null);
+
+  useEffect(() => {
+    navigator.mediaDevices.getUserMedia({ video: true, audio: true }).then(stream => {
+      streamRef.current = stream;
+      if(videoRef.current){
+        videoRef.current.srcObject = stream;
+        videoRef.current.play();
+      }
+      start();
+    });
+    return () => {
+      if(streamRef.current){
+        streamRef.current.getTracks().forEach(t => t.stop());
+      }
+    };
+  }, []);
+
+  const start = () => {
+    if(!streamRef.current) return;
+    const recorder = new MediaRecorder(streamRef.current);
+    recorderRef.current = recorder;
+    chunksRef.current = [];
+    recorder.ondataavailable = e => chunksRef.current.push(e.data);
+    recorder.onstop = () => {
+      const blob = new Blob(chunksRef.current, { type: recorder.mimeType });
+      const file = new File([blob], `video-${Date.now()}.webm`, { type: blob.type });
+      onRecorded && onRecorded(file);
+    };
+    recorder.start();
+    setRecording(true);
+    startTimeRef.current = Date.now();
+    const tick = () => {
+      const elapsed = Date.now() - startTimeRef.current;
+      setProgress(Math.min(elapsed / 10000, 1));
+      if(elapsed >= 10000){
+        stop();
+      } else {
+        timeoutRef.current = requestAnimationFrame(tick);
+      }
+    };
+    timeoutRef.current = requestAnimationFrame(tick);
+  };
+
+  const stop = () => {
+    if(recorderRef.current){
+      recorderRef.current.stop();
+      cancelAnimationFrame(timeoutRef.current);
+      timeoutRef.current = null;
+      setRecording(false);
+    }
+  };
+
+  const cancel = () => {
+    stop();
+    onCancel && onCancel();
+  };
+
+  const radius = 45;
+  const circumference = 2 * Math.PI * radius;
+  const offset = circumference * (1 - progress);
+  const remainingSeconds = startTimeRef.current
+    ? Math.max(0, 10 - Math.floor((Date.now() - startTimeRef.current) / 1000))
+    : 10;
+
+  return React.createElement('div', { className:'fixed inset-0 z-50 flex items-center justify-center bg-black/60' },
+    React.createElement('div', { className:'relative w-72 h-72' },
+      React.createElement('video', { ref: videoRef, className:'absolute inset-0 w-full h-full object-cover rounded', autoPlay:true, muted:true }),
+      React.createElement('svg', { className:'absolute inset-0 w-full h-full rotate-animation pointer-events-none', viewBox:'0 0 100 100' },
+        React.createElement('circle', { cx:'50', cy:'50', r:radius, stroke:'#9ca3af', strokeWidth:'8', fill:'none' }),
+        React.createElement('circle', {
+          cx:'50', cy:'50', r:radius, stroke:'#ff4895', strokeWidth:'8', fill:'none',
+          strokeDasharray:circumference, strokeDashoffset:offset
+        })
+      ),
+      React.createElement('button', { onClick: recording ? stop : start, className:'absolute inset-0 flex items-center justify-center text-pink-500 bg-white rounded-full border border-pink-500 w-20 h-20 m-auto' },
+        React.createElement(CameraIcon, { className:'w-10 h-10' })
+      ),
+      React.createElement('div', { className:'absolute inset-0 flex items-center justify-center text-white text-4xl font-bold pointer-events-none' }, remainingSeconds),
+      React.createElement('button', { onClick: cancel, className:'absolute -bottom-12 left-1/2 -translate-x-1/2 text-white bg-black/40 px-4 py-1 rounded' }, 'Annuller')
+    )
+  );
+}
+


### PR DESCRIPTION
## Summary
- implement `SnapVideoRecorder` with preview and countdown
- integrate video recorder into profile settings and update docs

## Testing
- `npm run build`
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_68702cbed1a8832da00726c020326166