### PR TITLE
Remove redundant change picture button

### DIFF
--- a/src/components/ProfileSettings.jsx
+++ b/src/components/ProfileSettings.jsx
@@ -386,11 +386,7 @@ export default function ProfileSettings({ userId, ageRange, onChangeAgeRange, pu
           ref:photoRef,
           onChange:handlePhotoChange,
           className:'hidden'
-        }),
-        !publicView && React.createElement(Button, {
-          className:'ml-4 bg-pink-500 text-white',
-          onClick:()=>photoRef.current && photoRef.current.click()
-        }, profile.photoURL ? 'Skift billede' : 'Upload billede')
+        })
       ),
       editInfo ?
         React.createElement('div', { className:'space-y-2 mb-2 w-full' },


### PR DESCRIPTION
## Summary
- remove the `Skift billede` button from the profile settings
- users can still change their picture by tapping the profile image directly

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_6872da6c9088832da935c127fb7166f4