### PR TITLE
Add logging for service worker registration

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -11,7 +11,10 @@ if ('serviceWorker' in navigator) {
     // Register the main service worker generated in the production build
     await navigator.serviceWorker
       .register(new URL('../public/service-worker.js', import.meta.url))
-      .then(reg => console.log('SW registered', reg))
+      .then(reg => {
+        console.log('SW registered', reg);
+        logEvent('main service worker registered');
+      })
       .catch(err => console.error('SW registration failed', err));
 
     // Register the Firebase messaging service worker now located under src
@@ -19,6 +22,7 @@ if ('serviceWorker' in navigator) {
       .register(new URL('./firebase-messaging-sw.js', import.meta.url))
       .then(reg => {
         console.log('SW registered', reg);
+        logEvent('firebase messaging service worker registered');
         return reg;
       })
       .catch(err => {


### PR DESCRIPTION
## Summary
- log service worker registration when extended logging is enabled

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_6879306d92b8832d870faf139d6fade0