### PR TITLE
Add admin feature test screen

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "realdate",
-  "version": "1.0.24",
+  "version": "1.0.27",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "realdate",
-      "version": "1.0.24",
+      "version": "1.0.27",
       "dependencies": {
         "firebase": "^9.23.0",
         "firebase-admin": "^11.10.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "realdate",
-  "version": "1.0.26",
+  "version": "1.0.28",
   "description": "A minimal React PWA for swiping short videos and speed dating.",
   "scripts": {
     "start": "npx serve .",

--- a/src/RealDateApp.jsx
+++ b/src/RealDateApp.jsx
@@ -16,6 +16,7 @@ import ScoreLogScreen from './components/ScoreLogScreen.jsx';
 import ActiveCallsScreen from './components/ActiveCallsScreen.jsx';
 import ReportedContentScreen from './components/ReportedContentScreen.jsx';
 import AboutScreen from './components/AboutScreen.jsx';
+import FunctionTestScreen from './components/FunctionTestScreen.jsx';
 import { useCollection, requestNotificationPermission, db, doc, updateDoc, increment } from './firebase.js';
 import { cacheMediaIfNewer } from './cacheMedia.js';
 
@@ -162,13 +163,14 @@ export default function RealDateApp() {
             onOpenAbout: ()=>setTab('about')
           }),
           tab==='likes' && React.createElement(LikesScreen, { userId, onBack: ()=>setTab('discovery'), onSelectProfile: selectProfile }),
-          tab==='admin' && React.createElement(AdminScreen, { onOpenStats: ()=>setTab('stats'), onOpenBugReports: ()=>setTab('bugs'), onOpenMatchLog: ()=>setTab('matchlog'), onOpenScoreLog: ()=>setTab('scorelog'), onOpenReports: ()=>setTab('reports'), onOpenCallLog: ()=>setTab('calllog'), profiles, userId, onSwitchProfile: id=>setUserId(id) }),
+          tab==='admin' && React.createElement(AdminScreen, { onOpenStats: ()=>setTab('stats'), onOpenBugReports: ()=>setTab('bugs'), onOpenMatchLog: ()=>setTab('matchlog'), onOpenScoreLog: ()=>setTab('scorelog'), onOpenReports: ()=>setTab('reports'), onOpenCallLog: ()=>setTab('calllog'), onOpenFunctionTest: ()=>setTab('functiontest'), profiles, userId, onSwitchProfile: id=>setUserId(id) }),
           tab==='stats' && React.createElement(StatsScreen, { onBack: ()=>setTab('admin') }),
           tab==='matchlog' && React.createElement(MatchLogScreen, { onBack: ()=>setTab('admin') }),
           tab==='scorelog' && React.createElement(ScoreLogScreen, { onBack: ()=>setTab('admin') }),
           tab==='calllog' && React.createElement(ActiveCallsScreen, { onBack: ()=>setTab('admin') }),
           tab==='reports' && React.createElement(ReportedContentScreen, { onBack: ()=>setTab('admin') }),
           tab==='bugs' && React.createElement(BugReportsScreen, { onBack: ()=>setTab('admin') }),
+          tab==='functiontest' && React.createElement(FunctionTestScreen, { onBack: ()=>setTab('admin') }),
           tab==='about' && React.createElement(AboutScreen, { onOpenAdmin: ()=>setTab('admin') })
         )
     ),

--- a/src/components/AdminScreen.jsx
+++ b/src/components/AdminScreen.jsx
@@ -7,7 +7,7 @@ import seedData from '../seedData.js';
 import { db, updateDoc, doc } from '../firebase.js';
 
 
-export default function AdminScreen({ onOpenStats, onOpenBugReports, onOpenMatchLog, onOpenScoreLog, onOpenReports, onOpenCallLog, profiles = [], userId, onSwitchProfile }) {
+export default function AdminScreen({ onOpenStats, onOpenBugReports, onOpenMatchLog, onOpenScoreLog, onOpenReports, onOpenCallLog, onOpenFunctionTest, profiles = [], userId, onSwitchProfile }) {
 
   const { lang, setLang } = useLang();
   const t = useT();
@@ -69,6 +69,8 @@ export default function AdminScreen({ onOpenStats, onOpenBugReports, onOpenMatch
     React.createElement('h3', { className: 'text-xl font-semibold mb-2 mt-4 text-blue-600' }, 'Anmeldt indhold'),
       React.createElement(Button, { className: 'mt-2 bg-blue-500 text-white px-4 py-2 rounded', onClick: onOpenReports }, 'Se anmeldt indhold'),
     React.createElement('h3', { className: 'text-xl font-semibold mb-2 mt-4 text-blue-600' }, 'Fejlmeldinger'),
-      React.createElement(Button, { className: 'mt-2 bg-blue-500 text-white px-4 py-2 rounded', onClick: onOpenBugReports }, 'Se alle fejlmeldinger')
+      React.createElement(Button, { className: 'mt-2 bg-blue-500 text-white px-4 py-2 rounded', onClick: onOpenBugReports }, 'Se alle fejlmeldinger'),
+    React.createElement('h3', { className: 'text-xl font-semibold mb-2 mt-4 text-blue-600' }, 'Funktionstest'),
+      React.createElement(Button, { className: 'mt-2 bg-blue-500 text-white px-4 py-2 rounded', onClick: onOpenFunctionTest }, 'Åbn funktionstest')
   );
 }

--- a/src/components/FunctionTestScreen.jsx
+++ b/src/components/FunctionTestScreen.jsx
@@ -1,0 +1,52 @@
+import React, { useState } from 'react';
+import { Card } from './ui/card.js';
+import { Button } from './ui/button.js';
+import SectionTitle from './SectionTitle.jsx';
+
+const features = [
+  'Daily discovery of short video clips (up to 3 or 6 with subscription)',
+  'Option to buy 3 extra clips for the day',
+  'Monthly subscriptions with visible expiration date',
+  'Basic chat between matched profiles with option to unmatch',
+  'Improved chat layout with timestamps',
+  'Celebration overlay when two profiles match',
+  'Calendar for daily reflections',
+  'Minimal profile settings and admin mode',
+  'Preferred languages with option to allow other languages',
+  'Choose up to five personal interests in profile settings',
+  'Profile pictures, audio clips and video clips cached for offline viewing',
+  'Premium page showing who liked you (subscription required)',
+  'Seed data includes 11 test profiles matching the default user',
+  'Video and audio clips limited to 10 seconds',
+  'Countdown animation during recording',
+  'Daily stats saved automatically and shown as graphs in admin',
+  'Statistics on how often profiles are opened',
+  'Graph of number of open bugs per day',
+  'Match log accessible from admin'
+];
+
+export default function FunctionTestScreen({ onBack }) {
+  const [results, setResults] = useState(() =>
+    Object.fromEntries(features.map((_, i) => [i, { status: '', comment: '' }]))
+  );
+
+  const update = (index, field, value) => {
+    setResults(r => ({ ...r, [index]: { ...r[index], [field]: value } }));
+  };
+
+  return React.createElement(Card, { className:'p-6 m-4 shadow-xl bg-white/90' },
+    React.createElement(SectionTitle, { title:'Funktionstest', colorClass:'text-blue-600', action: React.createElement(Button, { onClick: onBack }, 'Tilbage') }),
+    React.createElement('ul', { className:'space-y-4 mt-4 overflow-y-auto max-h-[70vh]' },
+      features.map((f, i) =>
+        React.createElement('li', { key:i, className:'border p-2 rounded' },
+          React.createElement('div', { className:'font-medium mb-1' }, f),
+          React.createElement('div', { className:'flex space-x-2 mb-1' },
+            React.createElement(Button, { className:`px-2 py-1 rounded ${results[i].status==='ok' ? 'bg-green-500 text-white' : 'bg-gray-200'}`, onClick:() => update(i,'status',results[i].status==='ok'?'':'ok') }, 'OK'),
+            React.createElement(Button, { className:`px-2 py-1 rounded ${results[i].status==='fail' ? 'bg-red-500 text-white' : 'bg-gray-200'}`, onClick:() => update(i,'status',results[i].status==='fail'?'':'fail') }, 'Fejl')
+          ),
+          React.createElement('textarea', { className:'w-full border p-1 text-sm', placeholder:'Kommentar', value:results[i].comment, onChange:e=>update(i,'comment',e.target.value) })
+        )
+      )
+    )
+  );
+}

--- a/src/version.js
+++ b/src/version.js
@@ -1,1 +1,1 @@
-export default '1.0.26';
+export default '1.0.28';


### PR DESCRIPTION
## Summary
- add FunctionTestScreen for testing each feature
- open the new screen from AdminScreen
- wire up FunctionTestScreen in RealDateApp

## Testing
- `npm install`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68765bb25050832d9cecd09b86ed47cd