### PR TITLE
Add received notification checklist item

### DIFF
--- a/src/components/TrackUserScreen.jsx
+++ b/src/components/TrackUserScreen.jsx
@@ -10,6 +10,7 @@ export default function TrackUserScreen({ profiles = [], onBack }) {
   const [userId, setUserId] = useState(profiles[0]?.id || '');
   const logs = useCollection('textLogs', 'details.userId', userId);
   const sorted = logs.sort((a, b) => new Date(b.timestamp) - new Date(a.timestamp));
+  const hasReceivedNotification = logs.some(l => l.event === 'push received');
 
   const [checkResult, setCheckResult] = useState({});
 
@@ -78,6 +79,9 @@ export default function TrackUserScreen({ profiles = [], onBack }) {
       ),
       React.createElement('li', { className: checkResult.fcmToken ? 'text-green-600' : 'text-red-600' },
         (checkResult.fcmToken ? '✔' : '✖') + ' FCM token tilg\u00e6ngelig'
+      ),
+      React.createElement('li', { className: hasReceivedNotification ? 'text-green-600' : 'text-red-600' },
+        (hasReceivedNotification ? '✔' : '✖') + ' Har modtaget mindst en notifikation'
       ),
       React.createElement('li', { className: checkResult.online ? 'text-green-600' : 'text-red-600' },
         (checkResult.online ? '✔' : '✖') + ' Browseren er online'


### PR DESCRIPTION
## Summary
- track in TrackUserScreen if the user has received at least one push notification
- display a checklist item that turns green when a "push received" log exists

## Testing
- `npm install`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6879385abca4832d93cf91172e44a200