### PR TITLE
Add birthday overlay hint

### DIFF
--- a/src/components/WelcomeScreen.jsx
+++ b/src/components/WelcomeScreen.jsx
@@ -13,6 +13,7 @@ export default function WelcomeScreen({ profiles = [], onLogin }) {
   const [city, setCity] = useState('');
   const [gender, setGender] = useState('Kvinde');
   const [birthday, setBirthday] = useState('');
+  const [showBirthdayOverlay, setShowBirthdayOverlay] = useState(false);
   const { lang, setLang } = useLang();
   const t = useT();
 
@@ -44,8 +45,14 @@ export default function WelcomeScreen({ profiles = [], onLogin }) {
     await setDoc(doc(db, 'profiles', id), profile);
     onLogin(id);
   };
-  return React.createElement(Card, { className: 'p-6 m-4 shadow-xl bg-white/90' },
-    showRegister ? (
+  return React.createElement(
+    React.Fragment,
+    null,
+    showBirthdayOverlay && React.createElement('div', {
+      className: 'fixed top-0 left-0 right-0 bg-black/70 text-white text-center p-2 z-50'
+    }, t('chooseBirthday')),
+    React.createElement(Card, { className: 'p-6 m-4 shadow-xl bg-white/90' },
+      showRegister ? (
       React.createElement(React.Fragment, null,
         React.createElement('h1', { className: 'text-3xl font-bold mb-4 text-pink-600 text-center' }, t('register')),
         React.createElement('label', { className:'block mb-1' }, t('firstName')),
@@ -72,7 +79,9 @@ export default function WelcomeScreen({ profiles = [], onLogin }) {
           type: 'date',
           className: 'border p-2 mb-2 w-full',
           value: birthday,
-          onChange: e => setBirthday(e.target.value),
+          onFocus: () => setShowBirthdayOverlay(true),
+          onBlur: () => setShowBirthdayOverlay(false),
+          onChange: e => { setBirthday(e.target.value); setShowBirthdayOverlay(false); },
           placeholder: 'F\u00f8dselsdag'
         }),
         React.createElement('datalist', { id: 'city-list' },
@@ -138,5 +147,5 @@ export default function WelcomeScreen({ profiles = [], onLogin }) {
         }, t('register'))
       )
     )
-  );
+  ));
 }

--- a/src/i18n.js
+++ b/src/i18n.js
@@ -34,6 +34,7 @@ const messages = {
   firstName:{ en:'First name', da:'Fornavn', sv:'Förnamn', es:'Nombre', fr:'Prénom', de:'Vorname' },
   city:{ en:'City', da:'By', sv:'Stad', es:'Ciudad', fr:'Ville', de:'Stadt' },
   birthday:{ en:'Birthday', da:'Fødselsdag', sv:'Födelsedag', es:'Cumpleaños', fr:'Anniversaire', de:'Geburtstag' },
+  chooseBirthday:{ en:'Select your birthday', da:'Vælg din fødselsdag', sv:'Välj din födelsedag', es:'Selecciona tu cumpleaños', fr:'Sélectionnez votre anniversaire', de:'Wähle deinen Geburtstag' },
   gender:{ en:'Gender', da:'Køn', sv:'Kön', es:'Género', fr:'Genre', de:'Geschlecht' },
   uploadVideoPrompt:{ en:'Please upload at least one video before browsing profiles', da:'Upload mindst et videoklip før du kan se profiler', sv:'Ladda upp minst ett videoklipp innan du kan se profiler', es:'Sube al menos un video antes de ver perfiles', fr:'Téléversez au moins une vidéo avant de voir les profils', de:'Lade zuerst mindestens ein Video hoch, bevor du Profile ansehen kannst' },
   uploadVideoButton:{ en:'Upload video', da:'Upload video', sv:'Ladda upp video', es:'Subir video', fr:'Téléverser une vidéo', de:'Video hochladen' }


### PR DESCRIPTION
## Summary
- show overlay on date input to prompt birthday
- add `chooseBirthday` translations

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68721e4fa5cc832d89c339bc18531453