### PR TITLE
Implement Netlify-based push notification credentials

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,10 +95,10 @@ The profile filtering logic used on the Daily Discovery page lives in `src/selec
 ## Push Notifications
 
 This project uses Firebase Cloud Messaging to deliver updates. Notifications are
-sent using the HTTP **v1** API, authenticated with a service account. Provide
-the path to your service account JSON in the `GOOGLE_APPLICATION_CREDENTIALS`
-environment variable when sending messages from the server. The legacy
-`FCM_SERVER_KEY` is no longer used.
+sent using the HTTP **v1** API, authenticated with a service account. On
+Netlify you can either provide the path to your service account JSON via the
+`GOOGLE_APPLICATION_CREDENTIALS` environment variable or store the JSON itself in
+`FIREBASE_SERVICE_ACCOUNT_JSON`. The legacy `FCM_SERVER_KEY` is no longer used.
 
 In this repository, a Netlify Function (`netlify/functions/send-push.js`) handles
 delivery. The function reads stored push tokens from Firestore and uses the

--- a/netlify/functions/send-push.js
+++ b/netlify/functions/send-push.js
@@ -1,8 +1,11 @@
 const admin = require('firebase-admin');
 
 if (!admin.apps.length) {
+  const cred = process.env.FIREBASE_SERVICE_ACCOUNT_JSON
+    ? admin.credential.cert(JSON.parse(process.env.FIREBASE_SERVICE_ACCOUNT_JSON))
+    : admin.credential.applicationDefault();
   admin.initializeApp({
-    credential: admin.credential.applicationDefault()
+    credential: cred
   });
 }
 


### PR DESCRIPTION
## Summary
- load service account JSON from `FIREBASE_SERVICE_ACCOUNT_JSON` when running on Netlify
- mention the new environment variable in the docs

## Testing
- `npm install`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68779bd89540832da98895efefa19a72