### PR TITLE
Fix SnapVideoRecorder overlay

### DIFF
--- a/src/components/SnapVideoRecorder.jsx
+++ b/src/components/SnapVideoRecorder.jsx
@@ -76,7 +76,7 @@ export default function SnapVideoRecorder({ onCancel, onRecorded }) {
 
   return React.createElement('div', { className:'fixed inset-0 z-50 flex items-center justify-center bg-black/60' },
     React.createElement('div', { className:'relative w-72 h-72' },
-      React.createElement('video', { ref: videoRef, className:'absolute inset-0 w-full h-full object-cover rounded', autoPlay:true, muted:true }),
+      React.createElement('video', { ref: videoRef, className:'absolute inset-0 w-full h-full object-cover rounded', autoPlay:true, muted:true, playsInline:true }),
       React.createElement('svg', { className:'absolute inset-0 w-full h-full rotate-animation pointer-events-none', viewBox:'0 0 100 100' },
         React.createElement('circle', { cx:'50', cy:'50', r:radius, stroke:'#9ca3af', strokeWidth:'8', fill:'none' }),
         React.createElement('circle', {


### PR DESCRIPTION
## Summary
- ensure the video element stays inline instead of entering fullscreen

## Testing
- `npm install`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_687030706f00832d843b73eee84701da