### PR TITLE
Fix push subscription ID encoding

### DIFF
--- a/netlify/functions/send-webpush.js
+++ b/netlify/functions/send-webpush.js
@@ -28,7 +28,8 @@ exports.handler = async function(event) {
     await Promise.all(subs.map(sub =>
       webPush.sendNotification(sub, payload).catch(err => {
         if (err.statusCode === 410 || err.statusCode === 404) {
-          db.collection('webPushSubscriptions').doc(sub.endpoint).delete().catch(() => {});
+          const safeId = Buffer.from(sub.endpoint).toString('base64');
+          db.collection('webPushSubscriptions').doc(safeId).delete().catch(() => {});
         }
       })
     ));

--- a/src/firebase.js
+++ b/src/firebase.js
@@ -65,7 +65,8 @@ export async function subscribeToWebPush(userId) {
         applicationServerKey: appKey
       });
     }
-    await setDoc(doc(db, 'webPushSubscriptions', sub.endpoint), {
+    const safeId = btoa(sub.endpoint);
+    await setDoc(doc(db, 'webPushSubscriptions', safeId), {
       ...sub.toJSON(),
       userId
     });


### PR DESCRIPTION
## Summary
- encode push subscription endpoint so Firestore IDs are valid
- use encoded ID when cleaning up broken web push subscriptions

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68783b67cd14832d8281e8a85acf15c8