### PR TITLE
Add email privacy notice

### DIFF
--- a/src/components/ProfileSettings.jsx
+++ b/src/components/ProfileSettings.jsx
@@ -552,6 +552,7 @@ export default function ProfileSettings({ userId, ageRange, onChangeAgeRange, pu
             name:'email',
             autoComplete:'email'
           }),
+          React.createElement('p', { className:'text-xs text-gray-500 mt-1 mb-2' }, t('emailPrivate')),
           React.createElement(Button, {
             className:'bg-pink-500 text-white w-full',
             onClick: () => setEditInfo(false)

--- a/src/components/WelcomeScreen.jsx
+++ b/src/components/WelcomeScreen.jsx
@@ -113,6 +113,9 @@ export default function WelcomeScreen({ onLogin }) {
           name: 'email',
           autoComplete: 'email'
         }),
+        React.createElement('p', {
+          className:'text-xs text-gray-500 mb-2'
+        }, t('emailPrivate')),
         React.createElement('label', { className:'block mb-1' }, t('gender')),
         React.createElement('select', {
           className: 'border p-2 mb-4 w-full',

--- a/src/i18n.js
+++ b/src/i18n.js
@@ -39,6 +39,7 @@ const messages = {
   city:{ en:'City', da:'By', sv:'Stad', es:'Ciudad', fr:'Ville', de:'Stadt' },
   birthday:{ en:'Birthday', da:'Fødselsdag', sv:'Födelsedag', es:'Cumpleaños', fr:'Anniversaire', de:'Geburtstag' },
   email:{ en:'Email', da:'E-mail', sv:'E-post', es:'Correo', fr:'E-mail', de:'E-Mail' },
+  emailPrivate:{ en:'Your email address is only visible to you', da:'Din e-mailadresse kan kun ses af dig selv', sv:'Din e-postadress kan bara ses av dig själv', es:'Tu correo electrónico solo es visible para ti', fr:"Votre adresse e-mail n'est visible que par vous", de:'Deine E-Mail-Adresse ist nur für dich sichtbar' },
   chooseBirthday:{ en:'Select your birthday', da:'Vælg din fødselsdag', sv:'Välj din födelsedag', es:'Selecciona tu cumpleaños', fr:'Sélectionnez votre anniversaire', de:'Wähle deinen Geburtstag' },
   gender:{ en:'Gender', da:'Køn', sv:'Kön', es:'Género', fr:'Genre', de:'Geschlecht' },
   loginCtaTitle:{ en:"Already have a profile?", da:"Har du en profil?", sv:"Har du en profil?", es:"¿Ya tienes perfil?", fr:"Vous avez déjà un profil ?", de:"Hast du ein Profil?" },


### PR DESCRIPTION
## Summary
- show a note that the email address is only visible to the user
- add translation for the new email privacy string

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68769bf04f8c832d83bcc2f0c205537b