### PR TITLE
Add formal policy documents

### DIFF
--- a/docs/community-guidelines.md
+++ b/docs/community-guidelines.md
@@ -1,0 +1,10 @@
+# Community Guidelines
+
+We want RealDate to be a friendly and respectful community. Please follow these guidelines:
+
+- Be kind and respectful to others.
+- Do not post offensive or illegal content.
+- Respect privacy and do not share personal information without consent.
+- Report any abusive behavior to the moderators.
+
+Failure to follow these guidelines may result in a warning or account suspension.

--- a/docs/cookie-policy.md
+++ b/docs/cookie-policy.md
@@ -1,0 +1,3 @@
+# Cookie Policy
+
+This site uses cookies or local storage to remember your preferences and keep you logged in. Cookies are only used for essential features and analytics to improve the service. You can clear cookies through your browser settings. By continuing to use the app you consent to our use of cookies.

--- a/docs/data-retention-policy.md
+++ b/docs/data-retention-policy.md
@@ -1,0 +1,3 @@
+# Data Retention and Deletion Policy
+
+We store your profile data, uploaded media and chat messages while your account remains active. Data required for accounting or legal purposes may be retained longer as required by law. When you delete your account, related data is removed from our active systems within 30 days. Backups may persist for up to 90 days before automatic deletion.

--- a/docs/privacy-policy.md
+++ b/docs/privacy-policy.md
@@ -1,0 +1,11 @@
+# Privacy Policy
+
+This app collects and stores personal data needed to provide the service. Profiles are stored in Firebase and may include uploaded media and chat messages. We only keep the minimum information required to operate the platform and will delete your data upon request. Data is processed in accordance with the EU General Data Protection Regulation (GDPR).
+
+**User Rights**
+- Access: You can request a copy of your stored data.
+- Rectification: You may update or correct your profile information.
+- Erasure: Contact support to delete your account and associated data.
+- Objection: You can object to data processing or withdraw consent at any time.
+
+We do not sell your data to third parties. Some data may be processed by service providers like Firebase and Netlify for hosting and push notifications.

--- a/docs/terms-of-service.md
+++ b/docs/terms-of-service.md
@@ -1,0 +1,11 @@
+# Terms of Service
+
+By using this app you agree to follow these terms:
+
+1. You must be at least 18 years old to create an account.
+2. Keep your login credentials secure and do not share them.
+3. You are responsible for any content you upload including videos, images, and messages.
+4. Do not harass other users or post illegal material.
+5. We may suspend accounts that violate these terms or applicable law.
+
+The service is provided "as is" without warranties. We may update these terms and will notify users of significant changes.


### PR DESCRIPTION
## Summary
- add a new `docs/` folder for formal documents
- provide basic policies: Privacy Policy, Terms of Service, Cookie Policy, Data Retention Policy, and Community Guidelines

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_68793c282920832db0ea90975471be4f