### PR TITLE
Extract profile filtering

### DIFF
--- a/FEATURES.txt
+++ b/FEATURES.txt
@@ -20,3 +20,4 @@ Seed data loader for test profiles with sample clips
 Switch between user profiles 
 Reset database from 
 Show Firestore credentials status
+Reusable profile filtering helper for Cloud Functions

--- a/README.md
+++ b/README.md
@@ -80,3 +80,8 @@ gsutil cors set cors.json gs://<your-storage-bucket>
 
 After this configuration, uploads from your site will succeed without CORS
 errors.
+
+## Development Notes
+
+The profile filtering logic used on the Daily Discovery page lives in `src/selectProfiles.js`. Keeping this code in its own module makes it easy to move the same logic to a Firebase Cloud Function when needed. Cloud Functions for Firebase can run JavaScript or TypeScript, so the helper can be reused on the server with minimal changes.
+

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "realdate",
-  "version": "1.0.4",
+  "version": "1.0.7",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "realdate",
-      "version": "1.0.4",
+      "version": "1.0.7",
       "dependencies": {
         "firebase": "^9.23.0",
         "lucide-react": "^0.322.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "realdate",
-  "version": "1.0.6",
+  "version": "1.0.8",
   "description": "A minimal React PWA for swiping short videos and speed dating.",
   "scripts": {
     "start": "npx serve .",

--- a/src/components/DailyDiscovery.jsx
+++ b/src/components/DailyDiscovery.jsx
@@ -5,6 +5,7 @@ import { Button } from './ui/button.js';
 import SectionTitle from './SectionTitle.jsx';
 import { useT } from '../i18n.js';
 import { useCollection, db, doc, setDoc, deleteDoc, getDoc, updateDoc } from '../firebase.js';
+import selectProfiles from '../selectProfiles.js';
 import PurchaseOverlay from './PurchaseOverlay.jsx';
 import MatchOverlay from './MatchOverlay.jsx';
 import InfoOverlay from './InfoOverlay.jsx';
@@ -13,22 +14,9 @@ export default function DailyDiscovery({ userId, onSelectProfile, ageRange, onOp
   const profiles = useCollection('profiles');
   const t = useT();
   const user = profiles.find(p => p.id === userId) || {};
-  const interest = user.interest;
   const hasSubscription = user.subscriptionExpires && new Date(user.subscriptionExpires) > new Date();
   const today = new Date().toISOString().split('T')[0];
-  const extra = user.extraClipsDate === today ? 3 : 0;
-  const limit = (hasSubscription ? 6 : 3) + extra;
-  const preferred = user.preferredLanguages || [];
-  const allowOther = user.allowOtherLanguages !== false;
-  const filtered = profiles.filter(p => {
-    const matchesLang = preferred.length === 0 || preferred.includes(p.language || 'en');
-    return (
-      p.gender === interest &&
-      p.age >= ageRange[0] &&
-      p.age <= ageRange[1] &&
-      (allowOther || matchesLang)
-    );
-  }).slice(0, limit);
+  const filtered = selectProfiles(user, profiles, ageRange);
   const likes = useCollection('likes','userId',userId);
 
   const [hoursUntil, setHoursUntil] = useState(0);

--- a/src/selectProfiles.js
+++ b/src/selectProfiles.js
@@ -1,0 +1,20 @@
+// Filtering helper kept separate so it can also run in a Firebase
+// Cloud Function. Cloud Functions support both JavaScript and TypeScript.
+export default function selectProfiles(user, profiles, ageRange){
+  const interest = user.interest;
+  const hasSubscription = user.subscriptionExpires && new Date(user.subscriptionExpires) > new Date();
+  const today = new Date().toISOString().split('T')[0];
+  const extra = user.extraClipsDate === today ? 3 : 0;
+  const limit = (hasSubscription ? 6 : 3) + extra;
+  const preferred = user.preferredLanguages || [];
+  const allowOther = user.allowOtherLanguages !== false;
+  return profiles.filter(p => {
+    const matchesLang = preferred.length === 0 || preferred.includes(p.language || 'en');
+    return (
+      p.gender === interest &&
+      p.age >= ageRange[0] &&
+      p.age <= ageRange[1] &&
+      (allowOther || matchesLang)
+    );
+  }).slice(0, limit);
+}

--- a/src/version.js
+++ b/src/version.js
@@ -1,1 +1,1 @@
-export default '1.0.6';
+export default '1.0.8';


### PR DESCRIPTION
## Summary
- move profile selection logic into `selectProfiles`
- use helper in `DailyDiscovery`
- keep filtering helper separate for future Firebase Cloud Function
- document helper purpose in README

## Testing
- `npm install`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_687205f3a960832d80cb6b8ba98a9da7