### PR TITLE
Implement age validation on birthday blur

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "realdate",
-  "version": "1.0.12",
+  "version": "1.0.16",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "realdate",
-      "version": "1.0.12",
+      "version": "1.0.16",
       "dependencies": {
         "firebase": "^9.23.0",
         "firebase-admin": "^11.10.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "realdate",
-  "version": "1.0.13",
+  "version": "1.0.16",
   "description": "A minimal React PWA for swiping short videos and speed dating.",
   "scripts": {
     "start": "npx serve .",

--- a/src/components/WelcomeScreen.jsx
+++ b/src/components/WelcomeScreen.jsx
@@ -18,6 +18,13 @@ export default function WelcomeScreen({ onLogin }) {
   const { lang } = useLang();
   const t = useT();
 
+  const handleBirthdayBlur = () => {
+    setShowBirthdayOverlay(false);
+    if (birthday && getAge(birthday) < 18) {
+      alert('Du skal v\u00e6re mindst 18 \u00e5r for at bruge appen');
+    }
+  };
+
   const register = async () => {
     const trimmed = name.trim();
     if (!trimmed) return;
@@ -81,7 +88,7 @@ export default function WelcomeScreen({ onLogin }) {
           className: 'border p-2 mb-2 w-full',
           value: birthday,
           onFocus: () => setShowBirthdayOverlay(true),
-          onBlur: () => setShowBirthdayOverlay(false),
+          onBlur: handleBirthdayBlur,
           onChange: e => { setBirthday(e.target.value); setShowBirthdayOverlay(false); },
           placeholder: 'F\u00f8dselsdag'
         }),

--- a/src/version.js
+++ b/src/version.js
@@ -1,1 +1,1 @@
-export default '1.0.13';
+export default '1.0.16';


### PR DESCRIPTION
## Summary
- show warning if birthday makes user <18 when leaving field during registration
- bump version to 1.0.16

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_6874e6dd7250832daf989322e9951ac2