### PR TITLE
Fix invite.html not built

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "start": "npx serve .",
     "dev": "parcel public/index.html",
     "prebuild": "node scripts/bump-version.js",
-    "build": "parcel build public/index.html --dist-dir dist --public-url ./"
+    "build": "parcel build public/index.html public/invite.html --dist-dir dist --public-url ./"
   },
   "dependencies": {
     "firebase": "^9.23.0",


### PR DESCRIPTION
## Summary
- ensure invite.html is included when building for GitHub Pages

## Testing
- `npm ci`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_687a00f135d0832daef45099e76ea685