### PR TITLE
Prompt for email at signup

### DIFF
--- a/src/components/ProfileSettings.jsx
+++ b/src/components/ProfileSettings.jsx
@@ -180,6 +180,12 @@ export default function ProfileSettings({ userId, ageRange, onChangeAgeRange, pu
     await updateDoc(doc(db,'profiles',userId), { city });
   };
 
+  const handleEmailChange = async e => {
+    const email = e.target.value;
+    setProfile({ ...profile, email });
+    await updateDoc(doc(db,'profiles',userId), { email });
+  };
+
   const handleInterestChange = async e => {
     const interest = e.target.value;
     setProfile({ ...profile, interest });
@@ -405,23 +411,33 @@ export default function ProfileSettings({ userId, ageRange, onChangeAgeRange, pu
             className:'border p-2 rounded w-full',
             placeholder:'F\u00f8dselsdag'
           }),
-          React.createElement(Input, {
-            value: profile.city || '',
-            onChange: handleCityChange,
-            className:'border p-2 rounded w-full',
-            placeholder:'By',
-            name:'city',
-            autoComplete:'address-level2'
-          }),
-          React.createElement(Button, {
-            className:'bg-pink-500 text-white w-full',
-            onClick: () => setEditInfo(false)
-          }, 'Færdig')
+        React.createElement(Input, {
+          value: profile.city || '',
+          onChange: handleCityChange,
+          className:'border p-2 rounded w-full',
+          placeholder:'By',
+          name:'city',
+          autoComplete:'address-level2'
+        }),
+        React.createElement(Input, {
+          type:'email',
+          value: profile.email || '',
+          onChange: handleEmailChange,
+          className:'border p-2 rounded w-full',
+          placeholder:'you@example.com',
+          name:'email',
+          autoComplete:'email'
+        }),
+        React.createElement(Button, {
+          className:'bg-pink-500 text-white w-full',
+          onClick: () => setEditInfo(false)
+        }, 'Færdig')
         ) :
         React.createElement('div', { className:'flex items-center justify-between w-full' },
           React.createElement(SectionTitle, { title: `${profile.name}, ${profile.birthday ? getAge(profile.birthday) : profile.age}${profile.city ? ', ' + profile.city : ''}` }),
           !publicView && React.createElement(EditIcon, { className:'w-5 h-5 text-gray-500 cursor-pointer', onClick: () => setEditInfo(true) })
         ),
+      isOwnProfile && !publicView && profile.email && React.createElement('p', { className:'text-center text-sm text-gray-600 mt-1' }, profile.email),
       !publicView && profile.subscriptionExpires && React.createElement('p', {
         className: 'text-center text-sm mt-2 ' + (subscriptionActive ? 'text-green-600' : 'text-red-500')
       }, subscriptionActive

--- a/src/components/WelcomeScreen.jsx
+++ b/src/components/WelcomeScreen.jsx
@@ -11,6 +11,7 @@ export default function WelcomeScreen({ onLogin }) {
   const [showRegister, setShowRegister] = useState(false);
   const [name, setName] = useState('');
   const [city, setCity] = useState('');
+  const [email, setEmail] = useState('');
   const [gender, setGender] = useState('Kvinde');
   const [birthday, setBirthday] = useState('');
   const [showBirthdayOverlay, setShowBirthdayOverlay] = useState(false);
@@ -25,6 +26,7 @@ export default function WelcomeScreen({ onLogin }) {
       id,
       name: trimmed,
       city: city.trim(),
+      email: email.trim(),
       gender,
       interest: gender === 'Kvinde' ? 'Mand' : 'Kvinde',
       birthday,
@@ -77,6 +79,16 @@ export default function WelcomeScreen({ onLogin }) {
           onBlur: () => setShowBirthdayOverlay(false),
           onChange: e => { setBirthday(e.target.value); setShowBirthdayOverlay(false); },
           placeholder: 'F\u00f8dselsdag'
+        }),
+        React.createElement('label', { className:'block mb-1' }, t('email')),
+        React.createElement(Input, {
+          type: 'email',
+          className: 'border p-2 mb-2 w-full',
+          value: email,
+          onChange: e => setEmail(e.target.value),
+          placeholder: 'you@example.com',
+          name: 'email',
+          autoComplete: 'email'
         }),
         React.createElement('datalist', { id: 'city-list' },
           ['København','Aarhus','Odense','Aalborg','Esbjerg','Randers'].map(c =>

--- a/src/i18n.js
+++ b/src/i18n.js
@@ -34,6 +34,7 @@ const messages = {
   firstName:{ en:'First name', da:'Fornavn', sv:'Förnamn', es:'Nombre', fr:'Prénom', de:'Vorname' },
   city:{ en:'City', da:'By', sv:'Stad', es:'Ciudad', fr:'Ville', de:'Stadt' },
   birthday:{ en:'Birthday', da:'Fødselsdag', sv:'Födelsedag', es:'Cumpleaños', fr:'Anniversaire', de:'Geburtstag' },
+  email:{ en:'Email', da:'E-mail', sv:'E-post', es:'Correo', fr:'E-mail', de:'E-Mail' },
   chooseBirthday:{ en:'Select your birthday', da:'Vælg din fødselsdag', sv:'Välj din födelsedag', es:'Selecciona tu cumpleaños', fr:'Sélectionnez votre anniversaire', de:'Wähle deinen Geburtstag' },
   gender:{ en:'Gender', da:'Køn', sv:'Kön', es:'Género', fr:'Genre', de:'Geschlecht' },
   loginCtaTitle:{ en:"Already have a profile?", da:"Har du en profil?", sv:"Har du en profil?", es:"¿Ya tienes perfil?", fr:"Vous avez déjà un profil ?", de:"Hast du ein Profil?" },


### PR DESCRIPTION
## Summary
- ask for an email address when creating a profile
- store the email on the profile document
- show the email only on the user's private profile page
- add `email` label to translations

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_687346d6261c832dbbe58c8ade909085