### PR TITLE
Add sign-up thank you message

### DIFF
--- a/src/components/WelcomeScreen.jsx
+++ b/src/components/WelcomeScreen.jsx
@@ -68,6 +68,7 @@ export default function WelcomeScreen({ onLogin }) {
       }
     }
     await setDoc(doc(db, 'profiles', id), profile);
+    alert(t(giftFrom ? 'profileCreatedGift' : 'profileCreated'));
     onLogin(id);
   };
   return React.createElement(

--- a/src/i18n.js
+++ b/src/i18n.js
@@ -55,6 +55,8 @@ inviteDesc:{ en:'Share the link below to invite others to RealDate', da:'Del lin
 share:{ en:'Share', da:'Del', sv:'Dela', es:'Compartir', fr:'Partager', de:'Teilen' },
 copyLink:{ en:'Copy link', da:'Kopiér link', sv:'Kopiera länk', es:'Copiar enlace', fr:'Copier le lien', de:'Link kopieren' },
 linkCopied:{ en:'Link copied to clipboard', da:'Link kopieret', sv:'Länk kopierad', es:'Enlace copiado', fr:'Lien copié', de:'Link kopiert' },
+profileCreated:{ en:'Thanks for creating your profile!', da:'Tak fordi du oprettede din profil!', sv:'Tack för att du skapade din profil!', es:'¡Gracias por crear tu perfil!', fr:'Merci d\'avoir créé votre profil !', de:'Danke für das Erstellen deines Profils!' },
+profileCreatedGift:{ en:'You have received 3 months of premium for free.', da:'Du har fået gratis premium i 3 måneder.', sv:'Du har fått 3 månaders premium gratis.', es:'Has recibido 3 meses de premium gratis.', fr:'Vous avez reçu 3 mois de premium gratuit.', de:'Du hast 3 Monate Premium gratis erhalten.' },
 };
 
 const LangContext = createContext({ lang: 'en', setLang: () => {} });


### PR DESCRIPTION
## Summary
- thank users for creating their profile
- show a special message if they came from a premium invite
- add translations for the new messages

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_687a2959ccb8832da4ffc3f1cb9db153