### PR TITLE
Remove video upload requirement for profiles

### DIFF
--- a/FEATURES.txt
+++ b/FEATURES.txt
@@ -5,8 +5,6 @@ Calendar interface for daily reflection notes
 Profile settings with age range filtering
 Preferred languages with "allow other languages" option
 Ability to upload or record video clips
-Must upload at least one video before seeing candidate profiles
-Daily Clips page links to your profile until you upload a video
 Ability to upload or record audio clips
 Video/audio duration limited to 10 seconds
 Animated countdown shown while recording audio or video

--- a/README.md
+++ b/README.md
@@ -16,9 +16,6 @@ and simple profile management powered by Firebase.
 * Minimal profile settings and admin mode
 * Preferred languages with option to allow other languages
 * Profile pictures cached for offline viewing
-* Users must upload at least one video before viewing candidate profiles.
-  The "Daily Clips" screen still appears, but it only shows a prompt linking
-  to your profile page until a video has been uploaded.
 * Premium page showing who liked you (subscription required)
 * Seed data includes 11 mandlige profiler der matcher standardbrugeren så du kan teste premium og ekstra klip
 * Video- og lydklip begrænset til 10 sekunder

--- a/src/components/DailyDiscovery.jsx
+++ b/src/components/DailyDiscovery.jsx
@@ -20,12 +20,6 @@ export default function DailyDiscovery({ userId, onSelectProfile, ageRange, onOp
   const today = new Date().toISOString().split('T')[0];
   const filtered = selectProfiles(user, profiles, ageRange);
 
-  if(!(user.videoClips && user.videoClips.length)){
-    return React.createElement(Card, { className:'p-6 m-4 shadow-xl bg-white/90' },
-      React.createElement('p', { className:'mb-4 text-center' }, t('uploadVideoPrompt')),
-      React.createElement(Button, { className:'w-full bg-pink-500 text-white', onClick:onOpenProfile }, t('uploadVideoButton'))
-    );
-  }
   const likes = useCollection('likes','userId',userId);
 
   const [hoursUntil, setHoursUntil] = useState(0);

--- a/src/i18n.js
+++ b/src/i18n.js
@@ -36,8 +36,6 @@ const messages = {
   birthday:{ en:'Birthday', da:'Fødselsdag', sv:'Födelsedag', es:'Cumpleaños', fr:'Anniversaire', de:'Geburtstag' },
   chooseBirthday:{ en:'Select your birthday', da:'Vælg din fødselsdag', sv:'Välj din födelsedag', es:'Selecciona tu cumpleaños', fr:'Sélectionnez votre anniversaire', de:'Wähle deinen Geburtstag' },
   gender:{ en:'Gender', da:'Køn', sv:'Kön', es:'Género', fr:'Genre', de:'Geschlecht' },
-  uploadVideoPrompt:{ en:'Please upload at least one video before browsing profiles', da:'Upload mindst et videoklip før du kan se profiler', sv:'Ladda upp minst ett videoklipp innan du kan se profiler', es:'Sube al menos un video antes de ver perfiles', fr:'Téléversez au moins une vidéo avant de voir les profils', de:'Lade zuerst mindestens ein Video hoch, bevor du Profile ansehen kannst' },
-  uploadVideoButton:{ en:'Upload video', da:'Upload video', sv:'Ladda upp video', es:'Subir video', fr:'Téléverser une vidéo', de:'Video hochladen' },
   loginCtaTitle:{ en:"Already have a profile?", da:"Har du en profil?", sv:"Har du en profil?", es:"¿Ya tienes perfil?", fr:"Vous avez dj un profil ?", de:"Hast du ein Profil?" },
   loginCtaDesc:{ en:"Log in to continue", da:"Log ind for at fortstte", sv:"Logga in fr att fortstta", es:"Inicia sesión para continuar", fr:"Connectez-vous pour continuer", de:"Melde dich an, um fortzufahren" },
   registerCtaTitle:{ en:"New here?", da:"Ny her?", sv:"Ny här?", es:"¿Nuevo aquí?", fr:"Nouveau ici ?", de:"Neu hier?" },


### PR DESCRIPTION
## Summary
- allow discovering profiles without uploading a video
- remove outdated info about required video upload
- clean up unused translation messages

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68723447065c832da1d2cbe74ce4229b