### PR TITLE
Include VAPID/FCM secrets in build

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -25,16 +25,18 @@ jobs:
         with:
           node-version: 18
           cache: 'npm'
-      - name: Create .env file
-        run: |
-          cat <<'EOF' > .env
-          FIREBASE_API_KEY=${{ secrets.FIREBASE_API_KEY }}
-          FIREBASE_AUTH_DOMAIN=${{ secrets.FIREBASE_AUTH_DOMAIN }}
-          FIREBASE_PROJECT_ID=${{ secrets.FIREBASE_PROJECT_ID }}
-          FIREBASE_STORAGE_BUCKET=${{ secrets.FIREBASE_STORAGE_BUCKET }}
-          FIREBASE_MESSAGING_SENDER_ID=${{ secrets.FIREBASE_MESSAGING_SENDER_ID }}
-          FIREBASE_APP_ID=${{ secrets.FIREBASE_APP_ID }}
-          EOF
+        - name: Create .env file
+          run: |
+            cat <<'EOF' > .env
+            FIREBASE_API_KEY=${{ secrets.FIREBASE_API_KEY }}
+            FIREBASE_AUTH_DOMAIN=${{ secrets.FIREBASE_AUTH_DOMAIN }}
+            FIREBASE_PROJECT_ID=${{ secrets.FIREBASE_PROJECT_ID }}
+            FIREBASE_STORAGE_BUCKET=${{ secrets.FIREBASE_STORAGE_BUCKET }}
+            FIREBASE_MESSAGING_SENDER_ID=${{ secrets.FIREBASE_MESSAGING_SENDER_ID }}
+            FIREBASE_APP_ID=${{ secrets.FIREBASE_APP_ID }}
+            VAPID_KEY=${{ secrets.VAPID_KEY }}
+            FCM_SERVER_KEY=${{ secrets.FCM_SERVER_KEY }}
+            EOF
       - run: npm ci
       - run: npm run build
       - uses: actions/upload-pages-artifact@v3


### PR DESCRIPTION
## Summary
- add `VAPID_KEY` and `FCM_SERVER_KEY` to the generated `.env` in build workflow

## Testing
- `npm ci`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6873ebef8638832d9823df8056bd148c