### PR TITLE
Add interests overlay

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "realdate",
-  "version": "1.0.18",
+  "version": "1.0.20",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "realdate",
-      "version": "1.0.18",
+      "version": "1.0.20",
       "dependencies": {
         "firebase": "^9.23.0",
         "firebase-admin": "^11.10.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "realdate",
-  "version": "1.0.19",
+  "version": "1.0.21",
   "description": "A minimal React PWA for swiping short videos and speed dating.",
   "scripts": {
     "start": "npx serve .",

--- a/src/components/InterestsOverlay.jsx
+++ b/src/components/InterestsOverlay.jsx
@@ -1,0 +1,50 @@
+import React, { useState } from 'react';
+import { Card } from './ui/card.js';
+import { Button } from './ui/button.js';
+import { interestOptions, interestCategories } from '../interests.js';
+
+export default function InterestsOverlay({ current = [], onSave, onClose }) {
+  const [selected, setSelected] = useState(new Set(current));
+
+  const toggle = i => {
+    const next = new Set(selected);
+    if (next.has(i)) next.delete(i); else next.add(i);
+    setSelected(next);
+  };
+
+  const handleSave = () => {
+    const arr = Array.from(selected);
+    if (arr.length > 5) {
+      alert('Du kan vælge op til 5 interesser');
+      return;
+    }
+    onSave(arr);
+    onClose();
+  };
+
+  const categories = {};
+  interestOptions.forEach(i => {
+    const cat = interestCategories[i] || 'Andet';
+    if (!categories[cat]) categories[cat] = [];
+    categories[cat].push(i);
+  });
+
+  return React.createElement('div', { className:'fixed inset-0 z-50 bg-black/50 flex items-center justify-center overflow-auto' },
+    React.createElement(Card, { className:'bg-white p-6 rounded shadow-xl max-h-[80vh] overflow-y-auto w-full max-w-sm' },
+      React.createElement('h2', { className:'text-xl font-semibold mb-4 text-pink-600 text-center' }, 'Vælg interesser'),
+      Object.entries(categories).map(([cat, opts]) =>
+        React.createElement('div', { key:cat, className:'mb-2' },
+          React.createElement('h3', { className:'font-semibold mb-1' }, cat),
+          opts.map(o =>
+            React.createElement('label', { key:o, className:'block text-sm' },
+              React.createElement('input', { type:'checkbox', className:'mr-2', checked:selected.has(o), onChange:() => toggle(o) }),
+              o
+            )
+          )
+        )
+      ),
+      React.createElement(Button, { className:'w-full bg-pink-500 text-white mt-4', onClick: handleSave }, 'Tilføj'),
+      React.createElement(Button, { className:'w-full mt-2', onClick: onClose }, 'Luk')
+    )
+  );
+}

--- a/src/components/ProfileSettings.jsx
+++ b/src/components/ProfileSettings.jsx
@@ -1,7 +1,7 @@
 import React, { useState, useEffect, useRef } from 'react';
 import Slider from 'rc-slider';
 import 'rc-slider/assets/index.css';
-import { Mic, Camera as CameraIcon, User as UserIcon, Trash2 as TrashIcon, Pencil as EditIcon, Heart, Flag } from 'lucide-react';
+import { Mic, Camera as CameraIcon, User as UserIcon, Trash2 as TrashIcon, Pencil as EditIcon, Heart, Flag, Plus } from 'lucide-react';
 import { Card } from './ui/card.js';
 import { Button } from './ui/button.js';
 import { Input } from './ui/input.js';
@@ -11,6 +11,7 @@ import VideoPreview from './VideoPreview.jsx';
 import ReportOverlay from './ReportOverlay.jsx';
 import { useCollection, db, storage, getDoc, doc, updateDoc, setDoc, deleteDoc, ref, uploadBytes, getDownloadURL, listAll, deleteObject } from '../firebase.js';
 import PurchaseOverlay from './PurchaseOverlay.jsx';
+import InterestsOverlay from './InterestsOverlay.jsx';
 import SnapAudioRecorder from "./SnapAudioRecorder.jsx";
 import SnapVideoRecorder from "./SnapVideoRecorder.jsx";
 import MatchOverlay from './MatchOverlay.jsx';
@@ -27,6 +28,7 @@ export default function ProfileSettings({ userId, ageRange, onChangeAgeRange, pu
   const [showSnapRecorder, setShowSnapRecorder] = useState(false);
   const [showSnapVideoRecorder, setShowSnapVideoRecorder] = useState(false);
   const [showSub, setShowSub] = useState(false);
+  const [showInterests, setShowInterests] = useState(false);
   const [distanceRange, setDistanceRange] = useState([10,25]);
   const [editInfo, setEditInfo] = useState(false);
   const profiles = useCollection('profiles');
@@ -223,6 +225,11 @@ export default function ProfileSettings({ userId, ageRange, onChangeAgeRange, pu
     const updated = (profile.interests || []).filter(i => i !== interest);
     setProfile({ ...profile, interests: updated });
     await updateDoc(doc(db,'profiles',userId), { interests: updated });
+  };
+
+  const handleSaveInterests = async interests => {
+    setProfile({ ...profile, interests });
+    await updateDoc(doc(db,'profiles',userId), { interests });
   };
 
   const handleDistanceRangeChange = async range => {
@@ -545,7 +552,7 @@ export default function ProfileSettings({ userId, ageRange, onChangeAgeRange, pu
     React.createElement(Card, { className: 'p-6 m-4 shadow-xl bg-white/90' }, videoSection),
     React.createElement(Card, { className: 'p-6 m-4 shadow-xl bg-white/90' }, audioSection),
     React.createElement(Card, { className: 'p-6 m-4 shadow-xl bg-white/90' },
-      React.createElement(SectionTitle, { title: t('interests') }),
+      React.createElement(SectionTitle, { title: t('interests'), action: !publicView && React.createElement(Plus, { className:'w-5 h-5 text-gray-500 cursor-pointer', onClick: () => setShowInterests(true) }) }),
       React.createElement('div', { className: 'flex flex-wrap gap-2 mb-2' },
         (profile.interests || []).map(i => {
           const cat = getInterestCategory(i);
@@ -624,6 +631,11 @@ export default function ProfileSettings({ userId, ageRange, onChangeAgeRange, pu
           React.createElement('li', null, '🎙️ Profilbooster: Få dit klip vist tidligere på dagen')
         )
       ),
+    showInterests && React.createElement(InterestsOverlay, {
+        current: profile.interests || [],
+        onSave: handleSaveInterests,
+        onClose: () => setShowInterests(false)
+      }),
     matchedProfile && React.createElement(MatchOverlay, {
         name: matchedProfile.name,
         onClose: () => setMatchedProfile(null)

--- a/src/version.js
+++ b/src/version.js
@@ -1,1 +1,1 @@
-export default '1.0.19';
+export default '1.0.21';


### PR DESCRIPTION
## Summary
- add `InterestsOverlay` component for choosing interests
- show plus icon on profile to open the overlay
- bump version after build

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_6875121fcf28832db2fecdd3e713315d