### PR TITLE
Rename About button

### DIFF
--- a/src/components/ProfileSettings.jsx
+++ b/src/components/ProfileSettings.jsx
@@ -442,6 +442,12 @@ export default function ProfileSettings({ userId, ageRange, onChangeAgeRange, pu
           className: 'bg-gray-200 text-gray-700 px-4 py-2 rounded',
           onClick: onLogout
         }, 'Logout')
+      ),
+      React.createElement('div', { className: 'mt-4 flex justify-end' },
+        React.createElement(Button, {
+          className: 'bg-pink-500 text-white',
+          onClick: onOpenAbout
+        }, t('about'))
       )
     ),
     React.createElement(Card, { className: 'p-6 m-4 shadow-xl bg-white/90' },
@@ -452,14 +458,6 @@ export default function ProfileSettings({ userId, ageRange, onChangeAgeRange, pu
             onClick: () => setEditInfo(true)
           })
         ) }),
-        !publicView && React.createElement('div', {
-          className: 'mb-4 flex justify-end gap-2'
-        },
-          React.createElement(Button, {
-            className: 'bg-pink-500 text-white',
-            onClick: onOpenAbout
-          }, t('about'))
-        ),
       publicView && onBack && React.createElement(Button, { className: 'mb-4 bg-pink-500 text-white', onClick: onBack }, 'Tilbage'),
       React.createElement('div', { className:'flex items-center mb-4 gap-4' },
         profile.photoURL ?

--- a/src/i18n.js
+++ b/src/i18n.js
@@ -17,7 +17,7 @@ const messages = {
   chat: { en:'Chat', da:'Samtale', sv:'Chat', es:'Chat', fr:'Discussion', de:'Chat' },
   checkInTitle:{ en:'Daily reflection', da:'Dagens refleksion', sv:'Dagens reflektion', es:'Reflexión diaria', fr:'Réflexion du jour', de:'Tägliche Reflexion' },
   profile:{ en:'Profile', da:'Profil', sv:'Profil', es:'Perfil', fr:'Profil', de:'Profil' },
-  about:{ en:'About', da:'Om', sv:'Om', es:'Acerca de', fr:'À propos', de:'Über' },
+  about:{ en:'About RealDate', da:'Om RealDate', sv:'Om RealDate', es:'Acerca de RealDate', fr:'À propos de RealDate', de:'Über RealDate' },
   loadMore:{ en:'Load more', da:'Hent flere...', sv:'Hämta fler...', es:'Cargar más', fr:'Charger plus', de:'Mehr laden' },
   revealBestMatch:{ en:'Reveal best match', da:'Afslør bedste match', sv:'Visa bästa matchen', es:'Revelar mejor pareja', fr:'Révéler le meilleur match', de:'Bestes Match anzeigen' },
   noProfiles:{ en:'No profiles found', da:'Ingen profiler fundet', sv:'Inga profiler', es:'No hay perfiles', fr:'Aucun profil', de:'Keine Profile gefunden'},


### PR DESCRIPTION
## Summary
- rename i18n 'about' string to 'About RealDate'
- move about button to the top card below "View public profile"/"Logout"

## Testing
- `npm install`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6875ed46e44c832d9e1d39aea7313613