### PR TITLE
Add simple WebRTC call screen

### DIFF
--- a/src/components/ChatScreen.jsx
+++ b/src/components/ChatScreen.jsx
@@ -7,6 +7,7 @@ import { Textarea } from './ui/textarea.js';
 import SectionTitle from './SectionTitle.jsx';
 import { useT } from '../i18n.js';
 import { useCollection, db, doc, updateDoc, deleteDoc, arrayUnion } from '../firebase.js';
+import VideoCallScreen from './VideoCallScreen.jsx';
 
 export default function ChatScreen({ userId }) {
   const profiles = useCollection('profiles');
@@ -15,6 +16,7 @@ export default function ChatScreen({ userId }) {
   const profileMap = Object.fromEntries(profiles.map(p => [p.id, p]));
   const [active, setActive] = useState(null);
   const [text, setText] = useState('');
+  const [inCall, setInCall] = useState(false);
   const messagesRef = useRef(null);
   const textareaRef = useRef(null);
 
@@ -86,24 +88,27 @@ export default function ChatScreen({ userId }) {
       deleteDoc(doc(db,'matches',id1)),
       deleteDoc(doc(db,'matches',id2))
     ]);
+    setInCall(false);
     setActive(null);
   };
 
   const activeProfile = active ? profileMap[active.profileId] || {} : null;
-  const userProfile = profileMap[userId] || {};
 
   return React.createElement(Card, { className: 'p-6 m-4 shadow-xl bg-white/90 flex flex-col h-full flex-1 touch-none', style:{maxHeight:'calc(100vh - 10rem)', overflow:'hidden', touchAction:'none'} },
     React.createElement(SectionTitle, {
       title: t('chat'),
-      action: active && React.createElement(Button, { className: 'flex items-center gap-1', onClick: () => setActive(null) },
+      action: active && React.createElement(Button, { className: 'flex items-center gap-1', onClick: () => { setInCall(false); setActive(null); } },
         React.createElement(ArrowLeft, { className: 'w-4 h-4' }), 'Tilbage')
     }),
-    active ? (
+    inCall ? (
+      React.createElement(VideoCallScreen, { matchId: active.id, userId, onEnd: () => setInCall(false) })
+    ) : active ? (
       React.createElement(React.Fragment, null,
         activeProfile.photoURL ?
           React.createElement('img', { src: activeProfile.photoURL, className: 'w-24 h-24 rounded-full object-cover self-center mb-2' }) :
           React.createElement(UserIcon, { className: 'w-24 h-24 text-pink-500 self-center mb-2' }),
         React.createElement('p', { className: 'text-center font-medium mb-2' }, `${activeProfile.name || ''}, ${activeProfile.birthday ? getAge(activeProfile.birthday) : activeProfile.age || ''}, ${activeProfile.city || ''}`),
+        React.createElement(Button, { className: 'bg-pink-500 text-white mb-2 self-center', onClick: () => setInCall(true) }, 'Foretag opkald'),
         React.createElement('div', { ref: messagesRef, className: 'flex-1 bg-gray-100 p-4 rounded space-y-3 flex flex-col overflow-y-auto' },
           (active.messages || []).map((m,i) => {
             const fromSelf = m.from === userId;

--- a/src/components/VideoCallScreen.jsx
+++ b/src/components/VideoCallScreen.jsx
@@ -1,0 +1,99 @@
+import React, { useEffect, useRef } from 'react';
+import { db } from '../firebase.js';
+import { collection, doc, setDoc, getDoc, updateDoc, addDoc, onSnapshot } from 'firebase/firestore';
+
+export default function VideoCallScreen({ matchId, userId, onEnd }) {
+  const localVideoRef = useRef(null);
+  const remoteVideoRef = useRef(null);
+  const pcRef = useRef(null);
+
+  useEffect(() => {
+    const pc = new RTCPeerConnection({
+      iceServers: [{ urls: 'stun:stun.l.google.com:19302' }]
+    });
+    pcRef.current = pc;
+
+    const callDoc = doc(db, 'calls', matchId);
+    const offerCandidates = collection(callDoc, 'offerCandidates');
+    const answerCandidates = collection(callDoc, 'answerCandidates');
+
+    let unsubAnsCand;
+    let unsubOffer;
+
+    const init = async () => {
+      const localStream = await navigator.mediaDevices.getUserMedia({ video: true, audio: true });
+      localVideoRef.current.srcObject = localStream;
+      localStream.getTracks().forEach(t => pc.addTrack(t, localStream));
+
+      const remoteStream = new MediaStream();
+      remoteVideoRef.current.srcObject = remoteStream;
+      pc.ontrack = event => {
+        event.streams[0].getTracks().forEach(track => remoteStream.addTrack(track));
+      };
+
+      const snap = await getDoc(callDoc);
+      if (snap.exists()) {
+        // Join call
+        pc.onicecandidate = e => {
+          if (e.candidate) addDoc(answerCandidates, e.candidate.toJSON());
+        };
+
+        onSnapshot(offerCandidates, snapshot => {
+          snapshot.docChanges().forEach(change => {
+            if (change.type === 'added') {
+              pc.addIceCandidate(new RTCIceCandidate(change.doc.data()));
+            }
+          });
+        });
+
+        const data = snap.data();
+        await pc.setRemoteDescription(new RTCSessionDescription(data.offer));
+        const answer = await pc.createAnswer();
+        await pc.setLocalDescription(answer);
+        await updateDoc(callDoc, { answer: { type: answer.type, sdp: answer.sdp } });
+      } else {
+        // Create call
+        pc.onicecandidate = e => {
+          if (e.candidate) addDoc(offerCandidates, e.candidate.toJSON());
+        };
+
+        unsubAnsCand = onSnapshot(answerCandidates, snapshot => {
+          snapshot.docChanges().forEach(change => {
+            if (change.type === 'added') {
+              pc.addIceCandidate(new RTCIceCandidate(change.doc.data()));
+            }
+          });
+        });
+
+        const offer = await pc.createOffer();
+        await pc.setLocalDescription(offer);
+        await setDoc(callDoc, { offer: { type: offer.type, sdp: offer.sdp }, from: userId });
+
+        unsubOffer = onSnapshot(callDoc, snapshot => {
+          const data = snapshot.data();
+          if (data?.answer && !pc.currentRemoteDescription) {
+            pc.setRemoteDescription(new RTCSessionDescription(data.answer));
+          }
+        });
+      }
+    };
+
+    init();
+
+    return () => {
+      pc.getSenders().forEach(s => s.track && s.track.stop());
+      pc.close();
+      unsubAnsCand && unsubAnsCand();
+      unsubOffer && unsubOffer();
+      onEnd && onEnd();
+    };
+  }, [matchId, userId, onEnd]);
+
+  return (
+    React.createElement('div', { className: 'speed-date' },
+      React.createElement('video', { ref: remoteVideoRef, className: 'remote-video', autoPlay: true, playsInline: true }),
+      React.createElement('video', { ref: localVideoRef, className: 'local-video', autoPlay: true, muted: true, playsInline: true }),
+      React.createElement('button', { className: 'end-call-button', onClick: onEnd }, 'Afslut')
+    )
+  );
+}


### PR DESCRIPTION
## Summary
- add new `VideoCallScreen` component using Firestore for WebRTC signalling
- integrate video calling into `ChatScreen`

## Testing
- `npm install`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68760d5bc1f8832d87b043dc598a37c1