### PR TITLE
Add match log screen

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ and simple profile management powered by Firebase.
 * Daglige statistikker gemmes automatisk og vises som grafer i adminområdet
 * Statistik over hvor mange gange profiler bliver åbnet
 * Graf over antallet af \u00E5bne fejl pr. dag
+* Matchlog kan åbnes fra adminområdet
 
 
 ## Getting Started

--- a/src/RealDateApp.jsx
+++ b/src/RealDateApp.jsx
@@ -10,6 +10,7 @@ import ProfileSettings from './components/ProfileSettings.jsx';
 import AdminScreen from './components/AdminScreen.jsx';
 import StatsScreen from './components/StatsScreen.jsx';
 import BugReportsScreen from './components/BugReportsScreen.jsx';
+import MatchLogScreen from './components/MatchLogScreen.jsx';
 import AboutScreen from './components/AboutScreen.jsx';
 import { useCollection, requestNotificationPermission, db, doc, updateDoc, increment } from './firebase.js';
 
@@ -135,8 +136,9 @@ export default function RealDateApp() {
         onOpenAbout: ()=>setTab('about')
       }),
       tab==='likes' && React.createElement(LikesScreen, { userId, onBack: ()=>setTab('discovery'), onSelectProfile: selectProfile }),
-      tab==='admin' && React.createElement(AdminScreen, { onOpenStats: ()=>setTab('stats'), onOpenBugReports: ()=>setTab('bugs'), profiles, userId, onSwitchProfile: id=>setUserId(id) }),
+      tab==='admin' && React.createElement(AdminScreen, { onOpenStats: ()=>setTab('stats'), onOpenBugReports: ()=>setTab('bugs'), onOpenMatchLog: ()=>setTab('matchlog'), profiles, userId, onSwitchProfile: id=>setUserId(id) }),
       tab==='stats' && React.createElement(StatsScreen, { onBack: ()=>setTab('admin') }),
+      tab==='matchlog' && React.createElement(MatchLogScreen, { onBack: ()=>setTab('admin') }),
       tab==='bugs' && React.createElement(BugReportsScreen, { onBack: ()=>setTab('admin') }),
       tab==='about' && React.createElement(AboutScreen, { onOpenAdmin: ()=>setTab('admin') })
     ),

--- a/src/components/AdminScreen.jsx
+++ b/src/components/AdminScreen.jsx
@@ -6,7 +6,7 @@ import SectionTitle from './SectionTitle.jsx';
 import seedData from '../seedData.js';
 import { db, collection, getDocs } from '../firebase.js';
 
-export default function AdminScreen({ onOpenStats, onOpenBugReports, profiles = [], userId, onSwitchProfile }) {
+export default function AdminScreen({ onOpenStats, onOpenBugReports, onOpenMatchLog, profiles = [], userId, onSwitchProfile }) {
 
   const { lang, setLang } = useLang();
   const t = useT();
@@ -59,6 +59,8 @@ export default function AdminScreen({ onOpenStats, onOpenBugReports, profiles = 
     React.createElement(Button, { className: 'mt-2 bg-pink-500 text-white px-4 py-2 rounded', onClick: () => sendPush('Du har et match. Start samtalen') }, 'Du har et match. Start samtalen'),
     React.createElement('h3', { className: 'text-xl font-semibold mb-2 mt-4 text-pink-600' }, 'Statistik'),
     React.createElement(Button, { className: 'mt-2 bg-pink-500 text-white px-4 py-2 rounded', onClick: onOpenStats }, 'Vis statistik'),
+    React.createElement('h3', { className: 'text-xl font-semibold mb-2 mt-4 text-pink-600' }, 'Matchlog'),
+    React.createElement(Button, { className: 'mt-2', onClick: onOpenMatchLog }, 'Se matchlog'),
     React.createElement('h3', { className: 'text-xl font-semibold mb-2 mt-4 text-pink-600' }, 'Fejlmeldinger'),
     React.createElement(Button, { className: 'mt-2', onClick: onOpenBugReports }, 'Se alle fejlmeldinger')
   );

--- a/src/components/MatchLogScreen.jsx
+++ b/src/components/MatchLogScreen.jsx
@@ -1,0 +1,26 @@
+import React from 'react';
+import { Card } from './ui/card.js';
+import { Button } from './ui/button.js';
+import SectionTitle from './SectionTitle.jsx';
+import { useCollection } from '../firebase.js';
+
+export default function MatchLogScreen({ onBack }) {
+  const matches = useCollection('matches');
+  const profiles = useCollection('profiles');
+  const profileMap = Object.fromEntries(profiles.map(p => [p.id, p]));
+
+  const uniqueMatches = matches
+    .filter(m => m.userId < m.profileId)
+    .sort((a, b) => a.id.localeCompare(b.id));
+
+  return React.createElement(Card, { className: 'p-6 m-4 shadow-xl bg-white/90' },
+    React.createElement(SectionTitle, { title: 'Matchlog', action: React.createElement(Button, { onClick: onBack }, 'Tilbage') }),
+    uniqueMatches.length ?
+      React.createElement('ul', { className: 'space-y-2 mt-4 overflow-y-auto max-h-[70vh]' },
+        uniqueMatches.map(m =>
+          React.createElement('li', { key: m.id }, `${profileMap[m.userId]?.name || m.userId} ❤️ ${profileMap[m.profileId]?.name || m.profileId}`)
+        )
+      ) :
+      React.createElement('p', { className: 'text-center mt-4 text-gray-500' }, 'Ingen matches')
+  );
+}


### PR DESCRIPTION
## Summary
- add MatchLogScreen component
- link to MatchLogScreen from AdminScreen
- allow navigation to match log from main app
- document ability to open matchlog from admin

## Testing
- `npm install`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68737d01decc832d85bfba4340743afe