### PR TITLE
Add birthday calendar hint

### DIFF
--- a/src/components/ProfileSettings.jsx
+++ b/src/components/ProfileSettings.jsx
@@ -27,6 +27,7 @@ export default function ProfileSettings({ userId, ageRange, onChangeAgeRange, pu
   const [showSub, setShowSub] = useState(false);
   const [distanceRange, setDistanceRange] = useState([10,25]);
   const [editInfo, setEditInfo] = useState(false);
+  const [showBirthdayOverlay, setShowBirthdayOverlay] = useState(false);
   const currentUserId = viewerId || userId;
   const isOwnProfile = viewerId === userId;
   const likes = useCollection('likes','userId', currentUserId);
@@ -402,13 +403,19 @@ export default function ProfileSettings({ userId, ageRange, onChangeAgeRange, pu
           name:'given-name',
           autoComplete:'given-name'
         }),
-          React.createElement(Input, {
-            type:'date',
-            value: profile.birthday || '',
-            onChange: handleBirthdayChange,
-            className:'border p-2 rounded w-full',
-            placeholder:'F\u00f8dselsdag'
-          }),
+          React.createElement('label', { className:'sr-only' }, 'birthday'),
+          React.createElement('div', null,
+            showBirthdayOverlay && React.createElement('div', { className:'fixed top-0 left-0 right-0 bg-black/70 text-white text-center py-2 z-50' }, t('selectBirthday')),
+            React.createElement(Input, {
+              type:'date',
+              value: profile.birthday || '',
+              onChange: handleBirthdayChange,
+              onFocus: () => setShowBirthdayOverlay(true),
+              onBlur: () => setShowBirthdayOverlay(false),
+              className:'border p-2 rounded w-full',
+              placeholder:'F\u00f8dselsdag'
+            })
+          ),
           React.createElement(Input, {
             value: profile.city || '',
             onChange: handleCityChange,

--- a/src/components/WelcomeScreen.jsx
+++ b/src/components/WelcomeScreen.jsx
@@ -13,6 +13,7 @@ export default function WelcomeScreen({ profiles = [], onLogin }) {
   const [city, setCity] = useState('');
   const [gender, setGender] = useState('Kvinde');
   const [birthday, setBirthday] = useState('');
+  const [birthdayFocus, setBirthdayFocus] = useState(false);
   const { lang, setLang } = useLang();
   const t = useT();
 
@@ -68,11 +69,14 @@ export default function WelcomeScreen({ profiles = [], onLogin }) {
           autoComplete: 'address-level2'
         }),
         React.createElement('label', { className:'block mb-1' }, t('birthday')),
+        birthdayFocus && React.createElement('div', { className:'fixed top-0 left-0 right-0 bg-black/70 text-white text-center py-2 z-50' }, t('selectBirthday')),
         React.createElement(Input, {
           type: 'date',
           className: 'border p-2 mb-2 w-full',
           value: birthday,
           onChange: e => setBirthday(e.target.value),
+          onFocus: () => setBirthdayFocus(true),
+          onBlur: () => setBirthdayFocus(false),
           placeholder: 'F\u00f8dselsdag'
         }),
         React.createElement('datalist', { id: 'city-list' },

--- a/src/i18n.js
+++ b/src/i18n.js
@@ -34,6 +34,7 @@ const messages = {
   firstName:{ en:'First name', da:'Fornavn', sv:'Förnamn', es:'Nombre', fr:'Prénom', de:'Vorname' },
   city:{ en:'City', da:'By', sv:'Stad', es:'Ciudad', fr:'Ville', de:'Stadt' },
   birthday:{ en:'Birthday', da:'Fødselsdag', sv:'Födelsedag', es:'Cumpleaños', fr:'Anniversaire', de:'Geburtstag' },
+  selectBirthday:{ en:'Select your birthday', da:'Vælg din fødselsdag', sv:'Välj din födelsedag', es:'Selecciona tu cumpleaños', fr:"Sélectionnez votre anniversaire", de:'Wähle deinen Geburtstag' },
   gender:{ en:'Gender', da:'Køn', sv:'Kön', es:'Género', fr:'Genre', de:'Geschlecht' }
 };
 


### PR DESCRIPTION
## Summary
- highlight selecting birthday when date picker is opened
- add `selectBirthday` translation message

## Testing
- `npm run build`
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_68721d4efbd4832da032b7b015347f38