### PR TITLE
Add profile card header

### DIFF
--- a/src/components/ProfileSettings.jsx
+++ b/src/components/ProfileSettings.jsx
@@ -378,6 +378,9 @@ export default function ProfileSettings({ userId, ageRange, onChangeAgeRange, pu
   );
 
   return React.createElement(React.Fragment, null,
+    !publicView && React.createElement(Card, { className: 'p-4 m-4 shadow-xl bg-white/90' },
+      React.createElement('h2', { className: 'text-xl font-semibold text-pink-600 text-center' }, 'Din profil')
+    ),
     React.createElement(Card, { className: 'p-6 m-4 shadow-xl bg-white/90' },
         !publicView && React.createElement('div', {
           className: 'mb-4 flex justify-end gap-2'


### PR DESCRIPTION
## Summary
- show a card at the top of the profile settings page with the heading "Din profil"

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_6874de3df390832da1774471035fee8b