### PR TITLE
Add per-user logging view

### DIFF
--- a/FEATURES.txt
+++ b/FEATURES.txt
@@ -22,3 +22,4 @@ Switch between user profiles
 Reset database from 
 Show Firestore credentials status
 Reusable profile filtering helper for Netlify Functions
+Track logs for individual users from admin

--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ GitHub Pages. Serverless functions for push notifications and scoring run on Net
 * Statistik over hvor mange gange profiler bliver åbnet
 * Graf over antallet af \u00E5bne fejl pr. dag
 * Matchlog kan åbnes fra adminområdet
+* Mulighed for at følge log for en specifik bruger
 
 
 ## Farvetema

--- a/src/VideotpushApp.jsx
+++ b/src/VideotpushApp.jsx
@@ -18,6 +18,7 @@ import ReportedContentScreen from './components/ReportedContentScreen.jsx';
 import AboutScreen from './components/AboutScreen.jsx';
 import FunctionTestScreen from './components/FunctionTestScreen.jsx';
 import TextLogScreen from './components/TextLogScreen.jsx';
+import TrackUserScreen from './components/TrackUserScreen.jsx';
 import { useCollection, requestNotificationPermission, subscribeToWebPush, db, doc, updateDoc, increment, logEvent } from './firebase.js';
 import { cacheMediaIfNewer } from './cacheMedia.js';
 
@@ -182,7 +183,7 @@ export default function VideotpushApp() {
             onOpenAbout: ()=>setTab('about')
           }),
           tab==='likes' && React.createElement(LikesScreen, { userId, onBack: ()=>setTab('discovery'), onSelectProfile: selectProfile }),
-          tab==='admin' && React.createElement(AdminScreen, { onOpenStats: ()=>setTab('stats'), onOpenBugReports: ()=>setTab('bugs'), onOpenMatchLog: ()=>setTab('matchlog'), onOpenScoreLog: ()=>setTab('scorelog'), onOpenReports: ()=>setTab('reports'), onOpenCallLog: ()=>setTab('calllog'), onOpenFunctionTest: ()=>setTab('functiontest'), onOpenTextLog: ()=>setTab('textlog'), profiles, userId, onSwitchProfile: id=>setUserId(id) }),
+          tab==='admin' && React.createElement(AdminScreen, { onOpenStats: ()=>setTab('stats'), onOpenBugReports: ()=>setTab('bugs'), onOpenMatchLog: ()=>setTab('matchlog'), onOpenScoreLog: ()=>setTab('scorelog'), onOpenReports: ()=>setTab('reports'), onOpenCallLog: ()=>setTab('calllog'), onOpenFunctionTest: ()=>setTab('functiontest'), onOpenTextLog: ()=>setTab('textlog'), onOpenUserLog: ()=>setTab('trackuser'), profiles, userId, onSwitchProfile: id=>setUserId(id) }),
           tab==='stats' && React.createElement(StatsScreen, { onBack: ()=>setTab('admin') }),
           tab==='matchlog' && React.createElement(MatchLogScreen, { onBack: ()=>setTab('admin') }),
           tab==='scorelog' && React.createElement(ScoreLogScreen, { onBack: ()=>setTab('admin') }),
@@ -191,6 +192,7 @@ export default function VideotpushApp() {
           tab==='bugs' && React.createElement(BugReportsScreen, { onBack: ()=>setTab('admin') }),
           tab==='functiontest' && React.createElement(FunctionTestScreen, { onBack: ()=>setTab('admin') }),
           tab==='textlog' && React.createElement(TextLogScreen, { onBack: ()=>setTab('admin') }),
+          tab==='trackuser' && React.createElement(TrackUserScreen, { onBack: ()=>setTab('admin'), profiles }),
           tab==='about' && React.createElement(AboutScreen, null)
         )
     ),

--- a/src/components/AdminScreen.jsx
+++ b/src/components/AdminScreen.jsx
@@ -9,7 +9,7 @@ import { getToken } from 'firebase/messaging';
 import { fcmReg } from '../swRegistration.js';
 
 
-export default function AdminScreen({ onOpenStats, onOpenBugReports, onOpenMatchLog, onOpenScoreLog, onOpenReports, onOpenCallLog, onOpenFunctionTest, onOpenTextLog, profiles = [], userId, onSwitchProfile }) {
+export default function AdminScreen({ onOpenStats, onOpenBugReports, onOpenMatchLog, onOpenScoreLog, onOpenReports, onOpenCallLog, onOpenFunctionTest, onOpenTextLog, onOpenUserLog, profiles = [], userId, onSwitchProfile }) {
 
   const { lang, setLang } = useLang();
   const t = useT();
@@ -181,6 +181,7 @@ export default function AdminScreen({ onOpenStats, onOpenBugReports, onOpenMatch
     React.createElement(Button, { className: 'mt-2 bg-blue-500 text-white px-4 py-2 rounded', onClick: onOpenTextLog }, 'Se log'),
     React.createElement(Button, { className: 'mt-2 bg-blue-500 text-white px-4 py-2 rounded', onClick: onOpenMatchLog }, 'Se matchlog'),
     React.createElement(Button, { className: 'mt-2 bg-blue-500 text-white px-4 py-2 rounded', onClick: onOpenScoreLog }, 'Se score log'),
+    React.createElement(Button, { className: 'mt-2 bg-blue-500 text-white px-4 py-2 rounded', onClick: onOpenUserLog }, 'F\u00f8lg bruger'),
 
     React.createElement('h3', { className: 'text-xl font-semibold mb-2 mt-4 text-blue-600' }, 'Push notifications'),
     React.createElement(Button, { className: 'mt-2 bg-blue-500 text-white px-4 py-2 rounded mr-2', onClick: () => sendPush('Dagens klip er klar') }, 'Dagens klip er klar'),

--- a/src/components/TrackUserScreen.jsx
+++ b/src/components/TrackUserScreen.jsx
@@ -1,0 +1,37 @@
+import React, { useState } from 'react';
+import { Card } from './ui/card.js';
+import { Button } from './ui/button.js';
+import SectionTitle from './SectionTitle.jsx';
+import { useCollection, db, collection, query, where, getDocs, deleteDoc } from '../firebase.js';
+
+export default function TrackUserScreen({ profiles = [], onBack }) {
+  const [userId, setUserId] = useState(profiles[0]?.id || '');
+  const logs = useCollection('textLogs', 'details.userId', userId);
+  const sorted = logs.sort((a, b) => new Date(b.timestamp) - new Date(a.timestamp));
+
+  const resetLogs = async () => {
+    const q = query(collection(db, 'textLogs'), where('details.userId', '==', userId));
+    const snap = await getDocs(q);
+    await Promise.all(snap.docs.map(d => deleteDoc(d.ref)));
+  };
+
+  return React.createElement(Card, { className: 'p-6 m-4 shadow-xl bg-white/90 overflow-y-auto max-h-[90vh]' },
+    React.createElement(SectionTitle, { title: 'F\u00f8lg bruger', colorClass: 'text-blue-600', action: React.createElement(Button, { onClick: onBack }, 'Tilbage') }),
+    React.createElement('label', { className: 'block mb-1' }, 'V\u00e6lg bruger'),
+    React.createElement('select', { className: 'border p-2 mb-4 w-full', value: userId, onChange: e => setUserId(e.target.value) },
+      profiles.map(p => React.createElement('option', { key: p.id, value: p.id }, p.name))
+    ),
+    React.createElement(Button, { className: 'mb-4 bg-blue-500 text-white px-4 py-2 rounded', onClick: resetLogs }, 'Reset log'),
+    sorted.length ?
+      React.createElement('ul', { className: 'space-y-2' },
+        sorted.map(l =>
+          React.createElement('li', { key: l.id, className: 'border-b pb-1 text-sm' },
+            React.createElement('div', { className: 'font-mono text-xs text-gray-500' }, l.timestamp),
+            React.createElement('div', null, l.event),
+            l.details && React.createElement('pre', { className: 'whitespace-pre-wrap break-words text-xs' }, JSON.stringify(l.details, null, 2))
+          )
+        )
+      ) :
+      React.createElement('p', { className: 'text-center mt-4 text-gray-500' }, 'Ingen logs')
+  );
+}


### PR DESCRIPTION
## Summary
- implement TrackUserScreen to monitor logs for a specific user
- open the tracking screen from the admin panel
- document the new admin ability in FEATURES.txt and README

## Testing
- `npm install`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68792cc10c8c832db3c49ce8d2e033ad