### PR TITLE
Add offline caching for media files

### DIFF
--- a/FEATURES.txt
+++ b/FEATURES.txt
@@ -14,7 +14,7 @@ PWA manifest for standalone installation
 
 Profile view statistics
 
-Profile pictures cached for offline viewing
+Profile pictures, audio clips and video clips cached for offline viewing
 
 Admin mode
 Seed data loader for test profiles with sample clips

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ and simple profile management powered by Firebase.
 * Minimal profile settings and admin mode
 * Preferred languages with option to allow other languages
 * Choose up to five personal interests in profile settings
-* Profile pictures cached for offline viewing
+* Profile pictures, audio clips and video clips cached for offline viewing
 * Premium page showing who liked you (subscription required)
 * Seed data includes 11 mandlige profiler der matcher standardbrugeren så du kan teste premium og ekstra klip
 * Video- og lydklip begrænset til 10 sekunder

--- a/public/service-worker.js
+++ b/public/service-worker.js
@@ -1,7 +1,8 @@
 // Bump the cache name whenever cached files change to ensure
 // clients receive the latest versions.
 const CACHE_NAME = 'videotinder-v2';
-const IMAGE_CACHE = 'image-cache-v1';
+// Cache for images, audio and video so large media files work offline
+const MEDIA_CACHE = 'media-cache-v1';
 const URLS_TO_CACHE = [
   '/',
   '/public/index.html',
@@ -31,9 +32,10 @@ self.addEventListener('activate', event => {
 });
 
 self.addEventListener('fetch', event => {
-  if (event.request.destination === 'image') {
+  const dest = event.request.destination;
+  if (['image', 'video', 'audio'].includes(dest)) {
     event.respondWith(
-      caches.open(IMAGE_CACHE).then(cache =>
+      caches.open(MEDIA_CACHE).then(cache =>
         cache.match(event.request).then(response => {
           if (response) return response;
           return fetch(event.request)


### PR DESCRIPTION
## Summary
- cache images, audio and video in the service worker
- update feature list
- update README instructions

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_6875ea7a2cc4832d8ee963892e4fdf58