### PR TITLE
Add push receive logging

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,3 +112,5 @@ Firebase Cloud Messaging delivers updates on Android and desktop browsers. Notif
 For iOS PWAs, Safari only supports the standard Web Push API. A separate function (`netlify/functions/send-webpush.js`) sends notifications using VAPID keys defined in `WEB_PUSH_PUBLIC_KEY` and `WEB_PUSH_PRIVATE_KEY`. Subscriptions are stored in the `webPushSubscriptions` collection.
 
 The helper page (`netlify/functions/index.html`) posts data to `/.netlify/functions/send-push` for FCM tokens. To test Web Push on iOS, post to `/.netlify/functions/send-webpush` instead.
+
+When notifications are received in the browser, the service worker now broadcasts a `PUSH_RECEIVED` message. The app listens for this event and stores a log entry in the `textLogs` collection when extended logging is enabled. This makes it easier to confirm that pushes arrive on the device.

--- a/src/firebase-messaging-sw.js
+++ b/src/firebase-messaging-sw.js
@@ -28,12 +28,16 @@ self.addEventListener('push', event => {
     try { data = event.data.json(); } catch { data = { body: event.data.text() }; }
   }
   const title = data.title || 'Videotpush';
-  event.waitUntil(
-    self.registration.showNotification(title, {
+  event.waitUntil((async () => {
+    await self.registration.showNotification(title, {
       body: data.body,
       icon: 'icon-192.png'
-    })
-  );
+    });
+    const clientsArr = await self.clients.matchAll({ type: 'window', includeUncontrolled: true });
+    for (const client of clientsArr) {
+      client.postMessage({ type: 'PUSH_RECEIVED', payload: data });
+    }
+  })());
 });
 
 self.addEventListener('notificationclick', event => {

--- a/src/index.js
+++ b/src/index.js
@@ -2,7 +2,7 @@ import React from 'react';
 import ReactDOM from 'react-dom';
 import VideotpushApp from './VideotpushApp.jsx';
 import { setFcmReg } from './swRegistration.js';
-import { firebaseConfig } from './firebase.js';
+import { firebaseConfig, logEvent } from './firebase.js';
 
 ReactDOM.render(React.createElement(VideotpushApp), document.getElementById('root'));
 
@@ -17,5 +17,10 @@ if ('serviceWorker' in navigator) {
     const sw = fcmReg.active || fcmReg.waiting || fcmReg.installing;
     sw?.postMessage({ type: 'INIT_FIREBASE', config: firebaseConfig });
     setFcmReg(fcmReg);
+    navigator.serviceWorker.addEventListener('message', event => {
+      if (event.data && event.data.type === 'PUSH_RECEIVED') {
+        logEvent('push received', event.data.payload);
+      }
+    });
   });
 }


### PR DESCRIPTION
## Summary
- log `push` events from service worker
- forward message events to React app and log via `logEvent`
- document push logging behavior

## Testing
- `npm test` *(fails: missing script)*
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_6878d205f318832d914b02713fa4643a