### PR TITLE
Fix countdown overlap on video recorder

### DIFF
--- a/src/components/SnapVideoRecorder.jsx
+++ b/src/components/SnapVideoRecorder.jsx
@@ -84,7 +84,7 @@ export default function SnapVideoRecorder({ onCancel, onRecorded }) {
             strokeDasharray:circumference, strokeDashoffset:offset
           })
         ),
-        React.createElement('button', { onClick: recording ? stop : start, className:'absolute inset-0 flex items-center justify-center text-pink-500 bg-white rounded-full border border-pink-500 w-20 h-20 m-auto' },
+        React.createElement('button', { onClick: recording ? stop : start, className:'absolute inset-0 flex items-center justify-center text-pink-500 bg-white rounded-full border border-pink-500 w-20 h-20' },
           React.createElement(CameraIcon, { className:'w-10 h-10' })
         ),
         React.createElement('div', { className:'absolute inset-0 flex items-center justify-center text-white text-4xl font-bold pointer-events-none' }, remainingSeconds),


### PR DESCRIPTION
## Summary
- position the camera button at the edge of the progress ring so the countdown text is unobstructed

## Testing
- `npm install`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68703c96b27c832d8511ea9ebbd37a7c