### PR TITLE
Add admin call log

### DIFF
--- a/src/RealDateApp.jsx
+++ b/src/RealDateApp.jsx
@@ -13,6 +13,7 @@ import StatsScreen from './components/StatsScreen.jsx';
 import BugReportsScreen from './components/BugReportsScreen.jsx';
 import MatchLogScreen from './components/MatchLogScreen.jsx';
 import ScoreLogScreen from './components/ScoreLogScreen.jsx';
+import ActiveCallsScreen from './components/ActiveCallsScreen.jsx';
 import ReportedContentScreen from './components/ReportedContentScreen.jsx';
 import AboutScreen from './components/AboutScreen.jsx';
 import { useCollection, requestNotificationPermission, db, doc, updateDoc, increment } from './firebase.js';
@@ -161,10 +162,11 @@ export default function RealDateApp() {
             onOpenAbout: ()=>setTab('about')
           }),
           tab==='likes' && React.createElement(LikesScreen, { userId, onBack: ()=>setTab('discovery'), onSelectProfile: selectProfile }),
-          tab==='admin' && React.createElement(AdminScreen, { onOpenStats: ()=>setTab('stats'), onOpenBugReports: ()=>setTab('bugs'), onOpenMatchLog: ()=>setTab('matchlog'), onOpenScoreLog: ()=>setTab('scorelog'), onOpenReports: ()=>setTab('reports'), profiles, userId, onSwitchProfile: id=>setUserId(id) }),
+          tab==='admin' && React.createElement(AdminScreen, { onOpenStats: ()=>setTab('stats'), onOpenBugReports: ()=>setTab('bugs'), onOpenMatchLog: ()=>setTab('matchlog'), onOpenScoreLog: ()=>setTab('scorelog'), onOpenReports: ()=>setTab('reports'), onOpenCallLog: ()=>setTab('calllog'), profiles, userId, onSwitchProfile: id=>setUserId(id) }),
           tab==='stats' && React.createElement(StatsScreen, { onBack: ()=>setTab('admin') }),
           tab==='matchlog' && React.createElement(MatchLogScreen, { onBack: ()=>setTab('admin') }),
           tab==='scorelog' && React.createElement(ScoreLogScreen, { onBack: ()=>setTab('admin') }),
+          tab==='calllog' && React.createElement(ActiveCallsScreen, { onBack: ()=>setTab('admin') }),
           tab==='reports' && React.createElement(ReportedContentScreen, { onBack: ()=>setTab('admin') }),
           tab==='bugs' && React.createElement(BugReportsScreen, { onBack: ()=>setTab('admin') }),
           tab==='about' && React.createElement(AboutScreen, { onOpenAdmin: ()=>setTab('admin') })

--- a/src/components/ActiveCallsScreen.jsx
+++ b/src/components/ActiveCallsScreen.jsx
@@ -1,0 +1,46 @@
+import React from 'react';
+import { Card } from './ui/card.js';
+import { Button } from './ui/button.js';
+import SectionTitle from './SectionTitle.jsx';
+import { useCollection } from '../firebase.js';
+
+export default function ActiveCallsScreen({ onBack }) {
+  const calls = useCollection('calls');
+  const profiles = useCollection('profiles');
+  const tokens = useCollection('pushTokens');
+
+  const profileMap = Object.fromEntries(profiles.map(p => [p.id, p]));
+  const tokensByUser = tokens.reduce((acc, t) => {
+    if (!acc[t.userId]) acc[t.userId] = [];
+    acc[t.userId].push(t.id);
+    return acc;
+  }, {});
+
+  const formatName = id => profileMap[id]?.name || id;
+  const renderToken = id => tokensByUser[id]?.join(', ') || 'N/A';
+
+  return React.createElement(Card, { className: 'p-6 m-4 shadow-xl bg-white/90' },
+    React.createElement(SectionTitle, {
+      title: 'Aktive opkald',
+      colorClass: 'text-blue-600',
+      action: React.createElement(Button, { onClick: onBack }, 'Tilbage')
+    }),
+    calls.length ? (
+      React.createElement('ul', { className: 'space-y-4 mt-4 overflow-y-auto max-h-[70vh]' },
+        calls.map(call => {
+          const ids = call.id.split('-');
+          const [id1, id2] = ids;
+          return React.createElement('li', { key: call.id, className: 'border p-2 rounded' },
+            React.createElement('div', null, `${formatName(id1)} (${id1})`),
+            React.createElement('div', { className: 'text-xs text-gray-600 break-all' }, 'Token: ' + renderToken(id1)),
+            React.createElement('div', { className: 'mt-2' }, `${formatName(id2)} (${id2})`),
+            React.createElement('div', { className: 'text-xs text-gray-600 break-all' }, 'Token: ' + renderToken(id2)),
+            call.from && React.createElement('div', { className: 'text-xs text-gray-500 mt-1' }, `Startet af: ${formatName(call.from)}`)
+          );
+        })
+      )
+    ) : (
+      React.createElement('p', { className: 'text-center mt-4 text-gray-500' }, 'Ingen aktive opkald')
+    )
+  );
+}

--- a/src/components/AdminScreen.jsx
+++ b/src/components/AdminScreen.jsx
@@ -6,7 +6,7 @@ import SectionTitle from './SectionTitle.jsx';
 import seedData from '../seedData.js';
 
 
-export default function AdminScreen({ onOpenStats, onOpenBugReports, onOpenMatchLog, onOpenScoreLog, onOpenReports, profiles = [], userId, onSwitchProfile }) {
+export default function AdminScreen({ onOpenStats, onOpenBugReports, onOpenMatchLog, onOpenScoreLog, onOpenReports, onOpenCallLog, profiles = [], userId, onSwitchProfile }) {
 
   const { lang, setLang } = useLang();
   const t = useT();
@@ -55,6 +55,8 @@ export default function AdminScreen({ onOpenStats, onOpenBugReports, onOpenMatch
       React.createElement(Button, { className: 'mt-2 bg-blue-500 text-white px-4 py-2 rounded', onClick: onOpenMatchLog }, 'Se matchlog'),
     React.createElement('h3', { className: 'text-xl font-semibold mb-2 mt-4 text-blue-600' }, 'Score log'),
       React.createElement(Button, { className: 'mt-2 bg-blue-500 text-white px-4 py-2 rounded', onClick: onOpenScoreLog }, 'Se score log'),
+    React.createElement('h3', { className: 'text-xl font-semibold mb-2 mt-4 text-blue-600' }, 'Aktive opkald'),
+      React.createElement(Button, { className: 'mt-2 bg-blue-500 text-white px-4 py-2 rounded', onClick: onOpenCallLog }, 'Se aktive opkald'),
     React.createElement('h3', { className: 'text-xl font-semibold mb-2 mt-4 text-blue-600' }, 'Anmeldt indhold'),
       React.createElement(Button, { className: 'mt-2 bg-blue-500 text-white px-4 py-2 rounded', onClick: onOpenReports }, 'Se anmeldt indhold'),
     React.createElement('h3', { className: 'text-xl font-semibold mb-2 mt-4 text-blue-600' }, 'Fejlmeldinger'),


### PR DESCRIPTION
## Summary
- show active calls with user names and tokens
- add button in admin to view the call log
- link new screen from main app

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_6876405882bc832dbe161a4e2157b430