### PR TITLE
Fix clip alignment in profile settings

### DIFF
--- a/src/components/ProfileSettings.jsx
+++ b/src/components/ProfileSettings.jsx
@@ -293,7 +293,7 @@ export default function ProfileSettings({ userId, ageRange, onChangeAgeRange, pu
       Array.from({ length: 3 }).map((_, i) => {
         const clip = (profile.videoClips || [])[i];
         const url = clip && clip.url ? clip.url : clip;
-        return React.createElement('div', { key: i, className: 'w-[30%] flex flex-col items-center justify-center' },
+        return React.createElement('div', { key: i, className: 'w-[30%] flex flex-col items-center justify-end min-h-[160px]' },
           url
             ? React.createElement(VideoPreview, { src: url })
             : React.createElement(CameraIcon, {


### PR DESCRIPTION
## Summary
- keep profile video clips aligned along the bottom by adding a minimum height and bottom justification

## Testing
- `npm install`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68711ba2f32c832da8d8df056af923b7