### PR TITLE
Update build workflow to include web push keys

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -35,6 +35,8 @@ jobs:
           FIREBASE_MESSAGING_SENDER_ID=${{ secrets.FIREBASE_MESSAGING_SENDER_ID }}
           FIREBASE_APP_ID=${{ secrets.FIREBASE_APP_ID }}
           VAPID_KEY=${{ secrets.VAPID_KEY }}
+          WEB_PUSH_PUBLIC_KEY=${{ secrets.WEB_PUSH_PUBLIC_KEY }}
+          WEB_PUSH_PRIVATE_KEY=${{ secrets.WEB_PUSH_PRIVATE_KEY }}
           EOF
       - run: npm ci
       - run: npm run build


### PR DESCRIPTION
## Summary
- add `WEB_PUSH_PUBLIC_KEY` and `WEB_PUSH_PRIVATE_KEY` to the `.env` creation step

## Testing
- `npm ci`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_6878bd551cdc832d9a816368c689bf67