### PR TITLE
Implement admin day advance/reset

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "videotpush",
-  "version": "1.0.42",
+  "version": "1.0.45",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "videotpush",
-      "version": "1.0.42",
+      "version": "1.0.45",
       "dependencies": {
         "firebase": "^9.23.0",
         "firebase-admin": "^11.10.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "videotpush",
-  "version": "1.0.43",
+  "version": "1.0.45",
   "description": "A minimal React PWA for swiping short videos and speed dating.",
   "scripts": {
     "start": "npx serve .",

--- a/src/VideotpushApp.jsx
+++ b/src/VideotpushApp.jsx
@@ -21,6 +21,7 @@ import TextLogScreen from './components/TextLogScreen.jsx';
 import TrackUserScreen from './components/TrackUserScreen.jsx';
 import ServerLogScreen from './components/ServerLogScreen.jsx';
 import { useCollection, requestNotificationPermission, subscribeToWebPush, db, doc, updateDoc, increment, logEvent } from './firebase.js';
+import { getCurrentDate } from './utils.js';
 import { cacheMediaIfNewer } from './cacheMedia.js';
 
 
@@ -105,7 +106,7 @@ export default function VideotpushApp() {
     if(loggedIn && userId){
       logEvent('active user', { userId });
       updateDoc(doc(db, 'profiles', userId), {
-        lastActive: new Date().toISOString()
+        lastActive: getCurrentDate().toISOString()
       }).catch(err => console.error('Failed to update lastActive', err));
     }
   }, [loggedIn, userId]);

--- a/src/components/AdminScreen.jsx
+++ b/src/components/AdminScreen.jsx
@@ -5,6 +5,7 @@ import { Button } from './ui/button.js';
 import SectionTitle from './SectionTitle.jsx';
 import seedData from '../seedData.js';
 import { db, updateDoc, doc, getDoc, storage, listAll, ref, getDownloadURL, messaging, setExtendedLogging, isExtendedLogging, useDoc } from '../firebase.js';
+import { advanceDay, resetDay, getTodayStr } from '../utils.js';
 import { getToken } from 'firebase/messaging';
 import { fcmReg } from '../swRegistration.js';
 
@@ -183,8 +184,19 @@ export default function AdminScreen({ onOpenStats, onOpenBugReports, onOpenMatch
       }, 'Save & Logout')
     ),
 
-    // Daily admin section
-    React.createElement('h3', { className: 'text-xl font-semibold mb-2 mt-4 text-blue-600' }, 'Daglig administration'),
+  // Daily admin section
+  React.createElement('h3', { className: 'text-xl font-semibold mb-2 mt-4 text-blue-600' }, 'Daglig administration'),
+    React.createElement('p', { className: 'mb-2' }, 'Dagens dato: ' + getTodayStr()),
+    React.createElement('div', { className: 'flex gap-2 mb-4' },
+      React.createElement(Button, {
+        className: 'bg-blue-500 text-white px-4 py-2 rounded',
+        onClick: () => { advanceDay(); location.reload(); }
+      }, 'Næste dag'),
+      React.createElement(Button, {
+        className: 'bg-blue-500 text-white px-4 py-2 rounded',
+        onClick: () => { resetDay(); location.reload(); }
+      }, 'Reset dag')
+    ),
     React.createElement('h3', { className: 'text-xl font-semibold mb-2 text-blue-600' }, 'Fejlmeldinger'),
     React.createElement(Button, { className: 'mt-2 bg-blue-500 text-white px-4 py-2 rounded', onClick: onOpenBugReports }, 'Se alle fejlmeldinger'),
     React.createElement('h3', { className: 'text-xl font-semibold mb-2 mt-4 text-blue-600' }, 'Anmeldt indhold'),

--- a/src/components/DailyCheckIn.jsx
+++ b/src/components/DailyCheckIn.jsx
@@ -1,4 +1,5 @@
 import React, { useState } from 'react';
+import { getCurrentDate, getTodayStr } from '../utils.js';
 import { Card } from './ui/card.js';
 import { Button } from './ui/button.js';
 import { Textarea } from './ui/textarea.js';
@@ -10,7 +11,7 @@ export default function DailyCheckIn({ userId }) {
   const refs = useCollection('reflections','userId',userId);
   const t = useT();
   const [month,setMonth]=useState(()=>{
-    const d=new Date();
+    const d=getCurrentDate();
     d.setDate(1);
     return d;
   });
@@ -23,8 +24,8 @@ export default function DailyCheckIn({ userId }) {
   const save = async () => {
     const trimmed = text.trim();
     if(!trimmed) return;
-    const now = new Date();
-    const date = now.toISOString().split('T')[0];
+    const now = getCurrentDate();
+    const date = getTodayStr();
     const id = `${userId}-${date}`;
     await setDoc(doc(db,'reflections',id),{id,userId,date,text:trimmed});
     setText('');

--- a/src/components/DailyDiscovery.jsx
+++ b/src/components/DailyDiscovery.jsx
@@ -1,5 +1,5 @@
 import React, { useState, useEffect } from 'react';
-import { getAge } from '../utils.js';
+import { getAge, getTodayStr, getCurrentDate } from '../utils.js';
 import { User, PlayCircle, Heart } from 'lucide-react';
 import VideoOverlay from './VideoOverlay.jsx';
 import { Card } from './ui/card.js';
@@ -17,7 +17,7 @@ export default function DailyDiscovery({ userId, onSelectProfile, ageRange, onOp
   const t = useT();
   const user = profiles.find(p => p.id === userId) || {};
   const hasSubscription = user.subscriptionExpires && new Date(user.subscriptionExpires) > new Date();
-  const today = new Date().toISOString().split('T')[0];
+  const today = getTodayStr();
   const filtered = selectProfiles(user, profiles, ageRange);
   useEffect(() => {
     if(!userId || !profiles.length) return;
@@ -25,7 +25,7 @@ export default function DailyDiscovery({ userId, onSelectProfile, ageRange, onOp
     const selectedIds = filtered.map(p => p.id);
     const log = {
       userId,
-      date: new Date().toISOString(),
+      date: getCurrentDate().toISOString(),
       potential: scored.map(p => ({ id: p.id, score: { score: p.score, breakdown: p.breakdown } })),
       selected: scored
         .filter(p => selectedIds.includes(p.id))
@@ -45,7 +45,7 @@ export default function DailyDiscovery({ userId, onSelectProfile, ageRange, onOp
   const [activeVideo, setActiveVideo] = useState(null);
   const [showBest, setShowBest] = useState(false);
   const handleExtraPurchase = async () => {
-    const todayStr = new Date().toISOString().split('T')[0];
+    const todayStr = getTodayStr();
     await updateDoc(doc(db, 'profiles', userId), { extraClipsDate: todayStr });
     setShowPurchase(false);
   };
@@ -93,7 +93,7 @@ export default function DailyDiscovery({ userId, onSelectProfile, ageRange, onOp
     }
   };
   useEffect(() => {
-    const now = new Date();
+    const now = getCurrentDate();
     const next = new Date(now);
     next.setDate(now.getDate() + 1);
     next.setHours(0,0,0,0);

--- a/src/components/StatsScreen.jsx
+++ b/src/components/StatsScreen.jsx
@@ -5,7 +5,7 @@ import SectionTitle from './SectionTitle.jsx';
 import { db, collection, getDocs, setDoc, doc } from '../firebase.js';
 import StatsChart from './StatsChart.jsx';
 import AgeDistributionChart from './AgeDistributionChart.jsx';
-import { getAge } from '../utils.js';
+import { getAge, getTodayStr } from '../utils.js';
 
 export default function StatsScreen({ onBack }) {
   const [stats, setStats] = useState(null);
@@ -62,7 +62,7 @@ export default function StatsScreen({ onBack }) {
       };
       setStats(data);
 
-      const today = new Date().toISOString().split('T')[0];
+      const today = getTodayStr();
       await setDoc(doc(db, 'dailyStats', today), { date: today, ...data }, { merge: true });
       const histSnap = await getDocs(collection(db, 'dailyStats'));
       const hist = histSnap.docs.map(d => d.data()).sort((a, b) => a.date.localeCompare(b.date));

--- a/src/selectProfiles.js
+++ b/src/selectProfiles.js
@@ -1,6 +1,6 @@
 // Filtering helper kept separate so it can also run in a Netlify
 // Function. Netlify Functions support both JavaScript and TypeScript.
-import { getAge } from './utils.js';
+import { getAge, getTodayStr } from './utils.js';
 import { getInterestCategory } from './interests.js';
 
 // Calculate a detailed match score for a single profile. Missing data is handled
@@ -131,7 +131,7 @@ export function scoreProfiles(user, profiles, ageRange) {
 export default function selectProfiles(user, profiles, ageRange) {
   const hasSubscription =
     user.subscriptionExpires && new Date(user.subscriptionExpires) > new Date();
-  const today = new Date().toISOString().split('T')[0];
+  const today = getTodayStr();
   const extra = user.extraClipsDate === today ? 3 : 0;
   const limit = (hasSubscription ? 6 : 3) + extra;
   return scoreProfiles(user, profiles, ageRange).slice(0, limit);

--- a/src/utils.js
+++ b/src/utils.js
@@ -1,7 +1,27 @@
+export function getCurrentDate(){
+  const offset = parseInt(localStorage.getItem('dayOffset') || '0', 10);
+  const d = new Date();
+  d.setDate(d.getDate() + offset);
+  return d;
+}
+
+export function getTodayStr(){
+  return getCurrentDate().toISOString().split('T')[0];
+}
+
+export function advanceDay(){
+  const off = parseInt(localStorage.getItem('dayOffset') || '0', 10) + 1;
+  localStorage.setItem('dayOffset', off);
+}
+
+export function resetDay(){
+  localStorage.removeItem('dayOffset');
+}
+
 export function getAge(birthday){
   if(!birthday) return '';
   const birth = new Date(birthday);
-  const today = new Date();
+  const today = getCurrentDate();
   let age = today.getFullYear() - birth.getFullYear();
   const m = today.getMonth() - birth.getMonth();
   if(m < 0 || (m === 0 && today.getDate() < birth.getDate())){

--- a/src/version.js
+++ b/src/version.js
@@ -1,1 +1,1 @@
-export default '1.0.43';
+export default '1.0.45';


### PR DESCRIPTION
## Summary
- let admin advance/reset current day for demo purposes
- compute "today" based on stored day offset
- use new date helpers across daily features
- bump version to 1.0.45

## Testing
- `npm install`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_687a4d37b31c832d9dfffbf503229d52