### PR TITLE
Enhance profile UI contrast

### DIFF
--- a/src/components/DailyDiscovery.jsx
+++ b/src/components/DailyDiscovery.jsx
@@ -108,7 +108,7 @@ export default function DailyDiscovery({ userId, onSelectProfile, ageRange, onOp
       filtered.length ? filtered.map(p => (
         React.createElement('li', {
           key: p.id,
-          className: 'p-4 bg-pink-50 rounded-lg cursor-pointer shadow flex flex-col relative',
+          className: 'p-4 bg-white rounded-lg cursor-pointer shadow-lg border border-gray-200 flex flex-col relative',
           onClick: () => onSelectProfile(p.id)
         },
           React.createElement(Heart, {
@@ -122,7 +122,7 @@ export default function DailyDiscovery({ userId, onSelectProfile, ageRange, onOp
             ),
             React.createElement('div', null,
               React.createElement('p', { className: 'font-medium' }, `${p.name} (${p.birthday ? getAge(p.birthday) : p.age})`),
-              p.clip && React.createElement('p', { className: 'text-sm text-gray-500' }, `“${p.clip}”`)
+              p.clip && React.createElement('p', { className: 'text-sm text-gray-700' }, `“${p.clip}”`)
             )
           ),
         React.createElement('div', { className: 'flex gap-2 mt-2' },
@@ -138,7 +138,7 @@ export default function DailyDiscovery({ userId, onSelectProfile, ageRange, onOp
       scoreProfiles(user, profiles, ageRange).slice(0,3).map(p => (
         React.createElement('li', {
           key: 'best-' + p.id,
-          className: 'p-4 bg-purple-50 rounded-lg cursor-pointer shadow flex flex-col relative',
+          className: 'p-4 bg-white rounded-lg cursor-pointer shadow-lg border border-gray-200 flex flex-col relative',
           onClick: () => onSelectProfile(p.id)
         },
           React.createElement(Heart, {
@@ -152,7 +152,7 @@ export default function DailyDiscovery({ userId, onSelectProfile, ageRange, onOp
             ),
             React.createElement('div', null,
               React.createElement('p', { className: 'font-medium' }, `${p.name}(${p.birthday ? getAge(p.birthday) : p.age})`),
-              p.clip && React.createElement('p', { className: 'text-sm text-gray-500' }, `“${p.clip}”`)
+              p.clip && React.createElement('p', { className: 'text-sm text-gray-700' }, `“${p.clip}”`)
             )
           ),
           React.createElement('div', { className: 'flex gap-2 mt-2' },

--- a/src/components/ProfileSettings.jsx
+++ b/src/components/ProfileSettings.jsx
@@ -559,10 +559,14 @@ export default function ProfileSettings({ userId, ageRange, onChangeAgeRange, pu
           const cat = getInterestCategory(i);
           const exact = viewerInterests.includes(i);
           const sameCat = !exact && viewerCategories.has(cat);
-          const cls = 'px-2 py-1 rounded text-sm ' + (exact ? 'bg-pink-500 text-white' : sameCat ? 'bg-pink-100 text-pink-800' : 'bg-gray-100');
-          const sharedProps = { key: i, className: cls + (!publicView && editInterests ? ' cursor-pointer' : '') };
-          const elProps = publicView || !editInterests ? {} : { onClick: () => handleRemoveInterest(i) };
-          return React.createElement(publicView ? 'span' : 'button', { ...sharedProps, ...elProps }, i);
+          const base = exact ? 'bg-pink-500 text-white' : sameCat ? 'bg-pink-200 text-pink-800' : 'bg-gray-200 text-gray-800';
+          if(publicView || !editInterests){
+            return React.createElement('span', { key:i, className:`px-2 py-1 rounded text-sm ${base}` }, i);
+          }
+          return React.createElement('div', { key:i, className:`px-2 py-1 rounded text-sm flex items-center gap-1 ${base}` },
+            React.createElement('span', null, i),
+            React.createElement(TrashIcon, { className:'w-4 h-4 cursor-pointer', onClick: () => handleRemoveInterest(i) })
+          );
         })
       )
     ),


### PR DESCRIPTION
## Summary
- make daily discovery cards white with stronger shadow
- darken subtitle text to stand out
- show trash icon when editing interests

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68752e97b880832dab6cc1c533fd0dbb