### PR TITLE
Enable Web Push for iOS

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -5,4 +5,6 @@ FIREBASE_STORAGE_BUCKET=your_storage_bucket
 FIREBASE_MESSAGING_SENDER_ID=your_messaging_sender_id
 FIREBASE_APP_ID=your_app_id
 VAPID_KEY=your_web_vapid_key
+WEB_PUSH_PUBLIC_KEY=your_web_push_public_key
+WEB_PUSH_PRIVATE_KEY=your_web_push_private_key
 GOOGLE_APPLICATION_CREDENTIALS=/path/to/service_account.json

--- a/README.md
+++ b/README.md
@@ -68,6 +68,15 @@ FIREBASE_STORAGE_BUCKET
 FIREBASE_MESSAGING_SENDER_ID
 FIREBASE_APP_ID
 GOOGLE_APPLICATION_CREDENTIALS
+WEB_PUSH_PUBLIC_KEY
+WEB_PUSH_PRIVATE_KEY
+```
+
+Example values for the VAPID keys:
+
+```
+WEB_PUSH_PUBLIC_KEY=BBEqVE7NHz0GV-hLpS5057_Txhn1YMvDutBAfRS4mBwFb7JIV-BJGhUbNedFRWhVXeYhkU-fAPH25ZLOlKHBxXk
+WEB_PUSH_PRIVATE_KEY=6NCE6tcVeb6maHj6RtfiXPR5owid3lhxrPq4puqwZ_A
 ```
 
 During the build job, these secrets are written to a `.env` file so Parcel can embed the Firebase config.
@@ -96,16 +105,10 @@ The profile filtering logic used on the Daily Discovery page lives in `src/selec
 
 ## Push Notifications
 
-This project uses Firebase Cloud Messaging to deliver updates. Notifications are
-sent using the HTTP **v1** API, authenticated with a service account. On
-Netlify you can either provide the path to your service account JSON via the
-`GOOGLE_APPLICATION_CREDENTIALS` environment variable or store the JSON itself in
-`FIREBASE_SERVICE_ACCOUNT_JSON`. The legacy `FCM_SERVER_KEY` is no longer used.
+Firebase Cloud Messaging delivers updates on Android and desktop browsers. Notifications are sent using the HTTP **v1** API authenticated with a service account. Provide the service account path via `GOOGLE_APPLICATION_CREDENTIALS` or store the JSON in `FIREBASE_SERVICE_ACCOUNT_JSON`.
 
-In this repository, a Netlify Function (`netlify/functions/send-push.js`) handles
-delivery. The function reads stored push tokens from Firestore and uses the
-Firebase Admin SDK to send notifications via the v1 API. Trigger it by making a
-`POST` request to `/.netlify/functions/send-push` with a JSON body containing a
-`body` field and optional `title`.
+`netlify/functions/send-push.js` sends FCM messages to tokens stored in Firestore. Trigger it with a `POST` request containing a `body` and optional `title`.
 
-A small helper page (`netlify/functions/index.html`) lets you trigger a test notification directly from the deployed site. It posts the title and body to `/.netlify/functions/send-push` and shows the result.
+For iOS PWAs, Safari only supports the standard Web Push API. A separate function (`netlify/functions/send-webpush.js`) sends notifications using VAPID keys defined in `WEB_PUSH_PUBLIC_KEY` and `WEB_PUSH_PRIVATE_KEY`. Subscriptions are stored in the `webPushSubscriptions` collection.
+
+The helper page (`netlify/functions/index.html`) posts data to `/.netlify/functions/send-push` for FCM tokens. To test Web Push on iOS, post to `/.netlify/functions/send-webpush` instead.

--- a/netlify/functions/send-webpush.js
+++ b/netlify/functions/send-webpush.js
@@ -1,0 +1,40 @@
+const admin = require('firebase-admin');
+const webPush = require('web-push');
+
+if (!admin.apps.length) {
+  const serviceAccount = require('../../videotinder-38b8b-firebase-adminsdk-fbsvc-5f3bef3136.json');
+  admin.initializeApp({ credential: admin.credential.cert(serviceAccount) });
+}
+const db = admin.firestore();
+
+webPush.setVapidDetails(
+  'mailto:example@example.com',
+  process.env.WEB_PUSH_PUBLIC_KEY,
+  process.env.WEB_PUSH_PRIVATE_KEY
+);
+
+exports.handler = async function(event) {
+  if (event.httpMethod !== 'POST') {
+    return { statusCode: 405, body: 'Method Not Allowed' };
+  }
+  try {
+    const { title = 'Videotpush', body } = JSON.parse(event.body || '{}');
+    if (!body) {
+      return { statusCode: 400, body: 'Invalid payload' };
+    }
+    const subsSnap = await db.collection('webPushSubscriptions').get();
+    const subs = subsSnap.docs.map(d => d.data());
+    const payload = JSON.stringify({ title, body });
+    await Promise.all(subs.map(sub =>
+      webPush.sendNotification(sub, payload).catch(err => {
+        if (err.statusCode === 410 || err.statusCode === 404) {
+          db.collection('webPushSubscriptions').doc(sub.endpoint).delete().catch(() => {});
+        }
+      })
+    ));
+    return { statusCode: 200, body: JSON.stringify({ success: true, count: subs.length }) };
+  } catch (err) {
+    console.error(err);
+    return { statusCode: 500, body: 'Server error' };
+  }
+};

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,8 @@
         "lucide-react": "^0.322.0",
         "rc-slider": "^11.1.8",
         "react": "^17.0.0",
-        "react-dom": "^17.0.0"
+        "react-dom": "^17.0.0",
+        "web-push": "^3.5.4"
       },
       "devDependencies": {
         "@parcel/packager-raw-url": "^2.15.4",
@@ -3365,6 +3366,18 @@
         "node": ">=8"
       }
     },
+    "node_modules/asn1.js": {
+      "version": "5.4.1",
+      "resolved": "https://registry.npmjs.org/asn1.js/-/asn1.js-5.4.1.tgz",
+      "integrity": "sha512-+I//4cYPccV8LdmBLiX8CYvf9Sp3vQsrqu2QNXRcrbiWvcx/UdlFiqUJJzxRQxgsZmvhXhn4cSKeSmoFjVdupA==",
+      "license": "MIT",
+      "dependencies": {
+        "bn.js": "^4.0.0",
+        "inherits": "^2.0.1",
+        "minimalistic-assert": "^1.0.0",
+        "safer-buffer": "^2.1.0"
+      }
+    },
     "node_modules/async-retry": {
       "version": "1.3.3",
       "resolved": "https://registry.npmjs.org/async-retry/-/async-retry-1.3.3.tgz",
@@ -3429,6 +3442,12 @@
       "integrity": "sha512-XpNj6GDQzdfW+r2Wnn7xiSAd7TM3jzkxGXBGTtWKuSXv1xUV+azxAm8jdWZN06QTQk+2N2XB9jRDkvbmQmcRtg==",
       "license": "MIT",
       "optional": true
+    },
+    "node_modules/bn.js": {
+      "version": "4.12.2",
+      "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.12.2.tgz",
+      "integrity": "sha512-n4DSx829VRTRByMRGdjQ9iqsN0Bh4OolPsFnaZBLcbi8iXcB+kJ9s7EnRt4wILZNV3kPLHkRVfOc/HvhC3ovDw==",
+      "license": "MIT"
     },
     "node_modules/brace-expansion": {
       "version": "2.0.2",
@@ -4585,6 +4604,15 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/http_ece": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/http_ece/-/http_ece-1.2.0.tgz",
+      "integrity": "sha512-JrF8SSLVmcvc5NducxgyOrKXe3EsyHMgBFgSaIUGmArKe+rwr0uphRkRXvwiom3I+fpIfoItveHrfudL8/rxuA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=16"
+      }
+    },
     "node_modules/http-parser-js": {
       "version": "0.5.10",
       "resolved": "https://registry.npmjs.org/http-parser-js/-/http-parser-js-0.5.10.tgz",
@@ -4642,8 +4670,7 @@
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
       "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
-      "license": "ISC",
-      "optional": true
+      "license": "ISC"
     },
     "node_modules/is-extglob": {
       "version": "2.1.1",
@@ -4852,7 +4879,6 @@
       "resolved": "https://registry.npmjs.org/jwa/-/jwa-2.0.1.tgz",
       "integrity": "sha512-hRF04fqJIP8Abbkq5NKGN0Bbr3JxlQ+qhZufXVr0DvujKy93ZCbXZMHDL4EOtodSbCWxOqR8MS1tXA5hwqCXDg==",
       "license": "MIT",
-      "optional": true,
       "dependencies": {
         "buffer-equal-constant-time": "^1.0.1",
         "ecdsa-sig-formatter": "1.0.11",
@@ -4881,7 +4907,6 @@
       "resolved": "https://registry.npmjs.org/jws/-/jws-4.0.0.tgz",
       "integrity": "sha512-KDncfTmOZoOMTFG4mBlG0qUIOlc03fmzH+ru6RgYVZhPkyiy/92Owlt/8UEN+a4TXR1FQetfIpJE8ApdvdVxTg==",
       "license": "MIT",
-      "optional": true,
       "dependencies": {
         "jwa": "^2.0.0",
         "safe-buffer": "^5.0.1"
@@ -5437,6 +5462,12 @@
         "node": ">= 0.6"
       }
     },
+    "node_modules/minimalistic-assert": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/minimalistic-assert/-/minimalistic-assert-1.0.1.tgz",
+      "integrity": "sha512-UtJcAD4yEaGtjPezWuO9wC4nwUnVH/8/Im3yEHQP4b67cXlD/Qr9hdITCU1xDbSEXg2XKNaP8jsReV7vQd00/A==",
+      "license": "ISC"
+    },
     "node_modules/minimatch": {
       "version": "5.1.6",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.1.6.tgz",
@@ -5455,7 +5486,6 @@
       "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
       "integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==",
       "license": "MIT",
-      "optional": true,
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
@@ -6020,6 +6050,12 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/safer-buffer": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+      "license": "MIT"
+    },
     "node_modules/scheduler": {
       "version": "0.20.2",
       "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.20.2.tgz",
@@ -6348,6 +6384,47 @@
       "integrity": "sha512-DEAoo25RfSYMuTGc9vPJzZcZullwIqRDSI9LOy+fkCJPi6hykCnfKaXTuPBDuXAUcqHXyOgFtHNp/kB2FjYHbw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/web-push": {
+      "version": "3.6.7",
+      "resolved": "https://registry.npmjs.org/web-push/-/web-push-3.6.7.tgz",
+      "integrity": "sha512-OpiIUe8cuGjrj3mMBFWY+e4MMIkW3SVT+7vEIjvD9kejGUypv8GPDf84JdPWskK8zMRIJ6xYGm+Kxr8YkPyA0A==",
+      "license": "MPL-2.0",
+      "dependencies": {
+        "asn1.js": "^5.3.0",
+        "http_ece": "1.2.0",
+        "https-proxy-agent": "^7.0.0",
+        "jws": "^4.0.0",
+        "minimist": "^1.2.5"
+      },
+      "bin": {
+        "web-push": "src/cli.js"
+      },
+      "engines": {
+        "node": ">= 16"
+      }
+    },
+    "node_modules/web-push/node_modules/agent-base": {
+      "version": "7.1.4",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.4.tgz",
+      "integrity": "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/web-push/node_modules/https-proxy-agent": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.6.tgz",
+      "integrity": "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==",
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "^7.1.2",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
     },
     "node_modules/webidl-conversions": {
       "version": "3.0.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "videotpush",
-  "version": "1.0.31",
+  "version": "1.0.32",
   "description": "A minimal React PWA for swiping short videos and speed dating.",
   "scripts": {
     "start": "npx serve .",
@@ -14,7 +14,8 @@
     "lucide-react": "^0.322.0",
     "rc-slider": "^11.1.8",
     "react": "^17.0.0",
-    "react-dom": "^17.0.0"
+    "react-dom": "^17.0.0",
+    "web-push": "^3.5.4"
   },
   "devDependencies": {
     "@parcel/packager-raw-url": "^2.15.4",

--- a/src/VideotpushApp.jsx
+++ b/src/VideotpushApp.jsx
@@ -17,7 +17,7 @@ import ActiveCallsScreen from './components/ActiveCallsScreen.jsx';
 import ReportedContentScreen from './components/ReportedContentScreen.jsx';
 import AboutScreen from './components/AboutScreen.jsx';
 import FunctionTestScreen from './components/FunctionTestScreen.jsx';
-import { useCollection, requestNotificationPermission, db, doc, updateDoc, increment } from './firebase.js';
+import { useCollection, requestNotificationPermission, subscribeToWebPush, db, doc, updateDoc, increment } from './firebase.js';
 import { cacheMediaIfNewer } from './cacheMedia.js';
 
 
@@ -80,6 +80,7 @@ export default function VideotpushApp() {
   useEffect(() => {
     if (loggedIn && userId) {
       requestNotificationPermission(userId);
+      subscribeToWebPush(userId);
     }
   }, [loggedIn, userId]);
 

--- a/src/firebase-messaging-sw.js
+++ b/src/firebase-messaging-sw.js
@@ -21,3 +21,29 @@ function handleBackgroundMessages() {
     });
   });
 }
+
+self.addEventListener('push', event => {
+  let data = {};
+  if (event.data) {
+    try { data = event.data.json(); } catch { data = { body: event.data.text() }; }
+  }
+  const title = data.title || 'Videotpush';
+  event.waitUntil(
+    self.registration.showNotification(title, {
+      body: data.body,
+      icon: 'icon-192.png'
+    })
+  );
+});
+
+self.addEventListener('notificationclick', event => {
+  event.notification.close();
+  event.waitUntil(
+    clients.matchAll({ type: 'window', includeUncontrolled: true }).then(clientsArr => {
+      for (const client of clientsArr) {
+        if (client.url.includes('/') && 'focus' in client) return client.focus();
+      }
+      if (clients.openWindow) return clients.openWindow('/');
+    })
+  );
+});


### PR DESCRIPTION
## Summary
- support subscribing to standard Web Push
- add push event handling to service worker
- expose new Netlify function to send Web Push notifications
- document Web Push configuration and add example VAPID keys
- include `web-push` library

## Testing
- `npm install`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68782b5f8e08832db47f287bf7c68a5d