### PR TITLE
Handle missing media timestamps

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "realdate",
-  "version": "1.0.24",
+  "version": "1.0.26",
   "description": "A minimal React PWA for swiping short videos and speed dating.",
   "scripts": {
     "start": "npx serve .",

--- a/src/RealDateApp.jsx
+++ b/src/RealDateApp.jsx
@@ -81,18 +81,18 @@ export default function RealDateApp() {
 
   useEffect(() => {
     profiles.forEach(p => {
-      if (p.photoURL && p.photoUploadedAt) {
+      if (p.photoURL) {
         cacheMediaIfNewer(p.photoURL, p.photoUploadedAt);
       }
       (p.audioClips || []).forEach(a => {
         const url = a && a.url ? a.url : a;
         const ts = a && a.uploadedAt;
-        if (url && ts) cacheMediaIfNewer(url, ts);
+        if (url) cacheMediaIfNewer(url, ts);
       });
       (p.videoClips || []).forEach(v => {
         const url = v && v.url ? v.url : v;
         const ts = v && v.uploadedAt;
-        if (url && ts) cacheMediaIfNewer(url, ts);
+        if (url) cacheMediaIfNewer(url, ts);
       });
     });
   }, [profiles]);

--- a/src/cacheMedia.js
+++ b/src/cacheMedia.js
@@ -1,15 +1,18 @@
 export async function cacheMediaIfNewer(url, uploadedAt) {
-  if (typeof window === 'undefined' || !('caches' in window)) return;
-  if (!url || !uploadedAt) return;
+  if (typeof window === 'undefined' || !('caches' in window) || !url) return;
   const key = `media:${url}`;
+  let ts = uploadedAt;
+  if (!ts) {
+    ts = localStorage.getItem(key) || new Date().toISOString();
+  }
   const stored = localStorage.getItem(key);
-  if (stored === uploadedAt) return;
+  if (stored === ts) return;
   try {
     const resp = await fetch(url);
     if (!resp.ok) throw new Error('Failed request');
     const cache = await caches.open('media-cache-v1');
     await cache.put(url, resp.clone());
-    localStorage.setItem(key, uploadedAt);
+    localStorage.setItem(key, ts);
   } catch (err) {
     console.error('Failed to cache media', err);
   }

--- a/src/version.js
+++ b/src/version.js
@@ -1,1 +1,1 @@
-export default '1.0.24';
+export default '1.0.26';


### PR DESCRIPTION
## Summary
- default to stored timestamp or current time when caching media
- cache media even when timestamps are missing
- bump version to 1.0.26

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_6875ff6912b8832d8488674ff783e14e