### PR TITLE
Add Save & Logout button to admin user selector

### DIFF
--- a/src/VideotpushApp.jsx
+++ b/src/VideotpushApp.jsx
@@ -199,7 +199,7 @@ export default function VideotpushApp() {
             onOpenAbout: ()=>setTab('about')
           }),
           tab==='likes' && React.createElement(LikesScreen, { userId, onBack: ()=>setTab('discovery'), onSelectProfile: selectProfile }),
-          tab==='admin' && React.createElement(AdminScreen, { onOpenStats: ()=>setTab('stats'), onOpenBugReports: ()=>setTab('bugs'), onOpenMatchLog: ()=>setTab('matchlog'), onOpenScoreLog: ()=>setTab('scorelog'), onOpenReports: ()=>setTab('reports'), onOpenCallLog: ()=>setTab('calllog'), onOpenFunctionTest: ()=>setTab('functiontest'), onOpenTextLog: ()=>setTab('textlog'), onOpenUserLog: ()=>setTab('trackuser'), onOpenServerLog: ()=>setTab('serverlog'), profiles, userId, onSwitchProfile: id=>setUserId(id) }),
+          tab==='admin' && React.createElement(AdminScreen, { onOpenStats: ()=>setTab('stats'), onOpenBugReports: ()=>setTab('bugs'), onOpenMatchLog: ()=>setTab('matchlog'), onOpenScoreLog: ()=>setTab('scorelog'), onOpenReports: ()=>setTab('reports'), onOpenCallLog: ()=>setTab('calllog'), onOpenFunctionTest: ()=>setTab('functiontest'), onOpenTextLog: ()=>setTab('textlog'), onOpenUserLog: ()=>setTab('trackuser'), onOpenServerLog: ()=>setTab('serverlog'), profiles, userId, onSwitchProfile: id=>setUserId(id), onSaveUserLogout: saveUserAndLogout }),
           tab==='stats' && React.createElement(StatsScreen, { onBack: ()=>setTab('admin') }),
           tab==='matchlog' && React.createElement(MatchLogScreen, { onBack: ()=>setTab('admin') }),
           tab==='scorelog' && React.createElement(ScoreLogScreen, { onBack: ()=>setTab('admin') }),

--- a/src/components/AdminScreen.jsx
+++ b/src/components/AdminScreen.jsx
@@ -9,7 +9,7 @@ import { getToken } from 'firebase/messaging';
 import { fcmReg } from '../swRegistration.js';
 
 
-export default function AdminScreen({ onOpenStats, onOpenBugReports, onOpenMatchLog, onOpenScoreLog, onOpenReports, onOpenCallLog, onOpenFunctionTest, onOpenTextLog, onOpenUserLog, onOpenServerLog, profiles = [], userId, onSwitchProfile }) {
+export default function AdminScreen({ onOpenStats, onOpenBugReports, onOpenMatchLog, onOpenScoreLog, onOpenReports, onOpenCallLog, onOpenFunctionTest, onOpenTextLog, onOpenUserLog, onOpenServerLog, profiles = [], userId, onSwitchProfile, onSaveUserLogout }) {
 
   const { lang, setLang } = useLang();
   const t = useT();
@@ -141,12 +141,18 @@ export default function AdminScreen({ onOpenStats, onOpenBugReports, onOpenMatch
       )
     ),
     React.createElement('label', { className: 'block mb-1' }, t('selectUser')),
-    React.createElement('select', {
-      className: 'border p-2 mb-4 w-full',
-      value: userId || '',
-      onChange: e => onSwitchProfile(e.target.value)
-    },
-      profiles.map(p => React.createElement('option', { key: p.id, value: p.id }, p.name))
+    React.createElement('div', { className: 'flex gap-2 mb-4' },
+      React.createElement('select', {
+        className: 'border p-2 flex-1',
+        value: userId || '',
+        onChange: e => onSwitchProfile(e.target.value)
+      },
+        profiles.map(p => React.createElement('option', { key: p.id, value: p.id }, p.name))
+      ),
+      onSaveUserLogout && React.createElement(Button, {
+        className: 'bg-blue-500 text-white px-4 py-2 rounded whitespace-nowrap',
+        onClick: onSaveUserLogout
+      }, 'Save & Logout')
     ),
 
     // Daily admin section


### PR DESCRIPTION
## Summary
- add optional `onSaveUserLogout` handler to `AdminScreen`
- show new **Save & Logout** button next to user dropdown
- pass `saveUserAndLogout` from `VideotpushApp` to `AdminScreen`

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6879eedea2c0832daf550ebfcc5d81f0