### PR TITLE
Highlight gratis in Danish invite page

### DIFF
--- a/public/invite.html
+++ b/public/invite.html
@@ -15,7 +15,7 @@
       <div id="profile-pic" class="mr-4"></div>
       <h2 id="invite-text" class="text-xl font-bold text-pink-600"></h2>
     </div>
-    <p class="mb-4">Få 3 måneders gratis premium adgang med disse fordele:</p>
+    <p class="mb-4">Få 3 måneders <strong>gratis</strong> premium adgang med disse fordele:</p>
     <ul class="list-disc list-inside text-left mb-6 space-y-1">
       <li>🎞️ Flere daglige klip: Se fx 6 i stedet for 3 kandidater om dagen</li>
       <li>🔁 Se tidligere klip igen ("Fortryd swipe")</li>
@@ -23,7 +23,7 @@
       <li>📝 Udfoldede profiler – adgang til længere refleksioner, flere videoer</li>
       <li>🎙️ Profilbooster: Få dit klip vist tidligere på dagen</li>
     </ul>
-    <a id="cta" href="./index.html" class="block bg-pink-500 text-white py-3 rounded-lg font-bold text-center">Prøv gratis i 3 måneder</a>
+    <a id="cta" href="./index.html" class="block bg-pink-500 text-white py-3 rounded-lg font-bold text-center">Prøv <strong>gratis</strong> i 3 måneder</a>
   </div>
   <script type="module" src="../src/invite.js"></script>
 </body>


### PR DESCRIPTION
## Summary
- emphasize the word **gratis** in the invitation page text

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_687a27cc4cb4832db439528d4c24b6eb