### PR TITLE
Add profile view stats

### DIFF
--- a/FEATURES.txt
+++ b/FEATURES.txt
@@ -11,6 +11,8 @@ Animated countdown shown while recording audio or video
 Offline support via service worker caching
 PWA manifest for standalone installation
 
+Profile view statistics
+
 Profile pictures cached for offline viewing
 
 Admin mode

--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ and simple profile management powered by Firebase.
   (optagelser lidt over 10s accepteres for at håndtere kodningsforsinkelser)
 * Animation med nedtælling viser hvor lang tid der er tilbage under lyd- og videooptagelse
 * Daglige statistikker gemmes automatisk og vises som grafer i adminområdet
+* Statistik over hvor mange gange profiler bliver åbnet
 
 
 ## Getting Started

--- a/src/RealDateApp.jsx
+++ b/src/RealDateApp.jsx
@@ -11,7 +11,7 @@ import AdminScreen from './components/AdminScreen.jsx';
 import StatsScreen from './components/StatsScreen.jsx';
 import BugReportsScreen from './components/BugReportsScreen.jsx';
 import AboutScreen from './components/AboutScreen.jsx';
-import { useCollection, requestNotificationPermission } from './firebase.js';
+import { useCollection, requestNotificationPermission, db, doc, updateDoc, increment } from './firebase.js';
 
 
 export default function RealDateApp() {
@@ -78,7 +78,15 @@ export default function RealDateApp() {
   if(!loggedIn) return React.createElement(LanguageProvider, { value:{lang,setLang} },
     React.createElement(WelcomeScreen, { profiles, onLogin: id=>{ setUserId(id); setLoggedIn(true); } })
   );
-  const selectProfile=id=>{setViewProfile(id); setTab('discovery');};
+  const selectProfile = async id => {
+    setViewProfile(id);
+    setTab('discovery');
+    try {
+      await updateDoc(doc(db, 'profiles', id), { viewCount: increment(1) });
+    } catch(err) {
+      console.error('Failed to record profile view', err);
+    }
+  };
 
 
 

--- a/src/components/StatsScreen.jsx
+++ b/src/components/StatsScreen.jsx
@@ -24,6 +24,7 @@ export default function StatsScreen({ onBack }) {
       const closedBugs = bugSnap.size - openBugs;
       const videoCount = profilesSnap.docs.reduce((acc, d) => acc + ((d.data().videoClips || []).length), 0);
       const audioCount = profilesSnap.docs.reduce((acc, d) => acc + ((d.data().audioClips || []).length), 0);
+      const viewCount = profilesSnap.docs.reduce((acc, d) => acc + (d.data().viewCount || 0), 0);
       const data = {
         profiles: profilesSnap.size,
         likes: likesSnap.size,
@@ -33,7 +34,8 @@ export default function StatsScreen({ onBack }) {
         bugOpen: openBugs,
         bugClosed: closedBugs,
         videos: videoCount,
-        audios: audioCount
+        audios: audioCount,
+        views: viewCount
       };
       setStats(data);
 
@@ -56,11 +58,13 @@ export default function StatsScreen({ onBack }) {
         React.createElement('li', null, `Beskeder: ${stats.messages}`),
         React.createElement('li', null, `Refleksioner: ${stats.reflections}`),
         React.createElement('li', null, `\u00C5bne fejl: ${stats.bugOpen}`),
-        React.createElement('li', null, `Lukkede fejl: ${stats.bugClosed}`)
+        React.createElement('li', null, `Lukkede fejl: ${stats.bugClosed}`),
+        React.createElement('li', null, `Profilvisninger: ${stats.views}`)
       ),
       React.createElement(StatsChart, { data: history, fields: 'profiles', title: 'Profiler over tid' }),
       React.createElement(StatsChart, { data: history, fields: 'likes', title: 'Likes over tid' }),
-      React.createElement(StatsChart, { data: history, fields: ['videos','audios'], title: 'Uploads over tid' })
+      React.createElement(StatsChart, { data: history, fields: ['videos','audios'], title: 'Uploads over tid' }),
+      React.createElement(StatsChart, { data: history, fields: 'views', title: 'Profilvisninger over tid' })
     ) : React.createElement('p', null, 'Indlæser...')
   );
 }

--- a/src/firebase.js
+++ b/src/firebase.js
@@ -12,7 +12,8 @@ import {
   getDoc,
   updateDoc,
   setDoc,
-  arrayUnion
+  arrayUnion,
+  increment
 } from 'firebase/firestore';
 import {
   getStorage,
@@ -87,6 +88,7 @@ export {
   updateDoc,
   setDoc,
   arrayUnion,
+  increment,
   ref,
   uploadBytes,
   getDownloadURL,


### PR DESCRIPTION
## Summary
- track profile views in Firestore
- expose view stats in the admin stats screen
- display profile view statistic bullet points

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_68717d5d1dc4832d9e5e78e50feab030