### PR TITLE
Allow send-push to accept provided tokens

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,7 +105,7 @@ The profile filtering logic used on the Daily Discovery page lives in `src/selec
 Firebase Cloud Messaging delivers updates on Android and desktop browsers. Notifications are sent using the HTTP **v1** API authenticated with a service account. Provide the service account path via `GOOGLE_APPLICATION_CREDENTIALS` or store the JSON in `FIREBASE_SERVICE_ACCOUNT_JSON`.
 The Netlify functions automatically read these variables and initialize the Firebase Admin SDK if present.
 
-`netlify/functions/send-push.js` sends FCM messages to tokens stored in Firestore. Trigger it with a `POST` request containing a `body` and optional `title`.
+`netlify/functions/send-push.js` sends FCM messages to tokens stored in Firestore. Trigger it with a `POST` request containing a `body` and optional `title`. You can also pass a `tokens` array to send to specific devices instead of using the stored tokens.
 
 For iOS PWAs, Safari only supports the standard Web Push API. A separate function (`netlify/functions/send-webpush.js`) sends notifications using VAPID keys defined in `WEB_PUSH_PUBLIC_KEY` and `WEB_PUSH_PRIVATE_KEY`. Subscriptions are stored in the `webPushSubscriptions` collection.
 
@@ -132,7 +132,9 @@ netlify dev
 The functions will be available at `http://localhost:8888`. You can send a test push with a `POST` request:
 
 ```bash
-curl -X POST http://localhost:8888/.netlify/functions/send-push -H "Content-Type: application/json" -d '{"body":"Hello from local"}'
+curl -X POST http://localhost:8888/.netlify/functions/send-push \
+  -H "Content-Type: application/json" \
+  -d '{"body":"Hello from local","tokens":["YOUR_TOKEN"]}'
 ```
 
 Make sure the Firebase credentials (`FIREBASE_*`) and VAPID keys (`WEB_PUSH_PUBLIC_KEY` and `WEB_PUSH_PRIVATE_KEY`) are set in your `.env` file so the functions can authenticate.

--- a/netlify/functions/send-push.js
+++ b/netlify/functions/send-push.js
@@ -1,3 +1,10 @@
+// POST payload example:
+// {
+//   "body": "Hello there",
+//   "title": "RealDate",
+//   "tokens": ["token1", "token2"] // optional
+// }
+
 const admin = require('firebase-admin');
 const fs = require('fs');
 const path = require('path');
@@ -37,12 +44,15 @@ exports.handler = async function(event) {
     return { statusCode: 405, body: 'Method Not Allowed' };
   }
   try {
-    const { title = 'RealDate', body } = JSON.parse(event.body || '{}');
+    const { title = 'RealDate', body, tokens: bodyTokens } = JSON.parse(event.body || '{}');
     if (!body) {
       return { statusCode: 400, body: 'Invalid payload' };
     }
-    const tokensSnap = await db.collection('pushTokens').get();
-    const tokens = tokensSnap.docs.map(d => d.id);
+    let tokens = bodyTokens;
+    if (!Array.isArray(tokens) || tokens.length === 0) {
+      const tokensSnap = await db.collection('pushTokens').get();
+      tokens = tokensSnap.docs.map(d => d.id);
+    }
     if (tokens.length === 0) {
       await db.collection('serverLogs').add({
         timestamp: new Date().toISOString(),


### PR DESCRIPTION
## Summary
- allow `send-push` netlify function to accept a `tokens` array
- document usage for custom tokens in README
- add a payload example comment in the function

## Testing
- `npm install`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6879596ceb84832da9df03e285ade61b