### PR TITLE
Fix FCM permission handling

### DIFF
--- a/src/firebase.js
+++ b/src/firebase.js
@@ -47,6 +47,16 @@ if (typeof window !== 'undefined') {
 
 export async function requestNotificationPermission(userId) {
   if (!messaging || Notification.permission === 'denied') return null;
+  let permission = Notification.permission;
+  if (permission === 'default') {
+    try {
+      permission = await Notification.requestPermission();
+    } catch (err) {
+      console.error('Failed to request notification permission', err);
+      return null;
+    }
+  }
+  if (permission !== 'granted') return null;
   try {
     const registration = await navigator.serviceWorker.ready;
     const token = await getToken(messaging, {


### PR DESCRIPTION
## Summary
- check for default notification permission before requesting FCM token
- request notification permission if needed
- only fetch token after permission is granted

## Testing
- `npm install`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6877cbbae364832d875c65949b3c000d