### PR TITLE
Adjust score log layout

### DIFF
--- a/src/components/ScoreLogScreen.jsx
+++ b/src/components/ScoreLogScreen.jsx
@@ -18,7 +18,7 @@ export default function ScoreLogScreen({ onBack }) {
     return s.score;
   };
 
-  return React.createElement(Card, { className: 'p-6 m-4 shadow-xl bg-white/90' },
+  return React.createElement(Card, { className: 'fixed inset-0 p-6 shadow-xl bg-white/90 overflow-y-auto' },
     React.createElement(SectionTitle, { title: 'Score log', action: React.createElement(Button, { onClick: onBack }, 'Tilbage') }),
     sortedLogs.length ?
       React.createElement('ul', { className: 'space-y-4 mt-4 overflow-y-auto max-h-[70vh]' },


### PR DESCRIPTION
## Summary
- keep score log visible by fixing the card to the viewport

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_6874ca649a8c832dae01ecebfb3fd8e6