### PR TITLE
Add color theme documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,10 @@ and simple profile management powered by Firebase.
 * Matchlog kan åbnes fra adminområdet
 
 
+## Farvetema
+
+Appen bruger generelt en rød/lyserød farveskala. Adminknapperne er blå, mens premium-funktioner er gule.
+
 ## Getting Started
 
 1. Copy `.env.example` to `.env` and fill in your Firebase credentials.


### PR DESCRIPTION
## Summary
- document the color theme with blue admin buttons and yellow premium features

## Testing
- `npm install`
- `npx parcel build public/index.html --dist-dir dist --public-url ./`


------
https://chatgpt.com/codex/tasks/task_e_68756bfebd1c832dbb96eff0df64c33b