### PR TITLE
Adjust invite page layout

### DIFF
--- a/public/invite.html
+++ b/public/invite.html
@@ -9,9 +9,12 @@
   <link rel="stylesheet" href="../src/style.css" />
 </head>
 <body class="bg-gradient-to-br from-pink-100 to-white min-h-screen flex items-center justify-center p-4">
-  <div id="invite" class="bg-white/90 p-6 rounded-lg shadow-xl max-w-md w-full text-center">
-    <div id="profile-pic"></div>
-    <h1 id="invite-text" class="text-2xl font-bold text-pink-600 mb-4">RealDate Premium</h1>
+  <div id="invite" class="bg-white/90 p-6 rounded-lg shadow-xl max-w-md w-full">
+    <h1 class="text-3xl font-bold text-pink-600 text-center mb-4">RealDate</h1>
+    <div class="flex items-center mb-4">
+      <div id="profile-pic" class="mr-4"></div>
+      <h2 id="invite-text" class="text-xl font-bold text-pink-600"></h2>
+    </div>
     <p class="mb-4">Få 3 måneders gratis premium adgang med disse fordele:</p>
     <ul class="list-disc list-inside text-left mb-6 space-y-1">
       <li>🎞️ Flere daglige klip: Se fx 6 i stedet for 3 kandidater om dagen</li>

--- a/src/invite.js
+++ b/src/invite.js
@@ -16,7 +16,7 @@ async function loadInvite() {
       const img = document.createElement('img');
       img.src = profile.photoURL;
       img.alt = profile.name;
-      img.className = 'w-32 h-32 rounded-full object-cover mx-auto mb-4';
+      img.className = 'w-20 h-20 rounded-full object-cover mr-4';
       picEl.appendChild(img);
     }
     const cta = document.getElementById('cta');


### PR DESCRIPTION
## Summary
- tweak invite page layout
  - add RealDate heading at top
  - show profile picture on the left in a smaller size

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_687a186049e0832d86844dd39814b43b