### PR TITLE
Add age validation for birthday

### DIFF
--- a/src/components/ProfileSettings.jsx
+++ b/src/components/ProfileSettings.jsx
@@ -171,6 +171,10 @@ export default function ProfileSettings({ userId, ageRange, onChangeAgeRange, pu
 
   const handleBirthdayChange = async e => {
     const birthday = e.target.value;
+    if(birthday && getAge(birthday) < 18){
+      alert('Du skal v\u00e6re mindst 18 \u00e5r for at bruge appen');
+      return;
+    }
     setProfile({ ...profile, birthday });
     const age = birthday ? getAge(birthday) : '';
     await updateDoc(doc(db,'profiles',userId), { birthday, age });

--- a/src/components/WelcomeScreen.jsx
+++ b/src/components/WelcomeScreen.jsx
@@ -21,6 +21,11 @@ export default function WelcomeScreen({ onLogin }) {
   const register = async () => {
     const trimmed = name.trim();
     if (!trimmed) return;
+    // Require a valid birthday confirming the user is at least 18
+    if (!birthday || getAge(birthday) < 18) {
+      alert('Du skal v\u00e6re mindst 18 \u00e5r for at bruge appen');
+      return;
+    }
     const id = Date.now().toString();
     const profile = {
       id,


### PR DESCRIPTION
## Summary
- enforce 18+ age requirement when creating a profile
- block profile birthday edits that would make the user younger than 18

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_6874c9619738832dbe5b997c364594c5