### PR TITLE
Document vision for 'Dagens profiler'

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,9 @@ and simple profile management powered by Firebase. The code is hosted on
 [GitHub](https://github.com/nyhave/videotpush) and the live demo is served from
 GitHub Pages. Serverless functions for push notifications and scoring run on Netlify.
 
+For more background on the guiding principles, see [Vision for "Dagens profiler"](docs/vision.md).
+Profiles are presented as short episodes rather than a catalog of faces. Each episode guides you through introduction, a behind-the-scenes prompt answer, a glimpse of daily life and space for your reaction.
+
 ## Features
 
 * Daily discovery of short video clips (up to 3 or 6 with subscription)

--- a/docs/vision.md
+++ b/docs/vision.md
@@ -1,0 +1,26 @@
+# Vision for "Dagens profiler"
+
+Vision for "Dagens profiler" og refleksionsbaseret matching:
+
+I denne dating-app skal “Dagens profiler” ikke føles som en endeløs strøm af ansigter, men som små historier – mennesker, man får lov at møde i et tempo, der giver plads til eftertanke. I stedet for at swipe hurtigt videre, inviteres brugeren til at stoppe op, mærke efter og reflektere over, hvad det egentlig vækker i dem at møde en ny person.
+
+For at understrege følelsen af små historier præsenteres hver dagsprofil som en lille episode snarere end et punkt i et katalog. Brugeren guides gennem et kort forløb med fire mennesker, hvor hvert møde rummer:
+
+* **Introduktion** – et kort videoklip eller et citat der giver en stemning for personen.
+* **Bagom** – et uddrag af deres svar på dagens prompt, så man får en lille refleksion med.
+* **Hverdagsklip** – et glimt fra deres dagligdag i form af et kort videoklip.
+* **Din reaktion** – plads til at notere en umiddelbar reaktion eller sende en emoji.
+
+Denne episodiske tilgang gør det mere engagerende end at bladre i et uendeligt katalog og inviterer til fordybelse i stedet for hurtige swipes.
+
+Vi tror på, at dybere forbindelser starter med nysgerrighed og tid – ikke med hurtige valg. Derfor får brugeren adgang til hver profil i tre trin over tre dage:
+
+1. **Dag 1 – Refleksion:** Brugeren ser en kort præsentation og svarer på en refleksions-prompt, der gemmes til senere.
+2. **Dag 2 – Reaktion:** Brugeren genser profilen og kan nu sende små reaktioner, fx emojier eller en kort besked.
+3. **Dag 3 – Forbindelse:** Hvis brugeren vælger at vende tilbage igen, gives mulighed for at matche og starte en samtale.
+
+Brugeren kan til enhver tid vende tilbage til tidligere refleksioner og gense profiler, men det er først efter tre separate møder, at muligheden for at matche opstår.
+
+Dette flow skaber en oplevelse, hvor forbindelser får lov at modne over tid – og hvor førstehåndsindtryk bliver en begyndelse, ikke en dom.
+
+Brug visionen som pejlemærke i al videre udvikling – fra UI-tekst og animationshastigheder til onboarding og notifikationer.


### PR DESCRIPTION
## Summary
- document product vision in `docs/vision.md`
- reference the vision from README
- expand on small stories with an episodic flow

## Testing
- `npm install`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_687a4cbb05e4832d8e069604718fda3e