### PR TITLE
Add FUNCTIONS_BASE_URL to build workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -37,6 +37,7 @@ jobs:
           VAPID_KEY=${{ secrets.VAPID_KEY }}
           WEB_PUSH_PUBLIC_KEY=${{ secrets.WEB_PUSH_PUBLIC_KEY }}
           WEB_PUSH_PRIVATE_KEY=${{ secrets.WEB_PUSH_PRIVATE_KEY }}
+          FUNCTIONS_BASE_URL=${{ secrets.FUNCTIONS_BASE_URL }}
           EOF
       - run: npm ci
       - run: npm run build


### PR DESCRIPTION
## Summary
- include `FUNCTIONS_BASE_URL` when creating the `.env` file during the build

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_6878f5c15ccc832d8006ec6a5e06a8ad