### PR TITLE
Add call to action prompts on login screen

### DIFF
--- a/src/components/WelcomeScreen.jsx
+++ b/src/components/WelcomeScreen.jsx
@@ -2,6 +2,8 @@ import React, { useState, useEffect } from 'react';
 import { Card } from './ui/card.js';
 import { Button } from './ui/button.js';
 import { Input } from './ui/input.js';
+import CallToAction from './CallToAction.jsx';
+import { UserPlus, LogIn } from 'lucide-react';
 import { languages, useLang, useT } from '../i18n.js';
 import { db, doc, setDoc } from '../firebase.js';
 import { getAge } from '../utils.js';
@@ -135,16 +137,20 @@ export default function WelcomeScreen({ profiles = [], onLogin }) {
           React.createElement('option', { value: '' }, `-- ${t('selectUser')} --`),
           profiles.map(p => React.createElement('option', { key: p.id, value: p.id }, p.name))
         ),
-        React.createElement(Button, {
-          onClick: () => selected && onLogin(selected),
-          className: 'bg-pink-500 hover:bg-pink-600 text-white mt-4',
-          disabled: !selected
-        }, t('login')),
-        React.createElement(Button, {
-          className: 'mt-2 w-full',
-          variant: 'outline',
+        React.createElement(CallToAction, {
+          icon: React.createElement(LogIn, { className: 'w-12 h-12 text-pink-600' }),
+          title: t('loginCtaTitle'),
+          description: t('loginCtaDesc'),
+          buttonText: t('login'),
+          onClick: () => selected && onLogin(selected)
+        }),
+        React.createElement(CallToAction, {
+          icon: React.createElement(UserPlus, { className: 'w-12 h-12 text-pink-600' }),
+          title: t('registerCtaTitle'),
+          description: t('registerCtaDesc'),
+          buttonText: t('register'),
           onClick: () => { setShowRegister(true); setName(''); setCity(''); }
-        }, t('register'))
+        })
       )
     )
   ));

--- a/src/i18n.js
+++ b/src/i18n.js
@@ -37,7 +37,11 @@ const messages = {
   chooseBirthday:{ en:'Select your birthday', da:'Vælg din fødselsdag', sv:'Välj din födelsedag', es:'Selecciona tu cumpleaños', fr:'Sélectionnez votre anniversaire', de:'Wähle deinen Geburtstag' },
   gender:{ en:'Gender', da:'Køn', sv:'Kön', es:'Género', fr:'Genre', de:'Geschlecht' },
   uploadVideoPrompt:{ en:'Please upload at least one video before browsing profiles', da:'Upload mindst et videoklip før du kan se profiler', sv:'Ladda upp minst ett videoklipp innan du kan se profiler', es:'Sube al menos un video antes de ver perfiles', fr:'Téléversez au moins une vidéo avant de voir les profils', de:'Lade zuerst mindestens ein Video hoch, bevor du Profile ansehen kannst' },
-  uploadVideoButton:{ en:'Upload video', da:'Upload video', sv:'Ladda upp video', es:'Subir video', fr:'Téléverser une vidéo', de:'Video hochladen' }
+  uploadVideoButton:{ en:'Upload video', da:'Upload video', sv:'Ladda upp video', es:'Subir video', fr:'Téléverser une vidéo', de:'Video hochladen' },
+  loginCtaTitle:{ en:"Already have a profile?", da:"Har du en profil?", sv:"Har du en profil?", es:"¿Ya tienes perfil?", fr:"Vous avez dj un profil ?", de:"Hast du ein Profil?" },
+  loginCtaDesc:{ en:"Log in to continue", da:"Log ind for at fortstte", sv:"Logga in fr att fortstta", es:"Inicia sesión para continuar", fr:"Connectez-vous pour continuer", de:"Melde dich an, um fortzufahren" },
+  registerCtaTitle:{ en:"New here?", da:"Ny her?", sv:"Ny här?", es:"¿Nuevo aquí?", fr:"Nouveau ici ?", de:"Neu hier?" },
+  registerCtaDesc:{ en:"Create a profile to get started", da:"Opret en profil for at komme i gang", sv:"Skapa en profil för att komma igång", es:"Crea un perfil para comenzar", fr:"Créez un profil pour commencer", de:"Erstelle ein Profil, um zu starten" }
 };
 
 const LangContext = createContext({ lang: 'en', setLang: () => {} });


### PR DESCRIPTION
## Summary
- import new CallToAction component and icons
- add login/signup call to action cards on `WelcomeScreen`
- provide translation strings for the new cards

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68722b3be9d4832daca13899b7887e9a