### PR TITLE
Show About screen on startup

### DIFF
--- a/src/RealDateApp.jsx
+++ b/src/RealDateApp.jsx
@@ -27,7 +27,7 @@ export default function RealDateApp() {
   const profiles = useCollection('profiles');
   const chats = useCollection('matches', 'userId', userId);
   const [ageRange,setAgeRange]=useState([35,55]);
-  const [tab,setTab]=useState('discovery');
+  const [tab,setTab]=useState('about');
   const [viewProfile,setViewProfile]=useState(null);
   const hasUnread = chats.some(c => c.unreadByUser || c.newMatch);
 


### PR DESCRIPTION
## Summary
- default to the About screen when a user is logged in

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68722b69cfe4832da5062eb8d58731fb