### PR TITLE
Handle web push errors

### DIFF
--- a/netlify/functions/index.html
+++ b/netlify/functions/index.html
@@ -33,8 +33,9 @@ button{margin-top:1em;padding:0.5em 1em;}
         document.getElementById('status').textContent = 'Failed: ' + text;
       } else {
         const data = await resp.json().catch(() => ({}));
-        document.getElementById('status').textContent =
-          'Notification sent to ' + (data.count ?? '?') + ' tokens';
+        let msg = 'Notification sent to ' + (data.count ?? '?') + ' subscriptions';
+        if (data.errors) msg += ' (' + data.errors + ' failed)';
+        document.getElementById('status').textContent = msg;
       }
     } catch (err) {
       document.getElementById('status').textContent = 'Error: ' + err.message;


### PR DESCRIPTION
## Summary
- track failed web push subscriptions in `send-webpush`
- show error counts in the push test helper page

## Testing
- `npm run build`
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6878cea76724832d85dd07328be26d35