### PR TITLE
Fix Firebase init in Netlify functions

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,6 +109,7 @@ The profile filtering logic used on the Daily Discovery page lives in `src/selec
 ## Push Notifications
 
 Firebase Cloud Messaging delivers updates on Android and desktop browsers. Notifications are sent using the HTTP **v1** API authenticated with a service account. Provide the service account path via `GOOGLE_APPLICATION_CREDENTIALS` or store the JSON in `FIREBASE_SERVICE_ACCOUNT_JSON`.
+The Netlify functions automatically read these variables and initialize the Firebase Admin SDK if present.
 
 `netlify/functions/send-push.js` sends FCM messages to tokens stored in Firestore. Trigger it with a `POST` request containing a `body` and optional `title`.
 

--- a/netlify/functions/send-push.js
+++ b/netlify/functions/send-push.js
@@ -3,12 +3,24 @@ const fs = require('fs');
 const path = require('path');
 
 if (!admin.apps.length) {
-  const credPath = path.join(__dirname, '../../videotinder-38b8b-firebase-adminsdk-fbsvc-5f3bef3136.json');
   try {
-    if (!fs.existsSync(credPath)) {
-      console.error('Firebase credential file missing:', credPath);
+    let serviceAccount = null;
+    if (process.env.FIREBASE_SERVICE_ACCOUNT_JSON) {
+      serviceAccount = JSON.parse(process.env.FIREBASE_SERVICE_ACCOUNT_JSON);
     } else {
-      const serviceAccount = require(credPath);
+      const credPath =
+        process.env.GOOGLE_APPLICATION_CREDENTIALS ||
+        path.join(
+          __dirname,
+          '../../videotinder-38b8b-firebase-adminsdk-fbsvc-5f3bef3136.json'
+        );
+      if (fs.existsSync(credPath)) {
+        serviceAccount = require(credPath);
+      } else {
+        console.error('Firebase credential file missing:', credPath);
+      }
+    }
+    if (serviceAccount) {
       admin.initializeApp({
         credential: admin.credential.cert(serviceAccount)
       });

--- a/netlify/functions/send-webpush.js
+++ b/netlify/functions/send-webpush.js
@@ -4,13 +4,27 @@ const path = require('path');
 const webPush = require('web-push');
 
 if (!admin.apps.length) {
-  const credPath = path.join(__dirname, '../../videotinder-38b8b-firebase-adminsdk-fbsvc-5f3bef3136.json');
   try {
-    if (!fs.existsSync(credPath)) {
-      console.error('Firebase credential file missing:', credPath);
+    let serviceAccount = null;
+    if (process.env.FIREBASE_SERVICE_ACCOUNT_JSON) {
+      serviceAccount = JSON.parse(process.env.FIREBASE_SERVICE_ACCOUNT_JSON);
     } else {
-      const serviceAccount = require(credPath);
-      admin.initializeApp({ credential: admin.credential.cert(serviceAccount) });
+      const credPath =
+        process.env.GOOGLE_APPLICATION_CREDENTIALS ||
+        path.join(
+          __dirname,
+          '../../videotinder-38b8b-firebase-adminsdk-fbsvc-5f3bef3136.json'
+        );
+      if (fs.existsSync(credPath)) {
+        serviceAccount = require(credPath);
+      } else {
+        console.error('Firebase credential file missing:', credPath);
+      }
+    }
+    if (serviceAccount) {
+      admin.initializeApp({
+        credential: admin.credential.cert(serviceAccount)
+      });
     }
   } catch (err) {
     console.error('Failed to load Firebase credentials:', err);


### PR DESCRIPTION
## Summary
- load Firebase admin credentials from `FIREBASE_SERVICE_ACCOUNT_JSON` or `GOOGLE_APPLICATION_CREDENTIALS`
- document env variable loading for Netlify functions

## Testing
- `npm install`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6878fc2a94e4832da92c2ebd7e557887