### PR TITLE
Update chat bubbles with timestamp

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ and simple profile management powered by Firebase.
 * Option to buy 3 extra clips for the day
 * Monthly subscriptions with visible expiration date
 * Basic chat between matched profiles with option to unmatch
+* Improved chat layout with timestamps for better readability
 * Celebration overlay when two profiles match
 * Calendar for daily reflections
 * Minimal profile settings and admin mode

--- a/src/components/ChatScreen.jsx
+++ b/src/components/ChatScreen.jsx
@@ -96,7 +96,7 @@ export default function ChatScreen({ userId }) {
         React.createElement('div', { ref: messagesRef, className: 'flex-1 overflow-y-auto bg-gray-100 p-4 rounded space-y-3 flex flex-col' },
           (active.messages || []).map((m,i) => {
             const fromSelf = m.from === userId;
-            const profile = fromSelf ? userProfile : activeProfile;
+            const time = new Date(m.ts).toLocaleTimeString([], { hour:'2-digit', minute:'2-digit' });
             return React.createElement('div', {
               key: i,
               className: `flex items-end ${fromSelf ? 'justify-end' : 'justify-start'}`
@@ -104,7 +104,10 @@ export default function ChatScreen({ userId }) {
               !fromSelf && React.createElement(ChatIcon, { className: 'w-6 h-6 text-pink-500 mr-1' }),
               React.createElement('div', {
                 className: `${fromSelf ? 'bg-pink-100' : 'bg-gray-200'} p-2 rounded-lg max-w-xs`
-              }, m.text),
+              },
+                React.createElement('div', null, m.text),
+                React.createElement('div', { className: `text-xs text-gray-500 ${fromSelf ? 'text-right' : 'text-left'}` }, time)
+              ),
               fromSelf && React.createElement(ChatIcon, { className: 'w-6 h-6 text-pink-500 ml-1' })
             );
           })


### PR DESCRIPTION
## Summary
- show colored chat bubbles again
- omit sender names but keep timestamps under each bubble

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6870ce7dbd28832d8141f69e04169ac5