### PR TITLE
Add server logs and admin monitoring

### DIFF
--- a/netlify/functions/send-webpush.js
+++ b/netlify/functions/send-webpush.js
@@ -89,6 +89,14 @@ exports.handler = async function(event) {
       }
     })
   );
+
+  await db.collection('serverLogs').add({
+    timestamp: new Date().toISOString(),
+    type: 'send-webpush',
+    body,
+    subscriptions: subs.length,
+    failed: failed.length
+  }).catch(() => {});
   return {
     statusCode: 200,
     body: JSON.stringify({
@@ -100,6 +108,11 @@ exports.handler = async function(event) {
   };
   } catch (err) {
     console.error(err);
+    await db.collection('serverLogs').add({
+      timestamp: new Date().toISOString(),
+      type: 'send-webpush',
+      error: err.message
+    }).catch(() => {});
     return { statusCode: 500, body: 'Server error!' };
   }
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "videotpush",
-  "version": "1.0.33",
+  "version": "1.0.34",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "videotpush",
-      "version": "1.0.33",
+      "version": "1.0.34",
       "dependencies": {
         "firebase": "^9.23.0",
         "firebase-admin": "^11.10.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "videotpush",
-  "version": "1.0.34",
+  "version": "1.0.36",
   "description": "A minimal React PWA for swiping short videos and speed dating.",
   "scripts": {
     "start": "npx serve .",

--- a/src/VideotpushApp.jsx
+++ b/src/VideotpushApp.jsx
@@ -19,6 +19,7 @@ import AboutScreen from './components/AboutScreen.jsx';
 import FunctionTestScreen from './components/FunctionTestScreen.jsx';
 import TextLogScreen from './components/TextLogScreen.jsx';
 import TrackUserScreen from './components/TrackUserScreen.jsx';
+import ServerLogScreen from './components/ServerLogScreen.jsx';
 import { useCollection, requestNotificationPermission, subscribeToWebPush, db, doc, updateDoc, increment, logEvent } from './firebase.js';
 import { cacheMediaIfNewer } from './cacheMedia.js';
 
@@ -183,7 +184,7 @@ export default function VideotpushApp() {
             onOpenAbout: ()=>setTab('about')
           }),
           tab==='likes' && React.createElement(LikesScreen, { userId, onBack: ()=>setTab('discovery'), onSelectProfile: selectProfile }),
-          tab==='admin' && React.createElement(AdminScreen, { onOpenStats: ()=>setTab('stats'), onOpenBugReports: ()=>setTab('bugs'), onOpenMatchLog: ()=>setTab('matchlog'), onOpenScoreLog: ()=>setTab('scorelog'), onOpenReports: ()=>setTab('reports'), onOpenCallLog: ()=>setTab('calllog'), onOpenFunctionTest: ()=>setTab('functiontest'), onOpenTextLog: ()=>setTab('textlog'), onOpenUserLog: ()=>setTab('trackuser'), profiles, userId, onSwitchProfile: id=>setUserId(id) }),
+          tab==='admin' && React.createElement(AdminScreen, { onOpenStats: ()=>setTab('stats'), onOpenBugReports: ()=>setTab('bugs'), onOpenMatchLog: ()=>setTab('matchlog'), onOpenScoreLog: ()=>setTab('scorelog'), onOpenReports: ()=>setTab('reports'), onOpenCallLog: ()=>setTab('calllog'), onOpenFunctionTest: ()=>setTab('functiontest'), onOpenTextLog: ()=>setTab('textlog'), onOpenUserLog: ()=>setTab('trackuser'), onOpenServerLog: ()=>setTab('serverlog'), profiles, userId, onSwitchProfile: id=>setUserId(id) }),
           tab==='stats' && React.createElement(StatsScreen, { onBack: ()=>setTab('admin') }),
           tab==='matchlog' && React.createElement(MatchLogScreen, { onBack: ()=>setTab('admin') }),
           tab==='scorelog' && React.createElement(ScoreLogScreen, { onBack: ()=>setTab('admin') }),
@@ -193,6 +194,7 @@ export default function VideotpushApp() {
           tab==='functiontest' && React.createElement(FunctionTestScreen, { onBack: ()=>setTab('admin') }),
           tab==='textlog' && React.createElement(TextLogScreen, { onBack: ()=>setTab('admin') }),
           tab==='trackuser' && React.createElement(TrackUserScreen, { onBack: ()=>setTab('admin'), profiles }),
+          tab==='serverlog' && React.createElement(ServerLogScreen, { onBack: ()=>setTab('admin') }),
           tab==='about' && React.createElement(AboutScreen, null)
         )
     ),

--- a/src/components/AdminScreen.jsx
+++ b/src/components/AdminScreen.jsx
@@ -9,7 +9,7 @@ import { getToken } from 'firebase/messaging';
 import { fcmReg } from '../swRegistration.js';
 
 
-export default function AdminScreen({ onOpenStats, onOpenBugReports, onOpenMatchLog, onOpenScoreLog, onOpenReports, onOpenCallLog, onOpenFunctionTest, onOpenTextLog, onOpenUserLog, profiles = [], userId, onSwitchProfile }) {
+export default function AdminScreen({ onOpenStats, onOpenBugReports, onOpenMatchLog, onOpenScoreLog, onOpenReports, onOpenCallLog, onOpenFunctionTest, onOpenTextLog, onOpenUserLog, onOpenServerLog, profiles = [], userId, onSwitchProfile }) {
 
   const { lang, setLang } = useLang();
   const t = useT();
@@ -189,6 +189,7 @@ export default function AdminScreen({ onOpenStats, onOpenBugReports, onOpenMatch
     React.createElement(Button, { className: 'mt-2 bg-blue-500 text-white px-4 py-2 rounded', onClick: logClientToken }, 'Log client token'),
     React.createElement(Button, { className: 'mt-2 bg-blue-500 text-white px-4 py-2 rounded', onClick: showVapidKeys }, 'Show VAPID keys'),
     React.createElement(Button, { className: 'mt-2 bg-blue-500 text-white px-4 py-2 rounded', onClick: showPushInfo }, 'Show push info'),
+    React.createElement(Button, { className: 'mt-2 bg-blue-500 text-white px-4 py-2 rounded', onClick: onOpenServerLog }, 'Server log'),
 
 
     React.createElement('h3', { className: 'text-xl font-semibold mb-2 mt-4 text-blue-600' }, 'Aktive opkald'),

--- a/src/components/ServerLogScreen.jsx
+++ b/src/components/ServerLogScreen.jsx
@@ -1,0 +1,33 @@
+import React from 'react';
+import { Card } from './ui/card.js';
+import { Button } from './ui/button.js';
+import SectionTitle from './SectionTitle.jsx';
+import { useCollection } from '../firebase.js';
+
+export default function ServerLogScreen({ onBack }) {
+  const logs = useCollection('serverLogs');
+  const sorted = logs.sort((a,b)=>new Date(b.timestamp)-new Date(a.timestamp));
+  const latest = sorted[0] || {};
+  const checks = [
+    { label: 'Seneste log registreret', ok: !!latest.timestamp },
+    { label: 'Seneste kald lykkedes', ok: !latest.error },
+    { label: 'Ingen fejl i loggen', ok: !sorted.some(l => l.error) }
+  ];
+  return React.createElement(Card, { className:'p-6 m-4 shadow-xl bg-white/90 overflow-y-auto max-h-[90vh]' },
+    React.createElement(SectionTitle, { title:'Server log', colorClass:'text-blue-600', action: React.createElement(Button,{onClick:onBack},'Tilbage') }),
+    React.createElement('h3',{className:'text-lg font-semibold mb-2'},'Tjekliste'),
+    React.createElement('ul',{className:'list-disc ml-5 mb-4 text-sm'},
+      checks.map((c,i)=>React.createElement('li',{key:i,className:c.ok?'text-green-600':'text-red-600'},(c.ok?'\u2714':'\u2716')+' '+c.label))
+    ),
+    sorted.length ? (
+      React.createElement('ul',{className:'space-y-2'},
+        sorted.map(l=>React.createElement('li',{key:l.id,className:'border-b pb-1 text-sm'},
+          React.createElement('div',{className:'font-mono text-xs text-gray-500'},l.timestamp),
+          React.createElement('div',null,`${l.type||''} ${l.body||''}`),
+          React.createElement('div',{className:'text-xs'},`success: ${l.successCount||0}, failed: ${l.failed||l.errorCount||0}`),
+          l.error && React.createElement('div',{className:'text-red-600 text-xs'},`error: ${l.error}`)
+        ))
+      )
+    ) : React.createElement('p',{className:'text-center mt-4 text-gray-500'},'Ingen logs')
+  );
+}

--- a/src/version.js
+++ b/src/version.js
@@ -1,1 +1,1 @@
-export default '1.0.34';
+export default '1.0.36';


### PR DESCRIPTION
## Summary
- log push function activity to Firestore
- display server log checklist in admin section
- route new ServerLogScreen

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68793b5f4124832da4fc58c6f6c9b3bb