### PR TITLE
Add address-level2 autocomplete to city input

### DIFF
--- a/src/components/ProfileSettings.jsx
+++ b/src/components/ProfileSettings.jsx
@@ -411,7 +411,9 @@ export default function ProfileSettings({ userId, ageRange, onChangeAgeRange, pu
             value: profile.city || '',
             onChange: handleCityChange,
             className:'border p-2 rounded w-full',
-            placeholder:'By'
+            placeholder:'By',
+            name:'city',
+            autoComplete:'address-level2'
           }),
           React.createElement(Button, {
             className:'bg-pink-500 text-white w-full',

--- a/src/components/WelcomeScreen.jsx
+++ b/src/components/WelcomeScreen.jsx
@@ -60,7 +60,7 @@ export default function WelcomeScreen({ profiles = [], onLogin }) {
           onChange: e => setCity(e.target.value),
           placeholder: 'By',
           name: 'city',
-          autoComplete: 'off'
+          autoComplete: 'address-level2'
         }),
         React.createElement('datalist', { id: 'city-list' },
           ['København','Aarhus','Odense','Aalborg','Esbjerg','Randers'].map(c =>


### PR DESCRIPTION
## Summary
- allow browser to autocomplete the city field with `address-level2`

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_687206eb1380832d92390fd99ae2f200