### PR TITLE
Store FCM service worker registration

### DIFF
--- a/src/firebase.js
+++ b/src/firebase.js
@@ -28,6 +28,7 @@ import {
   getToken,
   onMessage
 } from 'firebase/messaging';
+import { fcmReg } from './swRegistration.js';
 
 const firebaseConfig = {
   apiKey: process.env.FIREBASE_API_KEY,
@@ -46,12 +47,11 @@ if (typeof window !== 'undefined') {
 }
 
 export async function requestNotificationPermission(userId) {
-  if (!messaging || Notification.permission === 'denied') return null;
+  if (!messaging || !fcmReg || Notification.permission === 'denied') return null;
   try {
-    const registration = await navigator.serviceWorker.ready;
     const token = await getToken(messaging, {
       vapidKey: process.env.VAPID_KEY,
-      serviceWorkerRegistration: registration
+      serviceWorkerRegistration: fcmReg
     });
     if (token) {
       await setDoc(doc(db, 'pushTokens', token), { token, userId }, { merge: true });

--- a/src/index.js
+++ b/src/index.js
@@ -1,12 +1,14 @@
 import React from 'react';
 import ReactDOM from 'react-dom';
 import VideotpushApp from './VideotpushApp.jsx';
+import { setFcmReg } from './swRegistration.js';
 
 ReactDOM.render(React.createElement(VideotpushApp), document.getElementById('root'));
 
 if ('serviceWorker' in navigator) {
   window.addEventListener('load', async () => {
     await navigator.serviceWorker.register(new URL('../public/service-worker.js', import.meta.url));
-    await navigator.serviceWorker.register(new URL('./firebase-messaging-sw.js', import.meta.url));
+    const fcmReg = await navigator.serviceWorker.register(new URL('./firebase-messaging-sw.js', import.meta.url));
+    setFcmReg(fcmReg);
   });
 }

--- a/src/swRegistration.js
+++ b/src/swRegistration.js
@@ -1,0 +1,5 @@
+export let fcmReg = null;
+
+export function setFcmReg(reg) {
+  fcmReg = reg;
+}


### PR DESCRIPTION
## Summary
- export a place to store the FCM service worker registration
- save the registration when it is created in `index.js`
- use this registration in `requestNotificationPermission`

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_6877cba46d5c832d9f772f9892c06e59