### PR TITLE
Prevent text field scrolling in chat

### DIFF
--- a/src/components/ChatScreen.jsx
+++ b/src/components/ChatScreen.jsx
@@ -16,6 +16,15 @@ export default function ChatScreen({ userId }) {
   const [active, setActive] = useState(null);
   const [text, setText] = useState('');
   const messagesRef = useRef(null);
+  const textareaRef = useRef(null);
+
+  useEffect(() => {
+    if(textareaRef.current){
+      const el = textareaRef.current;
+      el.style.height = 'auto';
+      el.style.height = `${el.scrollHeight}px`;
+    }
+  }, [text]);
 
   useEffect(() => {
     if(active){
@@ -119,7 +128,8 @@ export default function ChatScreen({ userId }) {
               placeholder: 'Skriv besked...',
               rows: 3,
               value: text,
-              onChange: e => setText(e.target.value)
+              onChange: e => setText(e.target.value),
+              ref: textareaRef
             }),
             React.createElement(Button, {
               className: 'bg-pink-500 text-white',

--- a/src/components/ui/textarea.js
+++ b/src/components/ui/textarea.js
@@ -1,5 +1,5 @@
 import React from 'react';
-export function Textarea({ className = '', ...props }) {
+export const Textarea = React.forwardRef(function Textarea({ className = '', ...props }, ref){
   const base = 'w-full block';
-  return React.createElement('textarea', { className: `${base} ${className}`.trim(), ...props }, props.children);
-}
+  return React.createElement('textarea', { ref, className: `${base} ${className}`.trim(), ...props }, props.children);
+});


### PR DESCRIPTION
## Summary
- update Textarea to forward refs
- auto-resize message textarea so it doesn't scroll

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6874e65e3694832d807f007e48a7aed0