### PR TITLE
Save current admin user between logins

### DIFF
--- a/src/VideotpushApp.jsx
+++ b/src/VideotpushApp.jsx
@@ -32,6 +32,7 @@ export default function VideotpushApp() {
     return stored === 'true';
   });
   const DEFAULT_USER_ID = '101';
+  const LAST_USER_KEY = 'preferredUserId';
   const [userId, setUserId] = useState(null);
   const profiles = useCollection('profiles');
   const chats = useCollection('matches', 'userId', userId);
@@ -49,6 +50,15 @@ export default function VideotpushApp() {
 
   const openProfileSettings = () => {
     setTab('profile');
+    setViewProfile(null);
+  };
+
+  const saveUserAndLogout = () => {
+    if (userId) {
+      localStorage.setItem(LAST_USER_KEY, userId);
+    }
+    setLoggedIn(false);
+    setTab('discovery');
     setViewProfile(null);
   };
 
@@ -74,8 +84,12 @@ export default function VideotpushApp() {
       return;
     }
     if(!userId && profiles.length){
-      const defaultProfile = profiles.find(p => p.id === DEFAULT_USER_ID);
-      setUserId((defaultProfile || profiles[0]).id);
+      const savedId = localStorage.getItem(LAST_USER_KEY);
+      const defaultProfile =
+        (savedId && profiles.find(p => p.id === savedId)) ||
+        profiles.find(p => p.id === DEFAULT_USER_ID) ||
+        profiles[0];
+      if (defaultProfile) setUserId(defaultProfile.id);
     }
   },[loggedIn, profiles, userId]);
 
@@ -179,6 +193,7 @@ export default function VideotpushApp() {
             ageRange,
             onChangeAgeRange: setAgeRange,
             onLogout: ()=>{setLoggedIn(false); setTab('discovery'); setViewProfile(null);},
+            onSaveUserLogout: saveUserAndLogout,
             onViewPublicProfile: viewOwnPublicProfile,
             onOpenAbout: ()=>setTab('about')
           }),

--- a/src/components/ProfileSettings.jsx
+++ b/src/components/ProfileSettings.jsx
@@ -19,7 +19,7 @@ import { languages, useT } from '../i18n.js';
 import { getInterestCategory } from '../interests.js';
 import { getAge } from '../utils.js';
 
-export default function ProfileSettings({ userId, ageRange, onChangeAgeRange, publicView = false, onLogout = () => {}, onViewPublicProfile = () => {}, onOpenAbout = () => {}, viewerId, onBack }) {
+export default function ProfileSettings({ userId, ageRange, onChangeAgeRange, publicView = false, onLogout = () => {}, onSaveUserLogout, onViewPublicProfile = () => {}, onOpenAbout = () => {}, viewerId, onBack }) {
   const [profile,setProfile]=useState(null);
   const t = useT();
   const audioRef = useRef();
@@ -395,15 +395,21 @@ export default function ProfileSettings({ userId, ageRange, onChangeAgeRange, pu
 
   return React.createElement('div', { className:'mt-8' },
     !publicView && React.createElement(Card, { className: 'p-4 m-4 shadow-xl bg-white/90' },
-      React.createElement('div', { className: 'flex items-center justify-between' },
+      React.createElement('div', { className: 'flex items-center justify-between gap-2' },
         React.createElement(Button, {
           className: 'bg-gray-200 text-gray-700 px-4 py-2 rounded',
           onClick: onViewPublicProfile
         }, 'View public profile'),
-        React.createElement('button', {
-          className: 'bg-gray-200 text-gray-700 px-4 py-2 rounded',
-          onClick: onLogout
-        }, 'Logout')
+        React.createElement('div', { className: 'flex gap-2' },
+          React.createElement('button', {
+            className: 'bg-gray-200 text-gray-700 px-4 py-2 rounded',
+            onClick: onLogout
+          }, 'Logout'),
+          onSaveUserLogout && React.createElement('button', {
+            className: 'bg-gray-200 text-gray-700 px-4 py-2 rounded',
+            onClick: onSaveUserLogout
+          }, 'Save & Logout')
+        )
       ),
       React.createElement('div', { className: 'mt-4 flex justify-end' },
         React.createElement(Button, {


### PR DESCRIPTION
## Summary
- support saving admin-selected user for next login
- add Save & Logout button in Profile Settings

## Testing
- `npm test` *(fails: Missing script)*
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_687938d05f7c832da2574471467da083