### PR TITLE
Add admin stats page

### DIFF
--- a/src/RealDateApp.jsx
+++ b/src/RealDateApp.jsx
@@ -8,6 +8,7 @@ import DailyCheckIn from './components/DailyCheckIn.jsx';
 import ProfileSettings from './components/ProfileSettings.jsx';
 import PremiumFeatures from './components/PremiumFeatures.jsx';
 import AdminScreen from './components/AdminScreen.jsx';
+import StatsScreen from './components/StatsScreen.jsx';
 import AboutScreen from './components/AboutScreen.jsx';
 import { useCollection, requestNotificationPermission } from './firebase.js';
 
@@ -108,7 +109,8 @@ export default function RealDateApp() {
         onViewPublicProfile: viewOwnPublicProfile
       }),
       tab==='premium' && React.createElement(PremiumFeatures, { userId, onBack: ()=>setTab('discovery'), onSelectProfile: selectProfile }),
-      tab==='admin' && React.createElement(AdminScreen, null),
+      tab==='admin' && React.createElement(AdminScreen, { onOpenStats: ()=>setTab('stats') }),
+      tab==='stats' && React.createElement(StatsScreen, { onBack: ()=>setTab('admin') }),
       tab==='about' && React.createElement(AboutScreen, { onOpenAdmin: ()=>setTab('admin') })
     ),
     React.createElement('div', { className: 'p-4 bg-white shadow-inner flex justify-around fixed bottom-0 left-0 right-0' },

--- a/src/components/AdminScreen.jsx
+++ b/src/components/AdminScreen.jsx
@@ -5,7 +5,7 @@ import SectionTitle from './SectionTitle.jsx';
 import seedData from '../seedData.js';
 import { db, collection, getDocs } from '../firebase.js';
 
-export default function AdminScreen() {
+export default function AdminScreen({ onOpenStats }) {
 
   const sendPush = async body => {
     const serverKey = process.env.FCM_SERVER_KEY;
@@ -34,6 +34,8 @@ export default function AdminScreen() {
     React.createElement(Button, { className: 'mt-2 bg-pink-500 text-white px-4 py-2 rounded', onClick: seedData }, 'Reset database'),
     React.createElement('h3', { className: 'text-xl font-semibold mb-2 mt-4 text-pink-600' }, 'Push notifications'),
     React.createElement(Button, { className: 'mt-2 bg-pink-500 text-white px-4 py-2 rounded mr-2', onClick: () => sendPush('Dagens klip er klar') }, 'Dagens klip er klar'),
-    React.createElement(Button, { className: 'mt-2 bg-pink-500 text-white px-4 py-2 rounded', onClick: () => sendPush('Du har et match. Start samtalen') }, 'Du har et match. Start samtalen')
+    React.createElement(Button, { className: 'mt-2 bg-pink-500 text-white px-4 py-2 rounded', onClick: () => sendPush('Du har et match. Start samtalen') }, 'Du har et match. Start samtalen'),
+    React.createElement('h3', { className: 'text-xl font-semibold mb-2 mt-4 text-pink-600' }, 'Statistik'),
+    React.createElement(Button, { className: 'mt-2 bg-pink-500 text-white px-4 py-2 rounded', onClick: onOpenStats }, 'Vis statistik')
   );
 }

--- a/src/components/StatsScreen.jsx
+++ b/src/components/StatsScreen.jsx
@@ -1,0 +1,41 @@
+import React, { useState, useEffect } from 'react';
+import { Card } from './ui/card.js';
+import { Button } from './ui/button.js';
+import SectionTitle from './SectionTitle.jsx';
+import { db, collection, getDocs } from '../firebase.js';
+
+export default function StatsScreen({ onBack }) {
+  const [stats, setStats] = useState(null);
+
+  useEffect(() => {
+    const loadStats = async () => {
+      const [profilesSnap, likesSnap, matchesSnap, reflectionsSnap] = await Promise.all([
+        getDocs(collection(db, 'profiles')),
+        getDocs(collection(db, 'likes')),
+        getDocs(collection(db, 'matches')),
+        getDocs(collection(db, 'reflections'))
+      ]);
+
+      const messageCount = matchesSnap.docs.reduce((acc, d) => acc + ((d.data().messages || []).length), 0);
+      setStats({
+        profiles: profilesSnap.size,
+        likes: likesSnap.size,
+        matches: matchesSnap.size / 2,
+        messages: messageCount,
+        reflections: reflectionsSnap.size
+      });
+    };
+    loadStats();
+  }, []);
+
+  return React.createElement(Card, { className: 'p-6 m-4 shadow-xl bg-white/90' },
+    React.createElement(SectionTitle, { title: 'Statistik', action: React.createElement(Button, { onClick: onBack }, 'Tilbage') }),
+    stats ? React.createElement('ul', { className: 'space-y-2 mt-4' },
+      React.createElement('li', null, `Profiler: ${stats.profiles}`),
+      React.createElement('li', null, `Likes: ${stats.likes}`),
+      React.createElement('li', null, `Matches: ${stats.matches}`),
+      React.createElement('li', null, `Beskeder: ${stats.messages}`),
+      React.createElement('li', null, `Refleksioner: ${stats.reflections}`)
+    ) : React.createElement('p', null, 'Indlæser...')
+  );
+}


### PR DESCRIPTION
## Summary
- show a new stats page in admin
- count profiles, likes, matches, messages and reflections
- add navigation from admin screen to stats

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_6871268c026c832d9c7470e51480191f