### PR TITLE
Add detailed reporting tools

### DIFF
--- a/src/components/DailyDiscovery.jsx
+++ b/src/components/DailyDiscovery.jsx
@@ -2,7 +2,6 @@ import React, { useState, useEffect } from 'react';
 import { getAge } from '../utils.js';
 import { User, PlayCircle, Heart } from 'lucide-react';
 import VideoOverlay from './VideoOverlay.jsx';
-import ReportOverlay from './ReportOverlay.jsx';
 import { Card } from './ui/card.js';
 import { Button } from './ui/button.js';
 import SectionTitle from './SectionTitle.jsx';
@@ -44,7 +43,6 @@ export default function DailyDiscovery({ userId, onSelectProfile, ageRange, onOp
   const [showInfo, setShowInfo] = useState(false);
   const [matchedProfile, setMatchedProfile] = useState(null);
   const [activeVideo, setActiveVideo] = useState(null);
-  const [reportProfile, setReportProfile] = useState(null);
   const handleExtraPurchase = async () => {
     const todayStr = new Date().toISOString().split('T')[0];
     await updateDoc(doc(db, 'profiles', userId), { extraClipsDate: todayStr });
@@ -129,8 +127,7 @@ export default function DailyDiscovery({ userId, onSelectProfile, ageRange, onOp
           React.createElement('div', { className: 'flex gap-2 mt-2' },
             React.createElement(Button, { size: 'sm', variant: 'outline', className: 'flex items-center gap-1', onClick:e=>{e.stopPropagation(); const url=(p.videoClips&&p.videoClips[0])?(p.videoClips[0].url||p.videoClips[0]):null; if(url) setActiveVideo(url); } },
               React.createElement(PlayCircle, { className: 'w-5 h-5' }), 'Afspil'
-            ),
-            React.createElement(Button, { size: 'sm', variant: 'outline', onClick:e=>{e.stopPropagation(); setReportProfile(p);} }, 'Anmeld')
+            )
           )
         )
       )) :
@@ -164,12 +161,6 @@ export default function DailyDiscovery({ userId, onSelectProfile, ageRange, onOp
       name: matchedProfile.name,
       onClose: () => setMatchedProfile(null)
     }),
-    activeVideo && React.createElement(VideoOverlay, { src: activeVideo, onClose: () => setActiveVideo(null) }),
-    reportProfile && React.createElement(ReportOverlay, {
-      userId,
-      profileId: reportProfile.id,
-      clipURL: (reportProfile.videoClips && reportProfile.videoClips[0]) ? (reportProfile.videoClips[0].url || reportProfile.videoClips[0]) : '',
-      onClose: () => setReportProfile(null)
-    })
+    activeVideo && React.createElement(VideoOverlay, { src: activeVideo, onClose: () => setActiveVideo(null) })
   );
 }

--- a/src/components/ReportOverlay.jsx
+++ b/src/components/ReportOverlay.jsx
@@ -1,9 +1,11 @@
-import React from 'react';
+import React, { useState } from 'react';
 import { Card } from './ui/card.js';
 import { Button } from './ui/button.js';
+import { Textarea } from './ui/textarea.js';
 import { db, doc, setDoc } from '../firebase.js';
 
-export default function ReportOverlay({ userId, profileId, clipURL, onClose }) {
+export default function ReportOverlay({ userId, profileId, clipURL = '', text = '', onClose }) {
+  const [reason, setReason] = useState('');
   const submit = async () => {
     const id = Date.now().toString();
     await setDoc(doc(db, 'reports', id), {
@@ -11,6 +13,8 @@ export default function ReportOverlay({ userId, profileId, clipURL, onClose }) {
       reporterId: userId,
       profileId,
       clipURL,
+      text,
+      reason,
       createdAt: new Date().toISOString(),
       status: 'open'
     });
@@ -20,8 +24,14 @@ export default function ReportOverlay({ userId, profileId, clipURL, onClose }) {
   return React.createElement('div', { className:'fixed inset-0 z-50 bg-black/50 flex items-center justify-center' },
     React.createElement(Card, { className:'bg-white p-6 rounded shadow-xl max-w-sm w-full' },
       React.createElement('h2', { className:'text-xl font-semibold mb-4 text-pink-600 text-center' }, 'Anmeld indhold'),
-      React.createElement('p', { className:'mb-4 text-center' }, 'Vil du anmelde dette indhold?'),
-      React.createElement(Button, { className:'w-full bg-pink-500 text-white mb-2', onClick: submit }, 'Anmeld'),
+      React.createElement('p', { className:'mb-2 text-center' }, 'Vil du anmelde dette indhold?'),
+      React.createElement(Textarea, {
+        className: 'mb-4 border p-2 rounded w-full',
+        placeholder: 'Beskriv hvorfor...',
+        value: reason,
+        onChange: e => setReason(e.target.value)
+      }),
+      React.createElement(Button, { className:'w-full bg-pink-500 text-white mb-2', disabled: !reason.trim(), onClick: submit }, 'Anmeld'),
       React.createElement(Button, { className:'w-full', onClick: onClose }, 'Annuller')
     )
   );


### PR DESCRIPTION
## Summary
- remove report buttons from DailyDiscovery
- enable reporting from within public profile view
- add flag icons for reporting videos, audio clips and profile text
- collect reason when reporting content

## Testing
- `npm install`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6873dde314d4832db1b59197771129c7