### PR TITLE
Add service worker registration logging

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -9,10 +9,22 @@ ReactDOM.render(React.createElement(VideotpushApp), document.getElementById('roo
 if ('serviceWorker' in navigator) {
   window.addEventListener('load', async () => {
     // Register the main service worker generated in the production build
-    await navigator.serviceWorker.register(new URL('../public/service-worker.js', import.meta.url));
+    await navigator.serviceWorker
+      .register(new URL('../public/service-worker.js', import.meta.url))
+      .then(reg => console.log('SW registered', reg))
+      .catch(err => console.error('SW registration failed', err));
 
     // Register the Firebase messaging service worker now located under src
-    const fcmReg = await navigator.serviceWorker.register(new URL('./firebase-messaging-sw.js', import.meta.url));
+    const fcmReg = await navigator.serviceWorker
+      .register(new URL('./firebase-messaging-sw.js', import.meta.url))
+      .then(reg => {
+        console.log('SW registered', reg);
+        return reg;
+      })
+      .catch(err => {
+        console.error('SW registration failed', err);
+        throw err;
+      });
     // Send Firebase config to the service worker so it can initialize
     const sw = fcmReg.active || fcmReg.waiting || fcmReg.installing;
     sw?.postMessage({ type: 'INIT_FIREBASE', config: firebaseConfig });


### PR DESCRIPTION
## Summary
- log service worker registration success and failure for both main and messaging service workers

## Testing
- `npm test` *(fails: Missing script 'test')*

------
https://chatgpt.com/codex/tasks/task_e_68792ae223ec832d89cdc06b32d30f5b