### PR TITLE
Implement photo deletion check

### DIFF
--- a/src/components/ProfileSettings.jsx
+++ b/src/components/ProfileSettings.jsx
@@ -90,6 +90,10 @@ export default function ProfileSettings({ userId, ageRange, onChangeAgeRange, pu
 
   const uploadPhoto = async file => {
     if(!file) return;
+    if(profile.photoURL){
+      alert(t('deleteOldPhotoFirst'));
+      return;
+    }
     const storageRef = ref(storage, `profiles/${userId}/photo-${Date.now()}-${file.name}`);
     await uploadBytes(storageRef, file);
     const url = await getDownloadURL(storageRef);
@@ -132,16 +136,6 @@ export default function ProfileSettings({ userId, ageRange, onChangeAgeRange, pu
     };
   });
 
-  const replaceFile = async (file, field, index) => {
-    if(!file) return;
-    const storageRef = ref(storage, `profiles/${userId}/${field}-${Date.now()}-${file.name}`);
-    await uploadBytes(storageRef, file);
-    const url = await getDownloadURL(storageRef);
-    const updated = [...(profile[field] || [])];
-    updated[index] = { url, lang: profile.language || 'en', uploadedAt: new Date().toISOString() };
-    await updateDoc(doc(db,'profiles',userId), { [field]: updated });
-    setProfile({...profile, [field]: updated});
-  };
 
   const deleteFile = async (field, index) => {
     const updated = [...(profile[field] || [])];

--- a/src/i18n.js
+++ b/src/i18n.js
@@ -48,7 +48,8 @@ const messages = {
   videoCtaTitle:{ en:'Add video clips', da:'Tilføj videoer', sv:'Lägg till videoklipp', es:'Añadir videoclips', fr:'Ajouter des clips vidéo', de:'Videoclips hinzufügen' },
   videoCtaDesc:{ en:'Upload short clips to showcase yourself', da:'Upload korte videoklip for at vise dig frem', sv:'Ladda upp korta klipp för att visa dig', es:'Sube clips cortos para mostrarte', fr:'Téléchargez de courts clips pour vous présenter', de:'Lade kurze Clips hoch, um dich zu zeigen' },
   audioCtaTitle:{ en:'Add audio clips', da:'Tilføj lyde', sv:'Lägg till ljudklipp', es:'Añadir clips de audio', fr:'Ajouter des clips audio', de:'Audioclips hinzufügen' },
-  audioCtaDesc:{ en:'Upload short audio clips to share your voice', da:'Upload korte lydklip for at dele din stemme', sv:'Ladda upp korta lydklipp för att dela din röst', es:'Sube clips de audio para compartir tu voz', fr:'Téléchargez de courts clips audio pour partager votre voix', de:'Lade kurze Audioclips hoch, um deine Stimme zu teilen' }
+  audioCtaDesc:{ en:'Upload short audio clips to share your voice', da:'Upload korte lydklip for at dele din stemme', sv:'Ladda upp korta lydklipp för att dela din röst', es:'Sube clips de audio para compartir tu voz', fr:'Téléchargez de courts clips audio pour partager votre voix', de:'Lade kurze Audioclips hoch, um deine Stimme zu teilen' },
+  deleteOldPhotoFirst:{ en:"Delete the old photo before uploading a new one", da:"Slet det gamle billede f\u00f8r du uploader et nyt" }
 };
 
 const LangContext = createContext({ lang: 'en', setLang: () => {} });


### PR DESCRIPTION
## Summary
- require old photo to be deleted before uploading a new one in profile settings
- remove unused replaceFile helper
- add Danish/English message for delete confirmation

## Testing
- `npm install`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_6875fe687564832d9a9783c0cf00c5ea