### PR TITLE
Move language/profile selection to admin

### DIFF
--- a/src/RealDateApp.jsx
+++ b/src/RealDateApp.jsx
@@ -76,7 +76,7 @@ export default function RealDateApp() {
 
 
   if(!loggedIn) return React.createElement(LanguageProvider, { value:{lang,setLang} },
-    React.createElement(WelcomeScreen, { profiles, onLogin: id=>{ setUserId(id); setLoggedIn(true); } })
+    React.createElement(WelcomeScreen, { onLogin: () => setLoggedIn(true) })
   );
   const selectProfile = async id => {
     setViewProfile(id);
@@ -118,7 +118,7 @@ export default function RealDateApp() {
         onViewPublicProfile: viewOwnPublicProfile
       }),
       tab==='premium' && React.createElement(PremiumFeatures, { userId, onBack: ()=>setTab('discovery'), onSelectProfile: selectProfile }),
-      tab==='admin' && React.createElement(AdminScreen, { onOpenStats: ()=>setTab('stats'), onOpenBugReports: ()=>setTab('bugs') }),
+      tab==='admin' && React.createElement(AdminScreen, { onOpenStats: ()=>setTab('stats'), onOpenBugReports: ()=>setTab('bugs'), profiles, userId, onSwitchProfile: id=>setUserId(id) }),
       tab==='stats' && React.createElement(StatsScreen, { onBack: ()=>setTab('admin') }),
       tab==='bugs' && React.createElement(BugReportsScreen, { onBack: ()=>setTab('admin') }),
       tab==='about' && React.createElement(AboutScreen, { onOpenAdmin: ()=>setTab('admin') })

--- a/src/components/AdminScreen.jsx
+++ b/src/components/AdminScreen.jsx
@@ -1,11 +1,15 @@
 import React from 'react';
+import { languages, useLang, useT } from '../i18n.js';
 import { Card } from './ui/card.js';
 import { Button } from './ui/button.js';
 import SectionTitle from './SectionTitle.jsx';
 import seedData from '../seedData.js';
 import { db, collection, getDocs } from '../firebase.js';
 
-export default function AdminScreen({ onOpenStats, onOpenBugReports }) {
+export default function AdminScreen({ onOpenStats, onOpenBugReports, profiles = [], userId, onSwitchProfile }) {
+
+  const { lang, setLang } = useLang();
+  const t = useT();
 
   const sendPush = async body => {
     const serverKey = process.env.FCM_SERVER_KEY;
@@ -30,6 +34,24 @@ export default function AdminScreen({ onOpenStats, onOpenBugReports }) {
 
   return React.createElement(Card, { className: 'p-6 m-4 shadow-xl bg-white/90' },
     React.createElement(SectionTitle, { title: 'Administration' }),
+    React.createElement('label', { className: 'block mb-1' }, t('chooseLanguage')),
+    React.createElement('select', {
+      className: 'border p-2 mb-4 w-full',
+      value: lang,
+      onChange: e => setLang(e.target.value)
+    },
+      Object.entries(languages).map(([code, name]) =>
+        React.createElement('option', { key: code, value: code }, name)
+      )
+    ),
+    React.createElement('label', { className: 'block mb-1' }, t('selectUser')),
+    React.createElement('select', {
+      className: 'border p-2 mb-4 w-full',
+      value: userId || '',
+      onChange: e => onSwitchProfile(e.target.value)
+    },
+      profiles.map(p => React.createElement('option', { key: p.id, value: p.id }, p.name))
+    ),
     React.createElement('h3', { className: 'text-xl font-semibold mb-2 text-pink-600' }, 'Reset database'),
     React.createElement(Button, { className: 'mt-2 bg-pink-500 text-white px-4 py-2 rounded', onClick: () => seedData().then(() => alert('Databasen er nulstillet')) }, 'Reset database'),
     React.createElement('h3', { className: 'text-xl font-semibold mb-2 mt-4 text-pink-600' }, 'Push notifications'),

--- a/src/components/WelcomeScreen.jsx
+++ b/src/components/WelcomeScreen.jsx
@@ -1,29 +1,22 @@
-import React, { useState, useEffect } from 'react';
+import React, { useState } from 'react';
 import { Card } from './ui/card.js';
 import { Button } from './ui/button.js';
 import { Input } from './ui/input.js';
 import CallToAction from './CallToAction.jsx';
 import { UserPlus, LogIn } from 'lucide-react';
-import { languages, useLang, useT } from '../i18n.js';
+import { useLang, useT } from '../i18n.js';
 import { db, doc, setDoc } from '../firebase.js';
 import { getAge } from '../utils.js';
 
-export default function WelcomeScreen({ profiles = [], onLogin }) {
-  const [selected, setSelected] = useState(profiles[0]?.id || '');
+export default function WelcomeScreen({ onLogin }) {
   const [showRegister, setShowRegister] = useState(false);
   const [name, setName] = useState('');
   const [city, setCity] = useState('');
   const [gender, setGender] = useState('Kvinde');
   const [birthday, setBirthday] = useState('');
   const [showBirthdayOverlay, setShowBirthdayOverlay] = useState(false);
-  const { lang, setLang } = useLang();
+  const { lang } = useLang();
   const t = useT();
-
-  useEffect(() => {
-    if (!selected && profiles.length) {
-      setSelected(profiles[0].id);
-    }
-  }, [profiles, selected]);
 
   const register = async () => {
     const trimmed = name.trim();
@@ -119,30 +112,13 @@ export default function WelcomeScreen({ profiles = [], onLogin }) {
           'Her handler det ikke om hurtige swipes.' +
           'RealDate er for dig, der søger noget ægte og meningsfuldt.'
         ),
-        React.createElement('label', { className:'block mb-1' }, t('chooseLanguage')),
-        React.createElement('select', {
-          className: 'border p-2 mb-4 w-full',
-          onChange: e => setLang(e.target.value),
-          value: lang
-        },
-          Object.entries(languages).map(([code,name]) =>
-            React.createElement('option', { key: code, value: code }, name)
-          )
-        ),
-        React.createElement('select', {
-          className: 'border p-2 mb-4 w-full',
-          onChange: e => setSelected(e.target.value),
-          value: selected || ''
-        },
-          React.createElement('option', { value: '' }, `-- ${t('selectUser')} --`),
-          profiles.map(p => React.createElement('option', { key: p.id, value: p.id }, p.name))
-        ),
+        
         React.createElement(CallToAction, {
           icon: React.createElement(LogIn, { className: 'w-12 h-12 text-pink-600' }),
           title: t('loginCtaTitle'),
           description: t('loginCtaDesc'),
           buttonText: t('login'),
-          onClick: () => selected && onLogin(selected)
+          onClick: () => onLogin()
         }),
         React.createElement(CallToAction, {
           icon: React.createElement(UserPlus, { className: 'w-12 h-12 text-pink-600' }),


### PR DESCRIPTION
## Summary
- remove language and profile dropdowns from `WelcomeScreen`
- add language and profile selection to `AdminScreen`
- update app to handle login without selecting a profile and pass data to admin screen

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68722fb242f8832dae8c03f405c31195