### PR TITLE
Move admin shortcut to header

### DIFF
--- a/src/RealDateApp.jsx
+++ b/src/RealDateApp.jsx
@@ -1,6 +1,6 @@
 import React, { useState, useEffect } from 'react';
 import { LanguageProvider } from './i18n.js';
-import { Home as HomeIcon, User as UserIcon, MessageCircle as ChatIcon, CalendarDays, Heart } from 'lucide-react';
+import { Home as HomeIcon, User as UserIcon, MessageCircle as ChatIcon, CalendarDays, Heart, Shield } from 'lucide-react';
 import WelcomeScreen from './components/WelcomeScreen.jsx';
 import DailyDiscovery from './components/DailyDiscovery.jsx';
 import LikesScreen from './components/LikesScreen.jsx';
@@ -124,6 +124,12 @@ export default function RealDateApp() {
       className: 'p-4 bg-pink-600 text-white text-center font-bold fixed top-0 left-0 right-0 z-10',
       style: { paddingTop: 'calc(env(safe-area-inset-top, 0px) + 1rem)' }
     },
+      userId && React.createElement('div', {
+        className: 'absolute top-1/2 left-4 -translate-y-1/2 cursor-pointer',
+        onClick: () => setTab('admin')
+      },
+        React.createElement(Shield, { className: 'w-6 h-6 text-white' })
+      ),
       'RealDate',
       userId && React.createElement('div', {
         className: 'absolute top-1/2 right-4 -translate-y-1/2 cursor-pointer',
@@ -171,7 +177,7 @@ export default function RealDateApp() {
           tab==='reports' && React.createElement(ReportedContentScreen, { onBack: ()=>setTab('admin') }),
           tab==='bugs' && React.createElement(BugReportsScreen, { onBack: ()=>setTab('admin') }),
           tab==='functiontest' && React.createElement(FunctionTestScreen, { onBack: ()=>setTab('admin') }),
-          tab==='about' && React.createElement(AboutScreen, { onOpenAdmin: ()=>setTab('admin') })
+          tab==='about' && React.createElement(AboutScreen, null)
         )
     ),
     React.createElement('div', {

--- a/src/components/AboutScreen.jsx
+++ b/src/components/AboutScreen.jsx
@@ -4,7 +4,7 @@ import { Button } from './ui/button.js';
 import BugReportOverlay from './BugReportOverlay.jsx';
 import version from '../version.js';
 
-export default function AboutScreen({ onOpenAdmin }) {
+export default function AboutScreen() {
   const [showReport, setShowReport] = useState(false);
   return React.createElement(React.Fragment, null,
     React.createElement(Card, { className: 'p-6 m-4 shadow-xl bg-white/90' },
@@ -14,8 +14,7 @@ export default function AboutScreen({ onOpenAdmin }) {
         + 'RealDate er for dig, der søger noget ægte og meningsfuldt. Tag det stille og roligt, og find den forbindelse, der virkelig betyder noget.'
       ),
       React.createElement('p', { className: 'text-gray-500 text-sm text-center mb-4' }, `Version ${version}`),
-      React.createElement(Button, { className: 'bg-pink-500 text-white w-full mb-2', onClick: () => setShowReport(true) }, 'Fejlmeld'),
-      onOpenAdmin && React.createElement(Button, { className: 'bg-blue-500 hover:bg-blue-600 text-white mt-2 w-full', onClick: onOpenAdmin }, 'Admin'),
+      React.createElement(Button, { className: 'bg-pink-500 text-white w-full mb-2', onClick: () => setShowReport(true) }, 'Fejlmeld')
     ),
     showReport && React.createElement(BugReportOverlay, { onClose: () => setShowReport(false) })
   );


### PR DESCRIPTION
## Summary
- relocate admin link from the About page
- add admin shield button in the top bar

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_6876b421c40c832d9af7512b1ca0d62a