### PR TITLE
Add confirmation before unmatching

### DIFF
--- a/src/components/ChatScreen.jsx
+++ b/src/components/ChatScreen.jsx
@@ -69,6 +69,7 @@ export default function ChatScreen({ userId }) {
 
   const unmatch = async () => {
     if(!active) return;
+    if(!window.confirm('Er du sikker?')) return;
     const id1 = `${active.userId}-${active.profileId}`;
     const id2 = `${active.profileId}-${active.userId}`;
     await Promise.all([

--- a/src/components/DailyDiscovery.jsx
+++ b/src/components/DailyDiscovery.jsx
@@ -45,6 +45,7 @@ export default function DailyDiscovery({ userId, onSelectProfile, ageRange, onOp
     const exists = likes.some(l => l.profileId === profileId);
     const ref = doc(db,'likes',likeId);
     if(exists){
+      if(!window.confirm('Er du sikker?')) return;
       await deleteDoc(ref);
       // remove any existing match when unliking
       await Promise.all([

--- a/src/components/ProfileSettings.jsx
+++ b/src/components/ProfileSettings.jsx
@@ -200,6 +200,7 @@ export default function ProfileSettings({ userId, ageRange, onChangeAgeRange, pu
     const exists = likes.some(l => l.profileId === userId);
     const ref = doc(db,'likes',likeId);
     if(exists){
+      if(!window.confirm('Er du sikker?')) return;
       await deleteDoc(ref);
       await Promise.all([
         deleteDoc(doc(db,'matches',`${currentUserId}-${userId}`)),


### PR DESCRIPTION
## Summary
- show a confirmation dialog when unmatching
  - ChatScreen unmatch button
  - DailyDiscovery like toggle when unliking
  - ProfileSettings like toggle when unliking

## Testing
- `npm install`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_6870d014e01c832dbc6330e2ef793ab9