### PR TITLE
Add active user stats

### DIFF
--- a/src/VideotpushApp.jsx
+++ b/src/VideotpushApp.jsx
@@ -81,6 +81,9 @@ export default function VideotpushApp() {
   useEffect(() => {
     if(loggedIn && userId){
       logEvent('active user', { userId });
+      updateDoc(doc(db, 'profiles', userId), {
+        lastActive: new Date().toISOString()
+      }).catch(err => console.error('Failed to update lastActive', err));
     }
   }, [loggedIn, userId]);
 

--- a/src/components/StatsScreen.jsx
+++ b/src/components/StatsScreen.jsx
@@ -28,6 +28,11 @@ export default function StatsScreen({ onBack }) {
       const videoCount = profilesSnap.docs.reduce((acc, d) => acc + ((d.data().videoClips || []).length), 0);
       const audioCount = profilesSnap.docs.reduce((acc, d) => acc + ((d.data().audioClips || []).length), 0);
       const viewCount = profilesSnap.docs.reduce((acc, d) => acc + (d.data().viewCount || 0), 0);
+      const activeSince = Date.now() - 30 * 24 * 60 * 60 * 1000;
+      const activeUsers = profilesSnap.docs.filter(d => {
+        const last = d.data().lastActive;
+        return last && new Date(last).getTime() >= activeSince;
+      }).length;
 
       const dist = { '18-25': 0, '26-35': 0, '36-45': 0, '46-55': 0, '56+': 0 };
       profilesSnap.docs.forEach(d => {
@@ -52,7 +57,8 @@ export default function StatsScreen({ onBack }) {
         bugClosed: closedBugs,
         videos: videoCount,
         audios: audioCount,
-        views: viewCount
+        views: viewCount,
+        activeUsers
       };
       setStats(data);
 
@@ -77,6 +83,7 @@ export default function StatsScreen({ onBack }) {
       React.createElement(StatsChart, { data: history, fields: 'bugClosed', title: 'Lukkede fejl over tid' }),
       React.createElement(StatsChart, { data: history, fields: ['videos','audios'], title: 'Uploads over tid' }),
       React.createElement(StatsChart, { data: history, fields: 'views', title: 'Profilvisninger over tid' }),
+      React.createElement(StatsChart, { data: history, fields: 'activeUsers', title: 'Aktive brugere over tid' }),
       ageDist && React.createElement(AgeDistributionChart, { distribution: ageDist, title: 'Aldersfordeling' })
     ) : React.createElement('p', null, 'Indlæser...')
   );


### PR DESCRIPTION
## Summary
- update lastActive timestamp on login
- compute active user count in stats and store in dailyStats
- display active user history graph on the statistics page

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_6878ef7d25a4832d8d6b2beb62816193