### PR TITLE
Replace loading text with placeholder cards

### DIFF
--- a/src/components/ProfileSettings.jsx
+++ b/src/components/ProfileSettings.jsx
@@ -53,7 +53,12 @@ export default function ProfileSettings({ userId, ageRange, onChangeAgeRange, pu
 
   useEffect(()=>{if(!userId)return;getDoc(doc(db,'profiles',userId)).then(s=>s.exists()&&setProfile({id:s.id,...s.data()}));},[userId]);
   useEffect(()=>{if(profile && profile.distanceRange) setDistanceRange(profile.distanceRange);},[profile]);
-  if(!profile) return React.createElement('p', null, 'Indlæser profil...');
+  if(!profile) return React.createElement(React.Fragment, null,
+    React.createElement(Card, { className: 'p-6 m-4 shadow-xl bg-white/90 h-24 animate-pulse' }),
+    React.createElement(Card, { className: 'p-6 m-4 shadow-xl bg-white/90 h-32 animate-pulse' }),
+    React.createElement(Card, { className: 'p-6 m-4 shadow-xl bg-white/90 h-32 animate-pulse' }),
+    React.createElement(Card, { className: 'p-6 m-4 shadow-xl bg-white/90 h-40 animate-pulse' })
+  );
 
   const subscriptionActive = profile.subscriptionExpires && new Date(profile.subscriptionExpires) > new Date();
 


### PR DESCRIPTION
## Summary
- show a few empty card placeholders on profile page until profile data loads

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_6874e3157ff8832dad6bd0460991055e