### PR TITLE
Add login/register buttons on welcome screen

### DIFF
--- a/src/components/CallToAction.jsx
+++ b/src/components/CallToAction.jsx
@@ -1,13 +1,12 @@
 import React from 'react';
 import { Card } from './ui/card.js';
 
-export default function CallToAction({ icon, title, description, buttonText }) {
+export default function CallToAction({ icon, title, description }) {
   return React.createElement(Card, {
     className: 'p-6 m-4 shadow-lg bg-gradient-to-br from-white via-pink-50 to-white rounded-lg flex flex-col items-center text-center'
   },
     React.createElement('div', { className: 'text-4xl mb-4' }, icon),
     React.createElement('h2', { className: 'text-2xl font-bold mb-2 text-pink-600' }, title),
-    React.createElement('p', { className: 'mb-4 text-gray-700' }, description),
-    buttonText && React.createElement("div", { className: "mt-2 text-pink-600 font-semibold" }, buttonText)
+    React.createElement('p', { className: 'mb-4 text-gray-700' }, description)
   );
 }

--- a/src/components/WelcomeScreen.jsx
+++ b/src/components/WelcomeScreen.jsx
@@ -116,17 +116,21 @@ export default function WelcomeScreen({ onLogin }) {
         React.createElement(CallToAction, {
           icon: React.createElement(LogIn, { className: 'w-8 h-8 text-pink-600' }),
           title: t('loginCtaTitle'),
-          description: t('loginCtaDesc'),
-          buttonText: t('login'),
-          onClick: () => onLogin()
+          description: t('loginCtaDesc')
         }),
+        React.createElement(Button, {
+          className: 'bg-pink-500 text-white mb-4',
+          onClick: () => onLogin()
+        }, t('login')),
         React.createElement(CallToAction, {
           icon: React.createElement(UserPlus, { className: 'w-8 h-8 text-pink-600' }),
           title: t('registerCtaTitle'),
-          description: t('registerCtaDesc'),
-          buttonText: t('register'),
+          description: t('registerCtaDesc')
+        }),
+        React.createElement(Button, {
+          className: 'bg-pink-500 text-white',
           onClick: () => { setShowRegister(true); setName(''); setCity(''); }
-        })
+        }, t('register'))
       )
     )
   ));


### PR DESCRIPTION
## Summary
- remove button text support from `CallToAction` component
- add dedicated login/register buttons on the welcome page

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_687254106cd0832d9f275a018208ff51