### PR TITLE
Adjust CTA design

### DIFF
--- a/src/components/CallToAction.jsx
+++ b/src/components/CallToAction.jsx
@@ -1,17 +1,13 @@
 import React from 'react';
 import { Card } from './ui/card.js';
-import { Button } from './ui/button.js';
 
 export default function CallToAction({ icon, title, description, buttonText, onClick }) {
   return React.createElement(Card, {
-    className: 'p-6 m-4 shadow-lg bg-gradient-to-br from-white via-pink-50 to-white rounded-lg flex flex-col items-center text-center'
+    onClick, className: 'p-6 m-4 shadow-lg bg-gradient-to-br from-white via-pink-50 to-white rounded-lg flex flex-col items-center text-center cursor-pointer'
   },
-    React.createElement('div', { className: 'text-6xl mb-4' }, icon),
+    React.createElement('div', { className: 'text-4xl mb-4' }, icon),
     React.createElement('h2', { className: 'text-2xl font-bold mb-2 text-pink-600' }, title),
     React.createElement('p', { className: 'mb-4 text-gray-700' }, description),
-    React.createElement(Button, {
-      onClick,
-      className: 'bg-pink-500 hover:bg-pink-600 text-white px-4 py-2 rounded w-full max-w-xs'
-    }, buttonText)
+    buttonText && React.createElement("div", { className: "mt-2 text-pink-600 font-semibold" }, buttonText)
   );
 }

--- a/src/components/WelcomeScreen.jsx
+++ b/src/components/WelcomeScreen.jsx
@@ -138,14 +138,14 @@ export default function WelcomeScreen({ profiles = [], onLogin }) {
           profiles.map(p => React.createElement('option', { key: p.id, value: p.id }, p.name))
         ),
         React.createElement(CallToAction, {
-          icon: React.createElement(LogIn, { className: 'w-12 h-12 text-pink-600' }),
+          icon: React.createElement(LogIn, { className: 'w-8 h-8 text-pink-600' }),
           title: t('loginCtaTitle'),
           description: t('loginCtaDesc'),
           buttonText: t('login'),
           onClick: () => selected && onLogin(selected)
         }),
         React.createElement(CallToAction, {
-          icon: React.createElement(UserPlus, { className: 'w-12 h-12 text-pink-600' }),
+          icon: React.createElement(UserPlus, { className: 'w-8 h-8 text-pink-600' }),
           title: t('registerCtaTitle'),
           description: t('registerCtaDesc'),
           buttonText: t('register'),


### PR DESCRIPTION
## Summary
- simplify CallToAction component
- shrink login/register icons

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68722f732c60832d8cc66b178b618f97