### PR TITLE
Add birthday field and compute age

### DIFF
--- a/src/components/ChatScreen.jsx
+++ b/src/components/ChatScreen.jsx
@@ -1,4 +1,5 @@
 import React, { useState, useEffect, useRef } from 'react';
+import { getAge } from '../utils.js';
 import { User as UserIcon, Smile, MessageCircle as ChatIcon, ArrowLeft } from 'lucide-react';
 import { Card } from './ui/card.js';
 import { Button } from './ui/button.js';
@@ -93,7 +94,7 @@ export default function ChatScreen({ userId }) {
         activeProfile.photoURL ?
           React.createElement('img', { src: activeProfile.photoURL, className: 'w-24 h-24 rounded-full object-cover self-center mb-2' }) :
           React.createElement(UserIcon, { className: 'w-24 h-24 text-pink-500 self-center mb-2' }),
-        React.createElement('p', { className: 'text-center font-medium mb-2' }, `${activeProfile.name || ''}, ${activeProfile.age || ''}, ${activeProfile.city || ''}`),
+        React.createElement('p', { className: 'text-center font-medium mb-2' }, `${activeProfile.name || ''}, ${activeProfile.birthday ? getAge(activeProfile.birthday) : activeProfile.age || ''}, ${activeProfile.city || ''}`),
         React.createElement('div', { ref: messagesRef, className: 'flex-1 overflow-y-auto bg-gray-100 p-4 rounded space-y-3 flex flex-col' },
           (active.messages || []).map((m,i) => {
             const fromSelf = m.from === userId;
@@ -147,7 +148,7 @@ export default function ChatScreen({ userId }) {
               p.photoURL ?
                 React.createElement('img', { src: p.photoURL, className: 'w-10 h-10 rounded object-cover' }) :
                 React.createElement(UserIcon, { className: 'w-10 h-10 text-pink-500' }),
-              React.createElement('span', null, `${p.name || ''}, ${p.age || ''}, ${p.city || ''}`)
+              React.createElement('span', null, `${p.name || ''}, ${p.birthday ? getAge(p.birthday) : p.age || ''}, ${p.city || ''}`)
             );
           })
         ) :

--- a/src/components/DailyDiscovery.jsx
+++ b/src/components/DailyDiscovery.jsx
@@ -1,4 +1,5 @@
 import React, { useState, useEffect } from 'react';
+import { getAge } from '../utils.js';
 import { User, PlayCircle, Heart, Star } from 'lucide-react';
 import { Card } from './ui/card.js';
 import { Button } from './ui/button.js';
@@ -107,7 +108,7 @@ export default function DailyDiscovery({ userId, onSelectProfile, ageRange, onOp
               React.createElement(User, { className: 'w-10 h-10 text-pink-500' })
             ),
             React.createElement('div', null,
-              React.createElement('p', { className: 'font-medium' }, `${p.name} (${p.age})`),
+              React.createElement('p', { className: 'font-medium' }, `${p.name} (${p.birthday ? getAge(p.birthday) : p.age})`),
               p.clip && React.createElement('p', { className: 'text-sm text-gray-500' }, `“${p.clip}”`)
             )
           ),

--- a/src/components/PremiumFeatures.jsx
+++ b/src/components/PremiumFeatures.jsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import { getAge } from '../utils.js';
 import { Card } from './ui/card.js';
 import { Button } from './ui/button.js';
 import SectionTitle from './SectionTitle.jsx';
@@ -24,7 +25,7 @@ export default function PremiumFeatures({ userId, onBack, onSelectProfile }) {
           p.photoURL ?
             React.createElement('img', { src: p.photoURL, className: 'w-10 h-10 rounded object-cover' }) :
             React.createElement(UserIcon, { className: 'w-10 h-10 text-pink-500' }),
-          React.createElement('span', null, `${p.name} (${p.age})`)
+          React.createElement('span', null, `${p.name} (${p.birthday ? getAge(p.birthday) : p.age})`)
         )
       )) :
         React.createElement('li', { className: 'text-gray-500 text-center' }, 'Ingen har liket dig endnu')

--- a/src/components/ProfileSettings.jsx
+++ b/src/components/ProfileSettings.jsx
@@ -14,6 +14,7 @@ import SnapAudioRecorder from "./SnapAudioRecorder.jsx";
 import SnapVideoRecorder from "./SnapVideoRecorder.jsx";
 import MatchOverlay from './MatchOverlay.jsx';
 import { languages, useT } from '../i18n.js';
+import { getAge } from '../utils.js';
 
 export default function ProfileSettings({ userId, ageRange, onChangeAgeRange, publicView = false, onLogout = () => {}, onViewPublicProfile = () => {}, viewerId, onBack }) {
   const [profile,setProfile]=useState(null);
@@ -165,10 +166,11 @@ export default function ProfileSettings({ userId, ageRange, onChangeAgeRange, pu
     await updateDoc(doc(db,'profiles',userId), { name });
   };
 
-  const handleAgeChange = async e => {
-    const age = parseInt(e.target.value, 10) || '';
-    setProfile({ ...profile, age });
-    await updateDoc(doc(db,'profiles',userId), { age });
+  const handleBirthdayChange = async e => {
+    const birthday = e.target.value;
+    setProfile({ ...profile, birthday });
+    const age = birthday ? getAge(birthday) : '';
+    await updateDoc(doc(db,'profiles',userId), { birthday, age });
   };
 
 
@@ -401,11 +403,11 @@ export default function ProfileSettings({ userId, ageRange, onChangeAgeRange, pu
           autoComplete:'given-name'
         }),
           React.createElement(Input, {
-            type:'number',
-            value: profile.age || '',
-            onChange: handleAgeChange,
+            type:'date',
+            value: profile.birthday || '',
+            onChange: handleBirthdayChange,
             className:'border p-2 rounded w-full',
-            placeholder:'Alder'
+            placeholder:'F\u00f8dselsdag'
           }),
           React.createElement(Input, {
             value: profile.city || '',
@@ -421,7 +423,7 @@ export default function ProfileSettings({ userId, ageRange, onChangeAgeRange, pu
           }, 'Færdig')
         ) :
         React.createElement('div', { className:'flex items-center justify-between w-full' },
-          React.createElement(SectionTitle, { title: `${profile.name}, ${profile.age}${profile.city ? ', ' + profile.city : ''}` }),
+          React.createElement(SectionTitle, { title: `${profile.name}, ${profile.birthday ? getAge(profile.birthday) : profile.age}${profile.city ? ', ' + profile.city : ''}` }),
           !publicView && React.createElement(EditIcon, { className:'w-5 h-5 text-gray-500 cursor-pointer', onClick: () => setEditInfo(true) })
         ),
       !publicView && profile.subscriptionExpires && React.createElement('p', {

--- a/src/components/WelcomeScreen.jsx
+++ b/src/components/WelcomeScreen.jsx
@@ -4,6 +4,7 @@ import { Button } from './ui/button.js';
 import { Input } from './ui/input.js';
 import { languages, useLang, useT } from '../i18n.js';
 import { db, doc, setDoc } from '../firebase.js';
+import { getAge } from '../utils.js';
 
 export default function WelcomeScreen({ profiles = [], onLogin }) {
   const [selected, setSelected] = useState(profiles[0]?.id || '');
@@ -11,6 +12,7 @@ export default function WelcomeScreen({ profiles = [], onLogin }) {
   const [name, setName] = useState('');
   const [city, setCity] = useState('');
   const [gender, setGender] = useState('Kvinde');
+  const [birthday, setBirthday] = useState('');
   const { lang, setLang } = useLang();
   const t = useT();
 
@@ -30,7 +32,8 @@ export default function WelcomeScreen({ profiles = [], onLogin }) {
       city: city.trim(),
       gender,
       interest: gender === 'Kvinde' ? 'Mand' : 'Kvinde',
-      age: 18,
+      birthday,
+      age: birthday ? getAge(birthday) : 18,
       language: lang,
       preferredLanguages: [lang],
       allowOtherLanguages: true,
@@ -61,6 +64,13 @@ export default function WelcomeScreen({ profiles = [], onLogin }) {
           placeholder: 'By',
           name: 'cityname',
           autoComplete: 'address-level2'
+        }),
+        React.createElement(Input, {
+          type: 'date',
+          className: 'border p-2 mb-2 w-full',
+          value: birthday,
+          onChange: e => setBirthday(e.target.value),
+          placeholder: 'F\u00f8dselsdag'
         }),
         React.createElement('datalist', { id: 'city-list' },
           ['København','Aarhus','Odense','Aalborg','Esbjerg','Randers'].map(c =>

--- a/src/selectProfiles.js
+++ b/src/selectProfiles.js
@@ -1,5 +1,7 @@
 // Filtering helper kept separate so it can also run in a Firebase
 // Cloud Function. Cloud Functions support both JavaScript and TypeScript.
+import { getAge } from './utils.js';
+
 export default function selectProfiles(user, profiles, ageRange){
   const interest = user.interest;
   const hasSubscription = user.subscriptionExpires && new Date(user.subscriptionExpires) > new Date();
@@ -12,8 +14,8 @@ export default function selectProfiles(user, profiles, ageRange){
     const matchesLang = preferred.length === 0 || preferred.includes(p.language || 'en');
     return (
       p.gender === interest &&
-      p.age >= ageRange[0] &&
-      p.age <= ageRange[1] &&
+      (p.birthday ? getAge(p.birthday) : p.age) >= ageRange[0] &&
+      (p.birthday ? getAge(p.birthday) : p.age) <= ageRange[1] &&
       (allowOther || matchesLang)
     );
   }).slice(0, limit);

--- a/src/utils.js
+++ b/src/utils.js
@@ -1,0 +1,11 @@
+export function getAge(birthday){
+  if(!birthday) return '';
+  const birth = new Date(birthday);
+  const today = new Date();
+  let age = today.getFullYear() - birth.getFullYear();
+  const m = today.getMonth() - birth.getMonth();
+  if(m < 0 || (m === 0 && today.getDate() < birth.getDate())){
+    age--;
+  }
+  return age;
+}


### PR DESCRIPTION
## Summary
- add small age helper
- allow birthday when registering
- update profile forms and views to use birthday
- compute age filter by birthday

## Testing
- `npm test` *(fails: Missing script)*
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68721019e5fc832d8785ce1df657862c