### PR TITLE
Show selectable interests as buttons

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "realdate",
-  "version": "1.0.18",
+  "version": "1.0.19",
   "description": "A minimal React PWA for swiping short videos and speed dating.",
   "scripts": {
     "start": "npx serve .",

--- a/src/components/ProfileSettings.jsx
+++ b/src/components/ProfileSettings.jsx
@@ -219,6 +219,12 @@ export default function ProfileSettings({ userId, ageRange, onChangeAgeRange, pu
     await updateDoc(doc(db,'profiles',userId), { interests: opts });
   };
 
+  const handleRemoveInterest = async interest => {
+    const updated = (profile.interests || []).filter(i => i !== interest);
+    setProfile({ ...profile, interests: updated });
+    await updateDoc(doc(db,'profiles',userId), { interests: updated });
+  };
+
   const handleDistanceRangeChange = async range => {
     setDistanceRange(range);
     await updateDoc(doc(db,'profiles',userId), { distanceRange: range });
@@ -538,15 +544,17 @@ export default function ProfileSettings({ userId, ageRange, onChangeAgeRange, pu
       ),
     React.createElement(Card, { className: 'p-6 m-4 shadow-xl bg-white/90' }, videoSection),
     React.createElement(Card, { className: 'p-6 m-4 shadow-xl bg-white/90' }, audioSection),
-    publicView && React.createElement(Card, { className: 'p-6 m-4 shadow-xl bg-white/90' },
+    React.createElement(Card, { className: 'p-6 m-4 shadow-xl bg-white/90' },
       React.createElement(SectionTitle, { title: t('interests') }),
-      React.createElement('div', { className: 'flex flex-wrap gap-2' },
+      React.createElement('div', { className: 'flex flex-wrap gap-2 mb-2' },
         (profile.interests || []).map(i => {
           const cat = getInterestCategory(i);
           const exact = viewerInterests.includes(i);
           const sameCat = !exact && viewerCategories.has(cat);
           const cls = 'px-2 py-1 rounded text-sm ' + (exact ? 'bg-pink-500 text-white' : sameCat ? 'bg-pink-100 text-pink-800' : 'bg-gray-100');
-          return React.createElement('span', { key: i, className: cls }, i);
+          const sharedProps = { key: i, className: cls + (!publicView ? ' cursor-pointer' : '') };
+          const elProps = publicView ? {} : { onClick: () => handleRemoveInterest(i) };
+          return React.createElement(publicView ? 'span' : 'button', { ...sharedProps, ...elProps }, i);
         })
       )
     ),

--- a/src/version.js
+++ b/src/version.js
@@ -1,1 +1,1 @@
-export default '1.0.18';
+export default '1.0.19';


### PR DESCRIPTION
## Summary
- increment version
- allow removing interests via button
- display interests as small buttons on profiles

## Testing
- `npm install`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68750e334ae4832db541ffc0a602f89f