### PR TITLE
Enable webpush from admin notifications

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,3 +117,5 @@ For iOS PWAs, Safari only supports the standard Web Push API. A separate functio
 The helper page (`netlify/functions/index.html`) posts data to `/.netlify/functions/send-push` for FCM tokens. To test Web Push on iOS, post to `/.netlify/functions/send-webpush` instead.
 
 When notifications are received in the browser, the service worker now broadcasts a `PUSH_RECEIVED` message. The app listens for this event and stores a log entry in the `textLogs` collection when extended logging is enabled. This makes it easier to confirm that pushes arrive on the device.
+
+From the admin screen you can send a notification that triggers **both** functions so that users receive updates regardless of whether they registered for FCM or standard Web Push.

--- a/src/components/AdminScreen.jsx
+++ b/src/components/AdminScreen.jsx
@@ -23,14 +23,24 @@ export default function AdminScreen({ onOpenStats, onOpenBugReports, onOpenMatch
 
   const sendPush = async body => {
     const base = process.env.FUNCTIONS_BASE_URL || '';
-    const resp = await fetch(`${base}/.netlify/functions/send-push`, {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ body })
-    });
-    if (!resp.ok) {
-      const text = await resp.text();
-      alert('Failed: ' + text);
+
+    const send = async endpoint => {
+      const resp = await fetch(`${base}/.netlify/functions/${endpoint}`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ body })
+      });
+      if (!resp.ok) {
+        const text = await resp.text();
+        throw new Error(text);
+      }
+    };
+
+    try {
+      await send('send-push');
+      await send('send-webpush');
+    } catch (err) {
+      alert('Failed: ' + err.message);
     }
   };
 


### PR DESCRIPTION
## Summary
- update admin push handler to call both send-push and send-webpush functions
- document that admin notifications now hit both endpoints

## Testing
- `npm install`
- `npm run build` (fails to run parcel if not installed globally; after installing, build succeeds)


------
https://chatgpt.com/codex/tasks/task_e_6878f60dd5ec832d818f292c7119105c