### PR TITLE
Show open/closed bug stats

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "realdate",
-  "version": "1.0.3",
+  "version": "1.0.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "realdate",
-      "version": "1.0.3",
+      "version": "1.0.4",
       "dependencies": {
         "firebase": "^9.23.0",
         "lucide-react": "^0.322.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "realdate",
-  "version": "1.0.4",
+  "version": "1.0.6",
   "description": "A minimal React PWA for swiping short videos and speed dating.",
   "scripts": {
     "start": "npx serve .",

--- a/src/components/BugReportOverlay.jsx
+++ b/src/components/BugReportOverlay.jsx
@@ -21,7 +21,8 @@ export default function BugReportOverlay({ onClose }) {
       id,
       text,
       screenshotURL,
-      createdAt: new Date().toISOString()
+      createdAt: new Date().toISOString(),
+      closed: false
     });
     onClose();
     alert('Tak for din fejlmelding');

--- a/src/components/BugReportsScreen.jsx
+++ b/src/components/BugReportsScreen.jsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useState } from 'react';
 import { Card } from './ui/card.js';
 import { Button } from './ui/button.js';
 import SectionTitle from './SectionTitle.jsx';
@@ -6,6 +6,11 @@ import { useCollection, db, doc, updateDoc } from '../firebase.js';
 
 export default function BugReportsScreen({ onBack }) {
   const bugReports = useCollection('bugReports');
+  const [showClosed, setShowClosed] = useState(false);
+
+  const filtered = bugReports
+    .filter(r => showClosed ? r.closed : !r.closed)
+    .sort((a,b)=> new Date(b.createdAt) - new Date(a.createdAt));
 
   const closeReport = async id => {
     await updateDoc(doc(db, 'bugReports', id), { closed: true });
@@ -13,9 +18,10 @@ export default function BugReportsScreen({ onBack }) {
 
   return React.createElement(Card, { className: 'p-6 m-4 shadow-xl bg-white/90' },
     React.createElement(SectionTitle, { title: 'Fejlmeldinger', action: React.createElement(Button, { onClick: onBack }, 'Tilbage') }),
-    bugReports.length ?
+    React.createElement(Button, { className: 'mb-2', onClick: () => setShowClosed(!showClosed) }, showClosed ? 'Vis \u00E5bne' : 'Vis lukkede'),
+    filtered.length ?
       React.createElement('ul', { className: 'space-y-4 mt-4 overflow-y-auto max-h-[70vh]' },
-        bugReports.map(r =>
+        filtered.map(r =>
           React.createElement('li', { key: r.id, className: 'border p-2 rounded' },
             r.screenshotURL && React.createElement('img', { src: r.screenshotURL, className: 'mb-2 max-h-40 object-contain w-full' }),
             React.createElement('p', { className: 'text-sm mb-2' }, r.text),
@@ -23,6 +29,6 @@ export default function BugReportsScreen({ onBack }) {
           )
         )
       ) :
-      React.createElement('p', { className: 'text-center mt-4 text-gray-500' }, 'Ingen fejlmeldinger')
+      React.createElement('p', { className: 'text-center mt-4 text-gray-500' }, showClosed ? 'Ingen lukkede fejl' : 'Ingen fejlmeldinger')
   );
 }

--- a/src/components/StatsScreen.jsx
+++ b/src/components/StatsScreen.jsx
@@ -9,20 +9,25 @@ export default function StatsScreen({ onBack }) {
 
   useEffect(() => {
     const loadStats = async () => {
-      const [profilesSnap, likesSnap, matchesSnap, reflectionsSnap] = await Promise.all([
+      const [profilesSnap, likesSnap, matchesSnap, reflectionsSnap, bugSnap] = await Promise.all([
         getDocs(collection(db, 'profiles')),
         getDocs(collection(db, 'likes')),
         getDocs(collection(db, 'matches')),
-        getDocs(collection(db, 'reflections'))
+        getDocs(collection(db, 'reflections')),
+        getDocs(collection(db, 'bugReports'))
       ]);
 
       const messageCount = matchesSnap.docs.reduce((acc, d) => acc + ((d.data().messages || []).length), 0);
+      const openBugs = bugSnap.docs.filter(d => !d.data().closed).length;
+      const closedBugs = bugSnap.size - openBugs;
       setStats({
         profiles: profilesSnap.size,
         likes: likesSnap.size,
         matches: matchesSnap.size / 2,
         messages: messageCount,
-        reflections: reflectionsSnap.size
+        reflections: reflectionsSnap.size,
+        bugOpen: openBugs,
+        bugClosed: closedBugs
       });
     };
     loadStats();
@@ -35,7 +40,9 @@ export default function StatsScreen({ onBack }) {
       React.createElement('li', null, `Likes: ${stats.likes}`),
       React.createElement('li', null, `Matches: ${stats.matches}`),
       React.createElement('li', null, `Beskeder: ${stats.messages}`),
-      React.createElement('li', null, `Refleksioner: ${stats.reflections}`)
+      React.createElement('li', null, `Refleksioner: ${stats.reflections}`),
+      React.createElement('li', null, `\u00C5bne fejl: ${stats.bugOpen}`),
+      React.createElement('li', null, `Lukkede fejl: ${stats.bugClosed}`)
     ) : React.createElement('p', null, 'Indlæser...')
   );
 }

--- a/src/version.js
+++ b/src/version.js
@@ -1,1 +1,1 @@
-export default '1.0.4';
+export default '1.0.6';


### PR DESCRIPTION
## Summary
- add `closed` field when submitting new bug reports
- filter bug list by open/closed with toggle
- show number of open and closed bugs in admin statistics
- bump version

## Testing
- `npm install`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_687141b31f20832d983ac1a4fc6f17a1