### PR TITLE
Fix invite link path

### DIFF
--- a/src/components/InviteOverlay.jsx
+++ b/src/components/InviteOverlay.jsx
@@ -5,7 +5,7 @@ import { useT } from '../i18n.js';
 
 export default function InviteOverlay({ onClose }) {
   const t = useT();
-  const link = window.location.origin;
+  const link = window.location.origin + '/VideoTinder';
 
   const copy = async () => {
     try {


### PR DESCRIPTION
## Summary
- ensure the invite overlay shares link with `/VideoTinder` path

## Testing
- `npm run build`
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6879f5f9ef04832d972265b278d3048e