### PR TITLE
Adjust chat input layout

### DIFF
--- a/src/components/ChatScreen.jsx
+++ b/src/components/ChatScreen.jsx
@@ -100,20 +100,22 @@ export default function ChatScreen({ userId }) {
             }, m.text)
           ))
         ),
-        React.createElement('div', { className: 'flex items-center gap-2 mt-2' },
-          React.createElement(Textarea, {
-            className: 'flex-1',
-            placeholder: 'Skriv besked...',
-            rows: 8,
-            value: text,
-            onChange: e => setText(e.target.value)
-          }),
-          React.createElement(Button, {
-            className: 'bg-pink-500 text-white',
-            disabled: !text.trim(),
-            onClick: sendMessage
-          },
-            React.createElement(ChatIcon, null)
+        React.createElement('div', { className: 'flex flex-col gap-2 mt-2' },
+          React.createElement('div', { className: 'flex items-center gap-2' },
+            React.createElement(Textarea, {
+              className: 'flex-1',
+              placeholder: 'Skriv besked...',
+              rows: 3,
+              value: text,
+              onChange: e => setText(e.target.value)
+            }),
+            React.createElement(Button, {
+              className: 'bg-pink-500 text-white',
+              disabled: !text.trim(),
+              onClick: sendMessage
+            },
+              React.createElement(ChatIcon, null)
+            )
           ),
           React.createElement(Button, {
             className: 'btn-outline-red',


### PR DESCRIPTION
## Summary
- shorten chat textarea to 3 rows
- place Unmatch button on its own line at the bottom

## Testing
- `npx -y parcel build public/index.html --dist-dir dist --public-url ./` *(fails: @parcel/transformer-webmanifest not installed)*

------
https://chatgpt.com/codex/tasks/task_e_6870c79f8598832da48df7a8a43ecfa0