### PR TITLE
Enforce video upload before browsing

### DIFF
--- a/FEATURES.txt
+++ b/FEATURES.txt
@@ -5,6 +5,7 @@ Calendar interface for daily reflection notes
 Profile settings with age range filtering
 Preferred languages with "allow other languages" option
 Ability to upload or record video clips
+Must upload at least one video before seeing candidate profiles
 Ability to upload or record audio clips
 Video/audio duration limited to 10 seconds
 Animated countdown shown while recording audio or video

--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ and simple profile management powered by Firebase.
 * Minimal profile settings and admin mode
 * Preferred languages with option to allow other languages
 * Profile pictures cached for offline viewing
+* Users must upload at least one video before viewing candidate profiles
 * Premium page showing who liked you (subscription required)
 * Seed data includes 11 mandlige profiler der matcher standardbrugeren så du kan teste premium og ekstra klip
 * Video- og lydklip begrænset til 10 sekunder

--- a/src/RealDateApp.jsx
+++ b/src/RealDateApp.jsx
@@ -96,7 +96,7 @@ export default function RealDateApp() {
     React.createElement('div', { className: 'flex-1' },
 
       tab==='discovery' && !viewProfile && (
-        React.createElement(DailyDiscovery, { userId, onSelectProfile: selectProfile, ageRange, onOpenPremium: ()=>setTab('premium') })
+        React.createElement(DailyDiscovery, { userId, onSelectProfile: selectProfile, ageRange, onOpenPremium: ()=>setTab('premium'), onOpenProfile: openProfileSettings })
       ),
       viewProfile && (
         React.createElement(ProfileSettings, {

--- a/src/components/DailyDiscovery.jsx
+++ b/src/components/DailyDiscovery.jsx
@@ -11,13 +11,20 @@ import PurchaseOverlay from './PurchaseOverlay.jsx';
 import MatchOverlay from './MatchOverlay.jsx';
 import InfoOverlay from './InfoOverlay.jsx';
 
-export default function DailyDiscovery({ userId, onSelectProfile, ageRange, onOpenPremium }) {
+export default function DailyDiscovery({ userId, onSelectProfile, ageRange, onOpenPremium, onOpenProfile }) {
   const profiles = useCollection('profiles');
   const t = useT();
   const user = profiles.find(p => p.id === userId) || {};
   const hasSubscription = user.subscriptionExpires && new Date(user.subscriptionExpires) > new Date();
   const today = new Date().toISOString().split('T')[0];
   const filtered = selectProfiles(user, profiles, ageRange);
+
+  if(!(user.videoClips && user.videoClips.length)){
+    return React.createElement(Card, { className:'p-6 m-4 shadow-xl bg-white/90' },
+      React.createElement('p', { className:'mb-4 text-center' }, t('uploadVideoPrompt')),
+      React.createElement(Button, { className:'w-full bg-pink-500 text-white', onClick:onOpenProfile }, t('uploadVideoButton'))
+    );
+  }
   const likes = useCollection('likes','userId',userId);
 
   const [hoursUntil, setHoursUntil] = useState(0);

--- a/src/i18n.js
+++ b/src/i18n.js
@@ -34,7 +34,9 @@ const messages = {
   firstName:{ en:'First name', da:'Fornavn', sv:'Förnamn', es:'Nombre', fr:'Prénom', de:'Vorname' },
   city:{ en:'City', da:'By', sv:'Stad', es:'Ciudad', fr:'Ville', de:'Stadt' },
   birthday:{ en:'Birthday', da:'Fødselsdag', sv:'Födelsedag', es:'Cumpleaños', fr:'Anniversaire', de:'Geburtstag' },
-  gender:{ en:'Gender', da:'Køn', sv:'Kön', es:'Género', fr:'Genre', de:'Geschlecht' }
+  gender:{ en:'Gender', da:'Køn', sv:'Kön', es:'Género', fr:'Genre', de:'Geschlecht' },
+  uploadVideoPrompt:{ en:'Please upload at least one video before browsing profiles', da:'Upload mindst et videoklip før du kan se profiler', sv:'Ladda upp minst ett videoklipp innan du kan se profiler', es:'Sube al menos un video antes de ver perfiles', fr:'Téléversez au moins une vidéo avant de voir les profils', de:'Lade zuerst mindestens ein Video hoch, bevor du Profile ansehen kannst' },
+  uploadVideoButton:{ en:'Upload video', da:'Upload video', sv:'Ladda upp video', es:'Subir video', fr:'Téléverser une vidéo', de:'Video hochladen' }
 };
 
 const LangContext = createContext({ lang: 'en', setLang: () => {} });


### PR DESCRIPTION
## Summary
- inform users they must upload at least one video before seeing candidates
- support opening profile settings from discovery when no video is present
- add Danish/English/etc. translations for the new message
- document the new requirement in README and FEATURES

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68721ca48480832d99ec0132c4372427