### PR TITLE
Add detailed scoring breakdown to logs

### DIFF
--- a/src/components/DailyDiscovery.jsx
+++ b/src/components/DailyDiscovery.jsx
@@ -26,10 +26,10 @@ export default function DailyDiscovery({ userId, onSelectProfile, ageRange, onOp
     const log = {
       userId,
       date: new Date().toISOString(),
-      potential: scored.map(p => ({ id: p.id, score: p.score })),
+      potential: scored.map(p => ({ id: p.id, score: { score: p.score, breakdown: p.breakdown } })),
       selected: scored
         .filter(p => selectedIds.includes(p.id))
-        .map(p => ({ id: p.id, score: p.score }))
+        .map(p => ({ id: p.id, score: { score: p.score, breakdown: p.breakdown } }))
     };
     setDoc(doc(collection(db, 'matchLogs')), log).catch(err =>
       console.error('Failed to log match scores', err)

--- a/src/components/ScoreLogScreen.jsx
+++ b/src/components/ScoreLogScreen.jsx
@@ -12,7 +12,11 @@ export default function ScoreLogScreen({ onBack }) {
   const sortedLogs = logs.sort((a, b) => new Date(b.date) - new Date(a.date));
 
   const formatName = id => profileMap[id]?.name || id;
-  const formatScore = s => typeof s.score === 'number' ? s.score.toFixed(1) : s.score;
+  const formatScore = s => {
+    if (typeof s.score === 'number') return s.score.toFixed(1);
+    if (s.score && typeof s.score.score === 'number') return s.score.score.toFixed(1);
+    return s.score;
+  };
 
   return React.createElement(Card, { className: 'p-6 m-4 shadow-xl bg-white/90' },
     React.createElement(SectionTitle, { title: 'Score log', action: React.createElement(Button, { onClick: onBack }, 'Tilbage') }),
@@ -26,12 +30,20 @@ export default function ScoreLogScreen({ onBack }) {
             ),
             React.createElement('details', { className: 'text-xs mt-1' },
               React.createElement('summary', null, 'Alle scorer'),
-              React.createElement('ul', { className: 'list-disc list-inside' },
-                (log.potential || []).map(p =>
-                  React.createElement('li', { key: p.id }, `${formatName(p.id)}: ${formatScore(p)}`)
+                React.createElement('ul', { className: 'list-disc list-inside' },
+                  (log.potential || []).map(p =>
+                    React.createElement('li', { key: p.id },
+                      `${formatName(p.id)}: ${formatScore(p)}`,
+                      p.score && p.score.breakdown &&
+                        React.createElement('ul', { className: 'ml-4 list-disc' },
+                          Object.entries(p.score.breakdown).map(([k, v]) =>
+                            React.createElement('li', { key: k }, `${k}: ${typeof v === 'number' ? v.toFixed(1) : v}`)
+                          )
+                        )
+                    )
+                  )
                 )
               )
-            )
           )
         )
       ) :

--- a/src/selectProfiles.js
+++ b/src/selectProfiles.js
@@ -4,7 +4,8 @@ import { getAge } from './utils.js';
 
 // Calculate a detailed match score for a single profile. Missing data is handled
 // gracefully so the function can run both on the client and as a Cloud Function.
-export function calculateMatchScore(user, profile, ageRange) {
+export function calculateMatchScoreDetailed(user, profile, ageRange) {
+  const breakdown = {};
   let score = 0;
 
   const userAge = user.birthday ? getAge(user.birthday) : user.age;
@@ -15,14 +16,22 @@ export function calculateMatchScore(user, profile, ageRange) {
     const mid = (ageRange[0] + ageRange[1]) / 2;
     const maxDiff = Math.max(mid - ageRange[0], ageRange[1] - mid) || 1;
     const diff = Math.abs(profAge - mid);
-    score += 20 * Math.max(0, 1 - diff / maxDiff);
+    const s = 20 * Math.max(0, 1 - diff / maxDiff);
+    breakdown.age = s;
+    score += s;
+  } else {
+    breakdown.age = 0;
   }
 
   // 2. Gender preference match (max 20)
   if (user.interest === profile.gender && profile.interest === user.gender) {
+    breakdown.gender = 20;
     score += 20;
   } else if (user.interest === profile.gender || profile.interest === user.gender) {
-    score += 10; // partial match
+    breakdown.gender = 10; // partial match
+    score += 10;
+  } else {
+    breakdown.gender = 0;
   }
 
   // 3. Distance (max 20)
@@ -30,41 +39,62 @@ export function calculateMatchScore(user, profile, ageRange) {
   // Without real geo data, treat same city as distance 0 and others as 100km
   const distance = user.city && profile.city && user.city === profile.city ? 0 : 100;
   if (distance <= userMax) {
+    breakdown.distance = 20;
     score += 20;
   } else if (distance <= userMax + 50) {
-    score += 20 * (1 - (distance - userMax) / 50);
+    const s = 20 * (1 - (distance - userMax) / 50);
+    breakdown.distance = s;
+    score += s;
+  } else {
+    breakdown.distance = 0;
   }
 
   // 4. Shared interests (max 15)
   const userInt = user.interests || [];
   const profInt = profile.interests || [];
   const shared = userInt.filter(i => profInt.includes(i)).length;
-  score += Math.min(shared, 5) / 5 * 15;
+  breakdown.interests = Math.min(shared, 5) / 5 * 15;
+  score += breakdown.interests;
 
   // 5. Activity level (max 10)
   if (profile.lastActive) {
     const hours = (Date.now() - new Date(profile.lastActive)) / 36e5;
-    if (hours <= 24) score += 10;
-    else if (hours <= 72) score += 7;
-    else if (hours <= 168) score += 4;
+    if (hours <= 24) breakdown.activity = 10;
+    else if (hours <= 72) breakdown.activity = 7;
+    else if (hours <= 168) breakdown.activity = 4;
+    else breakdown.activity = 0;
+    score += breakdown.activity;
+  } else {
+    breakdown.activity = 0;
   }
 
   // 6. Profile completeness (max 5)
   const completeness = [profile.clip, profile.photoURL, profile.interest].filter(Boolean).length;
-  score += completeness / 3 * 5;
+  breakdown.completeness = completeness / 3 * 5;
+  score += breakdown.completeness;
 
   // 7. Response rate (max 5)
   if (typeof profile.responseRate === 'number') {
-    score += Math.min(1, profile.responseRate) * 5;
+    breakdown.response = Math.min(1, profile.responseRate) * 5;
+    score += breakdown.response;
+  } else {
+    breakdown.response = 0;
   }
 
   // 8. Popularity balance (max 5)
   const popularity = (profile.viewCount || 0) + (profile.likeCount || 0);
-  if (popularity < 5) score += 5;
-  else if (popularity < 20) score += 3;
-  else if (popularity < 50) score += 1;
+  if (popularity < 5) breakdown.popularity = 5;
+  else if (popularity < 20) breakdown.popularity = 3;
+  else if (popularity < 50) breakdown.popularity = 1;
+  else breakdown.popularity = 0;
+  score += breakdown.popularity;
 
-  return Math.min(100, score);
+  const total = Math.min(100, score);
+  return { score: total, breakdown };
+}
+
+export function calculateMatchScore(user, profile, ageRange) {
+  return calculateMatchScoreDetailed(user, profile, ageRange).score;
 }
 
 export function scoreProfiles(user, profiles, ageRange) {
@@ -83,7 +113,10 @@ export function scoreProfiles(user, profiles, ageRange) {
         (allowOther || matchesLang)
       );
     })
-    .map(p => ({ ...p, score: calculateMatchScore(user, p, ageRange) }))
+    .map(p => {
+      const { score, breakdown } = calculateMatchScoreDetailed(user, p, ageRange);
+      return { ...p, score, breakdown };
+    })
     .sort((a, b) => b.score - a.score);
 }
 


### PR DESCRIPTION
## Summary
- expand scoring to include breakdown per category
- store breakdown when logging matches
- display breakdowns in Score Log screen

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68738ea2c0a8832d9b966cfb48923126