### PR TITLE
Fix web push subscription IDs

### DIFF
--- a/netlify/functions/send-webpush.js
+++ b/netlify/functions/send-webpush.js
@@ -28,7 +28,11 @@ exports.handler = async function(event) {
     await Promise.all(subs.map(sub =>
       webPush.sendNotification(sub, payload).catch(err => {
         if (err.statusCode === 410 || err.statusCode === 404) {
-          const safeId = Buffer.from(sub.endpoint).toString('base64');
+          const safeId = Buffer.from(sub.endpoint)
+            .toString('base64')
+            .replace(/\+/g, '-')
+            .replace(/\//g, '_')
+            .replace(/=+$/, '');
           db.collection('webPushSubscriptions').doc(safeId).delete().catch(() => {});
         }
       })

--- a/src/firebase.js
+++ b/src/firebase.js
@@ -65,7 +65,11 @@ export async function subscribeToWebPush(userId) {
         applicationServerKey: appKey
       });
     }
-    const safeId = btoa(sub.endpoint);
+    const safeId =
+      btoa(sub.endpoint)
+        .replace(/\+/g, '-')
+        .replace(/\//g, '_')
+        .replace(/=+$/, '');
     await setDoc(doc(db, 'webPushSubscriptions', safeId), {
       ...sub.toJSON(),
       userId


### PR DESCRIPTION
## Summary
- sanitize web push subscription IDs so Firestore accepts them

## Testing
- `npm install`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_6878b4e1ce98832da44e5b79e854be46