### PR TITLE
Profile CTAs for video and audio

### DIFF
--- a/src/components/CallToAction.jsx
+++ b/src/components/CallToAction.jsx
@@ -1,9 +1,9 @@
 import React from 'react';
 import { Card } from './ui/card.js';
 
-export default function CallToAction({ icon, title, description, buttonText, onClick }) {
+export default function CallToAction({ icon, title, description, buttonText }) {
   return React.createElement(Card, {
-    onClick, className: 'p-6 m-4 shadow-lg bg-gradient-to-br from-white via-pink-50 to-white rounded-lg flex flex-col items-center text-center cursor-pointer'
+    className: 'p-6 m-4 shadow-lg bg-gradient-to-br from-white via-pink-50 to-white rounded-lg flex flex-col items-center text-center'
   },
     React.createElement('div', { className: 'text-4xl mb-4' }, icon),
     React.createElement('h2', { className: 'text-2xl font-bold mb-2 text-pink-600' }, title),

--- a/src/components/ProfileSettings.jsx
+++ b/src/components/ProfileSettings.jsx
@@ -13,6 +13,7 @@ import PurchaseOverlay from './PurchaseOverlay.jsx';
 import SnapAudioRecorder from "./SnapAudioRecorder.jsx";
 import SnapVideoRecorder from "./SnapVideoRecorder.jsx";
 import MatchOverlay from './MatchOverlay.jsx';
+import CallToAction from './CallToAction.jsx';
 import { languages, useT } from '../i18n.js';
 import { getAge } from '../utils.js';
 
@@ -439,7 +440,17 @@ export default function ProfileSettings({ userId, ageRange, onChangeAgeRange, pu
         onClick: onViewPublicProfile
       }, 'View public profile')
     ),
+    React.createElement(CallToAction, {
+      icon: React.createElement(CameraIcon, { className: 'w-8 h-8 text-pink-600' }),
+      title: t('videoCtaTitle'),
+      description: t('videoCtaDesc')
+    }),
     React.createElement(Card, { className: 'p-6 m-4 shadow-xl bg-white/90' }, videoSection),
+    React.createElement(CallToAction, {
+      icon: React.createElement(Mic, { className: 'w-8 h-8 text-pink-600' }),
+      title: t('audioCtaTitle'),
+      description: t('audioCtaDesc')
+    }),
     React.createElement(Card, { className: 'p-6 m-4 shadow-xl bg-white/90' }, audioSection),
     !publicView && React.createElement(Card, { className: 'p-6 m-4 shadow-xl bg-white/90' },
       React.createElement(SectionTitle, { title: t('interestedIn') }),

--- a/src/i18n.js
+++ b/src/i18n.js
@@ -36,10 +36,14 @@ const messages = {
   birthday:{ en:'Birthday', da:'Fødselsdag', sv:'Födelsedag', es:'Cumpleaños', fr:'Anniversaire', de:'Geburtstag' },
   chooseBirthday:{ en:'Select your birthday', da:'Vælg din fødselsdag', sv:'Välj din födelsedag', es:'Selecciona tu cumpleaños', fr:'Sélectionnez votre anniversaire', de:'Wähle deinen Geburtstag' },
   gender:{ en:'Gender', da:'Køn', sv:'Kön', es:'Género', fr:'Genre', de:'Geschlecht' },
-  loginCtaTitle:{ en:"Already have a profile?", da:"Har du en profil?", sv:"Har du en profil?", es:"¿Ya tienes perfil?", fr:"Vous avez dj un profil ?", de:"Hast du ein Profil?" },
-  loginCtaDesc:{ en:"Log in to continue", da:"Log ind for at fortstte", sv:"Logga in fr att fortstta", es:"Inicia sesión para continuar", fr:"Connectez-vous pour continuer", de:"Melde dich an, um fortzufahren" },
+  loginCtaTitle:{ en:"Already have a profile?", da:"Har du en profil?", sv:"Har du en profil?", es:"¿Ya tienes perfil?", fr:"Vous avez déjà un profil ?", de:"Hast du ein Profil?" },
+  loginCtaDesc:{ en:"Log in to continue", da:"Log ind for at fortsætte", sv:"Logga in för att fortsätta", es:"Inicia sesión para continuar", fr:"Connectez-vous pour continuer", de:"Melde dich an, um fortzufahren" },
   registerCtaTitle:{ en:"New here?", da:"Ny her?", sv:"Ny här?", es:"¿Nuevo aquí?", fr:"Nouveau ici ?", de:"Neu hier?" },
-  registerCtaDesc:{ en:"Create a profile to get started", da:"Opret en profil for at komme i gang", sv:"Skapa en profil för att komma igång", es:"Crea un perfil para comenzar", fr:"Créez un profil pour commencer", de:"Erstelle ein Profil, um zu starten" }
+  registerCtaDesc:{ en:"Create a profile to get started", da:"Opret en profil for at komme i gang", sv:"Skapa en profil för att komme igång", es:"Crea un perfil para comenzar", fr:"Créez un profil pour commencer", de:"Erstelle ein Profil, um zu starten" },
+  videoCtaTitle:{ en:'Add video clips', da:'Tilføj videoer', sv:'Lägg till videoklipp', es:'Añadir videoclips', fr:'Ajouter des clips vidéo', de:'Videoclips hinzufügen' },
+  videoCtaDesc:{ en:'Upload short clips to showcase yourself', da:'Upload korte videoklip for at vise dig frem', sv:'Ladda upp korta klipp för att visa dig', es:'Sube clips cortos para mostrarte', fr:'Téléchargez de courts clips pour vous présenter', de:'Lade kurze Clips hoch, um dich zu zeigen' },
+  audioCtaTitle:{ en:'Add audio clips', da:'Tilføj lyde', sv:'Lägg till ljudklipp', es:'Añadir clips de audio', fr:'Ajouter des clips audio', de:'Audioclips hinzufügen' },
+  audioCtaDesc:{ en:'Upload short audio clips to share your voice', da:'Upload korte lydklip for at dele din stemme', sv:'Ladda upp korta lydklipp för att dela din röst', es:'Sube clips de audio para compartir tu voz', fr:'Téléchargez de courts clips audio pour partager votre voix', de:'Lade kurze Audioclips hoch, um deine Stimme zu teilen' }
 };
 
 const LangContext = createContext({ lang: 'en', setLang: () => {} });


### PR DESCRIPTION
## Summary
- remove interactivity from `CallToAction` card
- translate new CTA text strings
- import and render CTAs on profile page above video and audio sections

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_687246f123b0832d975acac8d523fe01