### PR TITLE
Fix video recorder layering

### DIFF
--- a/src/components/SnapVideoRecorder.jsx
+++ b/src/components/SnapVideoRecorder.jsx
@@ -84,7 +84,7 @@ export default function SnapVideoRecorder({ onCancel, onRecorded }) {
             strokeDasharray:circumference, strokeDashoffset:offset
           })
         ),
-        React.createElement('button', { onClick: recording ? stop : start, className:'absolute inset-0 flex items-center justify-center text-pink-500 bg-white rounded-full border border-pink-500 w-20 h-20' },
+        React.createElement('button', { onClick: recording ? stop : start, className:'absolute inset-0 flex items-center justify-center text-pink-500 bg-white rounded-full border border-pink-500 w-20 h-20 z-20' },
           React.createElement(CameraIcon, { className:'w-10 h-10' })
         ),
         React.createElement('div', { className:'absolute inset-0 flex items-center justify-center text-white text-4xl font-bold pointer-events-none' }, remainingSeconds),


### PR DESCRIPTION
## Summary
- keep the camera icon above the progress ring while recording video

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68703e1aa9d4832db3d51052573f76c0