### PR TITLE
Add score log view in admin

### DIFF
--- a/src/RealDateApp.jsx
+++ b/src/RealDateApp.jsx
@@ -11,6 +11,7 @@ import AdminScreen from './components/AdminScreen.jsx';
 import StatsScreen from './components/StatsScreen.jsx';
 import BugReportsScreen from './components/BugReportsScreen.jsx';
 import MatchLogScreen from './components/MatchLogScreen.jsx';
+import ScoreLogScreen from './components/ScoreLogScreen.jsx';
 import AboutScreen from './components/AboutScreen.jsx';
 import { useCollection, requestNotificationPermission, db, doc, updateDoc, increment } from './firebase.js';
 
@@ -136,9 +137,10 @@ export default function RealDateApp() {
         onOpenAbout: ()=>setTab('about')
       }),
       tab==='likes' && React.createElement(LikesScreen, { userId, onBack: ()=>setTab('discovery'), onSelectProfile: selectProfile }),
-      tab==='admin' && React.createElement(AdminScreen, { onOpenStats: ()=>setTab('stats'), onOpenBugReports: ()=>setTab('bugs'), onOpenMatchLog: ()=>setTab('matchlog'), profiles, userId, onSwitchProfile: id=>setUserId(id) }),
+      tab==='admin' && React.createElement(AdminScreen, { onOpenStats: ()=>setTab('stats'), onOpenBugReports: ()=>setTab('bugs'), onOpenMatchLog: ()=>setTab('matchlog'), onOpenScoreLog: ()=>setTab('scorelog'), profiles, userId, onSwitchProfile: id=>setUserId(id) }),
       tab==='stats' && React.createElement(StatsScreen, { onBack: ()=>setTab('admin') }),
       tab==='matchlog' && React.createElement(MatchLogScreen, { onBack: ()=>setTab('admin') }),
+      tab==='scorelog' && React.createElement(ScoreLogScreen, { onBack: ()=>setTab('admin') }),
       tab==='bugs' && React.createElement(BugReportsScreen, { onBack: ()=>setTab('admin') }),
       tab==='about' && React.createElement(AboutScreen, { onOpenAdmin: ()=>setTab('admin') })
     ),

--- a/src/components/AdminScreen.jsx
+++ b/src/components/AdminScreen.jsx
@@ -6,7 +6,7 @@ import SectionTitle from './SectionTitle.jsx';
 import seedData from '../seedData.js';
 import { db, collection, getDocs } from '../firebase.js';
 
-export default function AdminScreen({ onOpenStats, onOpenBugReports, onOpenMatchLog, profiles = [], userId, onSwitchProfile }) {
+export default function AdminScreen({ onOpenStats, onOpenBugReports, onOpenMatchLog, onOpenScoreLog, profiles = [], userId, onSwitchProfile }) {
 
   const { lang, setLang } = useLang();
   const t = useT();
@@ -61,6 +61,8 @@ export default function AdminScreen({ onOpenStats, onOpenBugReports, onOpenMatch
     React.createElement(Button, { className: 'mt-2 bg-pink-500 text-white px-4 py-2 rounded', onClick: onOpenStats }, 'Vis statistik'),
     React.createElement('h3', { className: 'text-xl font-semibold mb-2 mt-4 text-pink-600' }, 'Matchlog'),
     React.createElement(Button, { className: 'mt-2', onClick: onOpenMatchLog }, 'Se matchlog'),
+    React.createElement('h3', { className: 'text-xl font-semibold mb-2 mt-4 text-pink-600' }, 'Score log'),
+    React.createElement(Button, { className: 'mt-2', onClick: onOpenScoreLog }, 'Se score log'),
     React.createElement('h3', { className: 'text-xl font-semibold mb-2 mt-4 text-pink-600' }, 'Fejlmeldinger'),
     React.createElement(Button, { className: 'mt-2', onClick: onOpenBugReports }, 'Se alle fejlmeldinger')
   );

--- a/src/components/ScoreLogScreen.jsx
+++ b/src/components/ScoreLogScreen.jsx
@@ -1,0 +1,40 @@
+import React from 'react';
+import { Card } from './ui/card.js';
+import { Button } from './ui/button.js';
+import SectionTitle from './SectionTitle.jsx';
+import { useCollection } from '../firebase.js';
+
+export default function ScoreLogScreen({ onBack }) {
+  const logs = useCollection('matchLogs');
+  const profiles = useCollection('profiles');
+  const profileMap = Object.fromEntries(profiles.map(p => [p.id, p]));
+
+  const sortedLogs = logs.sort((a, b) => new Date(b.date) - new Date(a.date));
+
+  const formatName = id => profileMap[id]?.name || id;
+  const formatScore = s => typeof s.score === 'number' ? s.score.toFixed(1) : s.score;
+
+  return React.createElement(Card, { className: 'p-6 m-4 shadow-xl bg-white/90' },
+    React.createElement(SectionTitle, { title: 'Score log', action: React.createElement(Button, { onClick: onBack }, 'Tilbage') }),
+    sortedLogs.length ?
+      React.createElement('ul', { className: 'space-y-4 mt-4 overflow-y-auto max-h-[70vh]' },
+        sortedLogs.map(log =>
+          React.createElement('li', { key: log.id, className: 'border p-2 rounded' },
+            React.createElement('div', { className: 'text-sm font-medium' }, `${log.date} - ${formatName(log.userId)}`),
+            React.createElement('div', { className: 'text-xs mt-1' }, 'Valgte: ' +
+              (log.selected || []).map(s => `${formatName(s.id)} (${formatScore(s)})`).join(', ')
+            ),
+            React.createElement('details', { className: 'text-xs mt-1' },
+              React.createElement('summary', null, 'Alle scorer'),
+              React.createElement('ul', { className: 'list-disc list-inside' },
+                (log.potential || []).map(p =>
+                  React.createElement('li', { key: p.id }, `${formatName(p.id)}: ${formatScore(p)}`)
+                )
+              )
+            )
+          )
+        )
+      ) :
+      React.createElement('p', { className: 'text-center mt-4 text-gray-500' }, 'Ingen logs')
+  );
+}


### PR DESCRIPTION
## Summary
- allow admin to view log entries from the scoring system
- new `ScoreLogScreen` lists match scoring logs
- add navigation in `AdminScreen` and `RealDateApp`

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_6873890613f8832d997204d78b51493b