### PR TITLE
Show FCM token in alert

### DIFF
--- a/src/components/AdminScreen.jsx
+++ b/src/components/AdminScreen.jsx
@@ -33,12 +33,12 @@ export default function AdminScreen({ onOpenStats, onOpenBugReports, onOpenMatch
         serviceWorkerRegistration: fcmReg
       });
       if (token) {
-        console.log('Client token:', token);
+        alert('Client token: ' + token);
       } else {
-        console.warn('No registration token available.');
+        alert('No registration token available.');
       }
     } catch (err) {
-      console.error('Error getting token', err);
+      alert('Error getting token: ' + err);
     }
   };
 


### PR DESCRIPTION
## Summary
- show the FCM client token in an alert instead of logging it

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_6877d876f514832dabbda1e19bbe1acd