### PR TITLE
Add configurable extended logging

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "videotpush",
-  "version": "1.0.31",
+  "version": "1.0.33",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "videotpush",
-      "version": "1.0.31",
+      "version": "1.0.33",
       "dependencies": {
         "firebase": "^9.23.0",
         "firebase-admin": "^11.10.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "videotpush",
-  "version": "1.0.32",
+  "version": "1.0.34",
   "description": "A minimal React PWA for swiping short videos and speed dating.",
   "scripts": {
     "start": "npx serve .",

--- a/src/VideotpushApp.jsx
+++ b/src/VideotpushApp.jsx
@@ -17,7 +17,8 @@ import ActiveCallsScreen from './components/ActiveCallsScreen.jsx';
 import ReportedContentScreen from './components/ReportedContentScreen.jsx';
 import AboutScreen from './components/AboutScreen.jsx';
 import FunctionTestScreen from './components/FunctionTestScreen.jsx';
-import { useCollection, requestNotificationPermission, subscribeToWebPush, db, doc, updateDoc, increment } from './firebase.js';
+import TextLogScreen from './components/TextLogScreen.jsx';
+import { useCollection, requestNotificationPermission, subscribeToWebPush, db, doc, updateDoc, increment, logEvent } from './firebase.js';
 import { cacheMediaIfNewer } from './cacheMedia.js';
 
 
@@ -78,6 +79,12 @@ export default function VideotpushApp() {
   },[loggedIn, profiles, userId]);
 
   useEffect(() => {
+    if(loggedIn && userId){
+      logEvent('active user', { userId });
+    }
+  }, [loggedIn, userId]);
+
+  useEffect(() => {
     if (loggedIn && userId) {
       requestNotificationPermission(userId);
       subscribeToWebPush(userId);
@@ -104,7 +111,7 @@ export default function VideotpushApp() {
 
 
   if(!loggedIn) return React.createElement(LanguageProvider, { value:{lang,setLang} },
-    React.createElement(WelcomeScreen, { onLogin: () => setLoggedIn(true) })
+    React.createElement(WelcomeScreen, { onLogin: () => { setLoggedIn(true); logEvent('login'); } })
   );
   const selectProfile = async id => {
     setViewProfile(id);
@@ -170,7 +177,7 @@ export default function VideotpushApp() {
             onOpenAbout: ()=>setTab('about')
           }),
           tab==='likes' && React.createElement(LikesScreen, { userId, onBack: ()=>setTab('discovery'), onSelectProfile: selectProfile }),
-          tab==='admin' && React.createElement(AdminScreen, { onOpenStats: ()=>setTab('stats'), onOpenBugReports: ()=>setTab('bugs'), onOpenMatchLog: ()=>setTab('matchlog'), onOpenScoreLog: ()=>setTab('scorelog'), onOpenReports: ()=>setTab('reports'), onOpenCallLog: ()=>setTab('calllog'), onOpenFunctionTest: ()=>setTab('functiontest'), profiles, userId, onSwitchProfile: id=>setUserId(id) }),
+          tab==='admin' && React.createElement(AdminScreen, { onOpenStats: ()=>setTab('stats'), onOpenBugReports: ()=>setTab('bugs'), onOpenMatchLog: ()=>setTab('matchlog'), onOpenScoreLog: ()=>setTab('scorelog'), onOpenReports: ()=>setTab('reports'), onOpenCallLog: ()=>setTab('calllog'), onOpenFunctionTest: ()=>setTab('functiontest'), onOpenTextLog: ()=>setTab('textlog'), profiles, userId, onSwitchProfile: id=>setUserId(id) }),
           tab==='stats' && React.createElement(StatsScreen, { onBack: ()=>setTab('admin') }),
           tab==='matchlog' && React.createElement(MatchLogScreen, { onBack: ()=>setTab('admin') }),
           tab==='scorelog' && React.createElement(ScoreLogScreen, { onBack: ()=>setTab('admin') }),
@@ -178,6 +185,7 @@ export default function VideotpushApp() {
           tab==='reports' && React.createElement(ReportedContentScreen, { onBack: ()=>setTab('admin') }),
           tab==='bugs' && React.createElement(BugReportsScreen, { onBack: ()=>setTab('admin') }),
           tab==='functiontest' && React.createElement(FunctionTestScreen, { onBack: ()=>setTab('admin') }),
+          tab==='textlog' && React.createElement(TextLogScreen, { onBack: ()=>setTab('admin') }),
           tab==='about' && React.createElement(AboutScreen, null)
         )
     ),

--- a/src/components/AdminScreen.jsx
+++ b/src/components/AdminScreen.jsx
@@ -1,18 +1,25 @@
-import React from 'react';
+import React, { useState } from 'react';
 import { languages, useLang, useT } from '../i18n.js';
 import { Card } from './ui/card.js';
 import { Button } from './ui/button.js';
 import SectionTitle from './SectionTitle.jsx';
 import seedData from '../seedData.js';
-import { db, updateDoc, doc, getDoc, storage, listAll, ref, getDownloadURL, messaging } from '../firebase.js';
+import { db, updateDoc, doc, getDoc, storage, listAll, ref, getDownloadURL, messaging, setExtendedLogging, isExtendedLogging } from '../firebase.js';
 import { getToken } from 'firebase/messaging';
 import { fcmReg } from '../swRegistration.js';
 
 
-export default function AdminScreen({ onOpenStats, onOpenBugReports, onOpenMatchLog, onOpenScoreLog, onOpenReports, onOpenCallLog, onOpenFunctionTest, profiles = [], userId, onSwitchProfile }) {
+export default function AdminScreen({ onOpenStats, onOpenBugReports, onOpenMatchLog, onOpenScoreLog, onOpenReports, onOpenCallLog, onOpenFunctionTest, onOpenTextLog, profiles = [], userId, onSwitchProfile }) {
 
   const { lang, setLang } = useLang();
   const t = useT();
+  const [logEnabled, setLogEnabled] = useState(isExtendedLogging());
+
+  const toggleLog = () => {
+    const val = !logEnabled;
+    setLogEnabled(val);
+    setExtendedLogging(val);
+  };
 
   const sendPush = async body => {
     const resp = await fetch('/.netlify/functions/send-push', {
@@ -116,6 +123,12 @@ export default function AdminScreen({ onOpenStats, onOpenBugReports, onOpenMatch
   React.createElement(Button, { className: 'mt-2 bg-blue-500 text-white px-4 py-2 rounded', onClick: () => seedData().then(() => alert('Databasen er nulstillet')) }, 'Reset database'),
   React.createElement('h3', { className: 'text-xl font-semibold mb-2 mt-4 text-blue-600' }, 'Hent mistet fra DB'),
   React.createElement(Button, { className: 'mt-2 bg-blue-500 text-white px-4 py-2 rounded', onClick: recoverMissing }, 'Hent mistet fra DB'),
+    React.createElement('h3', { className: 'text-xl font-semibold mb-2 mt-4 text-blue-600' }, 'Logging'),
+    React.createElement('label', { className: 'flex items-center mb-2' },
+      React.createElement('input', { type: 'checkbox', className: 'mr-2', checked: logEnabled, onChange: toggleLog }),
+      'Udvidet logning'
+    ),
+    React.createElement(Button, { className: 'mt-2 bg-blue-500 text-white px-4 py-2 rounded', onClick: onOpenTextLog }, 'Se log'),
     React.createElement('h3', { className: 'text-xl font-semibold mb-2 mt-4 text-blue-600' }, 'Push notifications'),
     React.createElement(Button, { className: 'mt-2 bg-blue-500 text-white px-4 py-2 rounded mr-2', onClick: () => sendPush('Dagens klip er klar') }, 'Dagens klip er klar'),
     React.createElement(Button, { className: 'mt-2 bg-blue-500 text-white px-4 py-2 rounded mr-2', onClick: () => sendPush('Du har et match. Start samtalen') }, 'Du har et match. Start samtalen'),

--- a/src/components/TextLogScreen.jsx
+++ b/src/components/TextLogScreen.jsx
@@ -1,0 +1,24 @@
+import React from 'react';
+import { Card } from './ui/card.js';
+import { Button } from './ui/button.js';
+import SectionTitle from './SectionTitle.jsx';
+import { useCollection } from '../firebase.js';
+
+export default function TextLogScreen({ onBack }) {
+  const logs = useCollection('textLogs');
+  const sorted = logs.sort((a, b) => new Date(b.timestamp) - new Date(a.timestamp));
+  return React.createElement(Card, { className: 'p-6 m-4 shadow-xl bg-white/90 overflow-y-auto max-h-[90vh]' },
+    React.createElement(SectionTitle, { title: 'Tekstlog', colorClass: 'text-blue-600', action: React.createElement(Button, { onClick: onBack }, 'Tilbage') }),
+    sorted.length ?
+      React.createElement('ul', { className: 'space-y-2 mt-4' },
+        sorted.map(l =>
+          React.createElement('li', { key: l.id, className: 'border-b pb-1 text-sm' },
+            React.createElement('div', { className: 'font-mono text-xs text-gray-500' }, l.timestamp),
+            React.createElement('div', null, l.event),
+            l.details && React.createElement('pre', { className: 'whitespace-pre-wrap break-words text-xs' }, JSON.stringify(l.details, null, 2))
+          )
+        )
+      ) :
+      React.createElement('p', { className: 'text-center mt-4 text-gray-500' }, 'Ingen logs')
+  );
+}

--- a/src/version.js
+++ b/src/version.js
@@ -1,1 +1,1 @@
-export default '1.0.31';
+export default '1.0.34';


### PR DESCRIPTION
## Summary
- introduce `logEvent` helper in `firebase.js`
- log web push subscription and FCM permission steps
- add TextLogScreen component to view logs
- allow enabling logging from AdminScreen
- wire up new log screen in app
- bump version after build

## Testing
- `npm install`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_6878c73b7d9c832d8169e3fb076b03c5