### PR TITLE
Add daily stats with graphs

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ and simple profile management powered by Firebase.
 * Video- og lydklip begrænset til 10 sekunder
   (optagelser lidt over 10s accepteres for at håndtere kodningsforsinkelser)
 * Animation med nedtælling viser hvor lang tid der er tilbage under lyd- og videooptagelse
+* Daglige statistikker gemmes automatisk og vises som grafer i adminområdet
 
 
 ## Getting Started

--- a/src/components/StatsChart.jsx
+++ b/src/components/StatsChart.jsx
@@ -1,0 +1,35 @@
+import React from 'react';
+
+export default function StatsChart({ data = [], fields = [], title }) {
+  if (!Array.isArray(fields)) fields = [fields];
+  if (!data.length || !fields.length) return null;
+  const colors = ['#ec4899', '#3b82f6', '#10b981'];
+  const max = Math.max(...data.flatMap(d => fields.map(f => d[f] || 0)), 1);
+  const step = 40;
+  const width = Math.max((data.length - 1) * step, 1) + 20;
+  const height = 100;
+  const polylines = fields.map((field, idx) => {
+    const points = data.map((d, i) => `${i * step},${height - (d[field] || 0) / max * height}`).join(' ');
+    return React.createElement('polyline', {
+      key: field,
+      fill: 'none',
+      stroke: colors[idx % colors.length],
+      strokeWidth: 2,
+      points
+    });
+  });
+  const labels = data.map((d, i) => React.createElement('text', {
+    key: d.date,
+    x: i * step,
+    y: height + 12,
+    textAnchor: 'middle',
+    fontSize: 10
+  }, d.date.slice(5)));
+  return React.createElement('div', { className: 'mb-4' },
+    React.createElement('h3', { className: 'font-semibold mb-1' }, title),
+    React.createElement('svg', { width, height: height + 20 },
+      polylines,
+      labels
+    )
+  );
+}

--- a/src/components/StatsScreen.jsx
+++ b/src/components/StatsScreen.jsx
@@ -2,10 +2,12 @@ import React, { useState, useEffect } from 'react';
 import { Card } from './ui/card.js';
 import { Button } from './ui/button.js';
 import SectionTitle from './SectionTitle.jsx';
-import { db, collection, getDocs } from '../firebase.js';
+import { db, collection, getDocs, setDoc, doc } from '../firebase.js';
+import StatsChart from './StatsChart.jsx';
 
 export default function StatsScreen({ onBack }) {
   const [stats, setStats] = useState(null);
+  const [history, setHistory] = useState([]);
 
   useEffect(() => {
     const loadStats = async () => {
@@ -20,29 +22,45 @@ export default function StatsScreen({ onBack }) {
       const messageCount = matchesSnap.docs.reduce((acc, d) => acc + ((d.data().messages || []).length), 0);
       const openBugs = bugSnap.docs.filter(d => !d.data().closed).length;
       const closedBugs = bugSnap.size - openBugs;
-      setStats({
+      const videoCount = profilesSnap.docs.reduce((acc, d) => acc + ((d.data().videoClips || []).length), 0);
+      const audioCount = profilesSnap.docs.reduce((acc, d) => acc + ((d.data().audioClips || []).length), 0);
+      const data = {
         profiles: profilesSnap.size,
         likes: likesSnap.size,
         matches: matchesSnap.size / 2,
         messages: messageCount,
         reflections: reflectionsSnap.size,
         bugOpen: openBugs,
-        bugClosed: closedBugs
-      });
+        bugClosed: closedBugs,
+        videos: videoCount,
+        audios: audioCount
+      };
+      setStats(data);
+
+      const today = new Date().toISOString().split('T')[0];
+      await setDoc(doc(db, 'dailyStats', today), { date: today, ...data }, { merge: true });
+      const histSnap = await getDocs(collection(db, 'dailyStats'));
+      const hist = histSnap.docs.map(d => d.data()).sort((a, b) => a.date.localeCompare(b.date));
+      setHistory(hist);
     };
     loadStats();
   }, []);
 
   return React.createElement(Card, { className: 'p-6 m-4 shadow-xl bg-white/90' },
     React.createElement(SectionTitle, { title: 'Statistik', action: React.createElement(Button, { onClick: onBack }, 'Tilbage') }),
-    stats ? React.createElement('ul', { className: 'space-y-2 mt-4' },
-      React.createElement('li', null, `Profiler: ${stats.profiles}`),
-      React.createElement('li', null, `Likes: ${stats.likes}`),
-      React.createElement('li', null, `Matches: ${stats.matches}`),
-      React.createElement('li', null, `Beskeder: ${stats.messages}`),
-      React.createElement('li', null, `Refleksioner: ${stats.reflections}`),
-      React.createElement('li', null, `\u00C5bne fejl: ${stats.bugOpen}`),
-      React.createElement('li', null, `Lukkede fejl: ${stats.bugClosed}`)
+    stats ? React.createElement(React.Fragment, null,
+      React.createElement('ul', { className: 'space-y-2 mt-4' },
+        React.createElement('li', null, `Profiler: ${stats.profiles}`),
+        React.createElement('li', null, `Likes: ${stats.likes}`),
+        React.createElement('li', null, `Matches: ${stats.matches}`),
+        React.createElement('li', null, `Beskeder: ${stats.messages}`),
+        React.createElement('li', null, `Refleksioner: ${stats.reflections}`),
+        React.createElement('li', null, `\u00C5bne fejl: ${stats.bugOpen}`),
+        React.createElement('li', null, `Lukkede fejl: ${stats.bugClosed}`)
+      ),
+      React.createElement(StatsChart, { data: history, fields: 'profiles', title: 'Profiler over tid' }),
+      React.createElement(StatsChart, { data: history, fields: 'likes', title: 'Likes over tid' }),
+      React.createElement(StatsChart, { data: history, fields: ['videos','audios'], title: 'Uploads over tid' })
     ) : React.createElement('p', null, 'Indlæser...')
   );
 }


### PR DESCRIPTION
## Summary
- save daily statistics in Firestore
- render simple charts for user, likes and uploads history
- document stats feature in README

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68717b933298832da4bfee42013379e3