### PR TITLE
Add view public profile option

### DIFF
--- a/src/RealDateApp.jsx
+++ b/src/RealDateApp.jsx
@@ -34,6 +34,16 @@ export default function RealDateApp() {
     setViewProfile(null);
   };
 
+  const openProfileSettings = () => {
+    setTab('profile');
+    setViewProfile(null);
+  };
+
+  const viewOwnPublicProfile = () => {
+    setViewProfile(userId);
+    setTab('discovery');
+  };
+
   // Persist login status between sessions
   useEffect(() => {
     localStorage.setItem('loggedIn', loggedIn ? 'true' : 'false');
@@ -79,11 +89,24 @@ export default function RealDateApp() {
         React.createElement(DailyDiscovery, { userId, onSelectProfile: selectProfile, ageRange, onOpenPremium: ()=>setTab('premium') })
       ),
       viewProfile && (
-        React.createElement(ProfileSettings, { userId: viewProfile, viewerId: userId, ageRange, onChangeAgeRange: setAgeRange, publicView: true, onBack: openDailyClips })
+        React.createElement(ProfileSettings, {
+          userId: viewProfile,
+          viewerId: userId,
+          ageRange,
+          onChangeAgeRange: setAgeRange,
+          publicView: true,
+          onBack: viewProfile === userId ? openProfileSettings : openDailyClips
+        })
       ),
       tab==='chat' && React.createElement(ChatScreen, { userId }),
       tab==='checkin' && React.createElement(DailyCheckIn, { userId }),
-      tab==='profile' && React.createElement(ProfileSettings, { userId, ageRange, onChangeAgeRange: setAgeRange, onLogout: ()=>{setLoggedIn(false); setTab('discovery'); setViewProfile(null);} }),
+      tab==='profile' && React.createElement(ProfileSettings, {
+        userId,
+        ageRange,
+        onChangeAgeRange: setAgeRange,
+        onLogout: ()=>{setLoggedIn(false); setTab('discovery'); setViewProfile(null);},
+        onViewPublicProfile: viewOwnPublicProfile
+      }),
       tab==='premium' && React.createElement(PremiumFeatures, { userId, onBack: ()=>setTab('discovery'), onSelectProfile: selectProfile }),
       tab==='admin' && React.createElement(AdminScreen, null),
       tab==='about' && React.createElement(AboutScreen, { onOpenAdmin: ()=>setTab('admin') })

--- a/src/components/ProfileSettings.jsx
+++ b/src/components/ProfileSettings.jsx
@@ -15,7 +15,7 @@ import SnapVideoRecorder from "./SnapVideoRecorder.jsx";
 import MatchOverlay from './MatchOverlay.jsx';
 import { languages, useT } from '../i18n.js';
 
-export default function ProfileSettings({ userId, ageRange, onChangeAgeRange, publicView = false, onLogout = () => {}, viewerId, onBack }) {
+export default function ProfileSettings({ userId, ageRange, onChangeAgeRange, publicView = false, onLogout = () => {}, onViewPublicProfile = () => {}, viewerId, onBack }) {
   const [profile,setProfile]=useState(null);
   const t = useT();
   const videoRef = useRef();
@@ -361,10 +361,18 @@ export default function ProfileSettings({ userId, ageRange, onChangeAgeRange, pu
 
   return React.createElement(React.Fragment, null,
     React.createElement(Card, { className: 'p-6 m-4 shadow-xl bg-white/90' },
-      !publicView && React.createElement('button', {
-        className: 'mb-4 bg-gray-200 text-gray-700 px-4 py-2 rounded',
-        onClick: onLogout
-      }, 'Logout'),
+      !publicView && React.createElement('div', {
+        className: 'mb-4 flex justify-end gap-2'
+      },
+        React.createElement(Button, {
+          className: 'bg-gray-200 text-gray-700 px-4 py-2 rounded',
+          onClick: onViewPublicProfile
+        }, 'View public profile'),
+        React.createElement('button', {
+          className: 'bg-gray-200 text-gray-700 px-4 py-2 rounded',
+          onClick: onLogout
+        }, 'Logout')
+      ),
       publicView && onBack && React.createElement(Button, { className: 'mb-4 bg-pink-500 text-white', onClick: onBack }, 'Tilbage'),
       React.createElement('div', { className:'flex items-center mb-4 gap-4' },
         profile.photoURL ?


### PR DESCRIPTION
## Summary
- add controls to preview the public profile from settings
- route back to settings when previewing own profile

## Testing
- `npm install`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_6870a88a3878832d951842f0e9fa0904