### PR TITLE
Add logout button back on profile page

### DIFF
--- a/src/VideotpushApp.jsx
+++ b/src/VideotpushApp.jsx
@@ -63,6 +63,12 @@ export default function VideotpushApp() {
     setViewProfile(null);
   };
 
+  const logout = () => {
+    setLoggedIn(false);
+    setTab('discovery');
+    setViewProfile(null);
+  };
+
   const viewOwnPublicProfile = () => {
     setViewProfile(userId);
     setTab('discovery');
@@ -194,7 +200,8 @@ export default function VideotpushApp() {
             ageRange,
             onChangeAgeRange: setAgeRange,
             onViewPublicProfile: viewOwnPublicProfile,
-            onOpenAbout: ()=>setTab('about')
+            onOpenAbout: ()=>setTab('about'),
+            onLogout: logout
           }),
           tab==='likes' && React.createElement(LikesScreen, { userId, onBack: ()=>setTab('discovery'), onSelectProfile: selectProfile }),
           tab==='admin' && React.createElement(AdminScreen, { onOpenStats: ()=>setTab('stats'), onOpenBugReports: ()=>setTab('bugs'), onOpenMatchLog: ()=>setTab('matchlog'), onOpenScoreLog: ()=>setTab('scorelog'), onOpenReports: ()=>setTab('reports'), onOpenCallLog: ()=>setTab('calllog'), onOpenFunctionTest: ()=>setTab('functiontest'), onOpenTextLog: ()=>setTab('textlog'), onOpenUserLog: ()=>setTab('trackuser'), onOpenServerLog: ()=>setTab('serverlog'), profiles, userId, onSwitchProfile: id=>setUserId(id), onSaveUserLogout: saveUserAndLogout }),

--- a/src/components/ProfileSettings.jsx
+++ b/src/components/ProfileSettings.jsx
@@ -19,7 +19,7 @@ import { languages, useT } from '../i18n.js';
 import { getInterestCategory } from '../interests.js';
 import { getAge } from '../utils.js';
 
-export default function ProfileSettings({ userId, ageRange, onChangeAgeRange, publicView = false, onViewPublicProfile = () => {}, onOpenAbout = () => {}, viewerId, onBack }) {
+export default function ProfileSettings({ userId, ageRange, onChangeAgeRange, publicView = false, onViewPublicProfile = () => {}, onOpenAbout = () => {}, onLogout = null, viewerId, onBack }) {
   const [profile,setProfile]=useState(null);
   const t = useT();
   const audioRef = useRef();
@@ -400,7 +400,10 @@ export default function ProfileSettings({ userId, ageRange, onChangeAgeRange, pu
           className: 'bg-gray-200 text-gray-700 px-4 py-2 rounded',
           onClick: onViewPublicProfile
         }, 'View public profile'),
-        null
+        onLogout && React.createElement(Button, {
+          className: 'bg-gray-200 text-gray-700 px-4 py-2 rounded',
+          onClick: onLogout
+        }, 'Logout')
       ),
       React.createElement('div', { className: 'mt-4 flex justify-end' },
         React.createElement(Button, {


### PR DESCRIPTION
## Summary
- add optional `onLogout` prop to ProfileSettings
- render Logout button when handler is provided
- wire up new logout handler from VideotpushApp

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_6879fd765378832d9fc214a914dc1394