### PR TITLE
Implement episodic daily profiles

### DIFF
--- a/FEATURES.txt
+++ b/FEATURES.txt
@@ -1,4 +1,5 @@
 Daily discovery of short video clips or sound clips
+Three-day episodic flow for each profile (reflection, reaction, connection)
 Basic chat between matched profiles
 Unmatch to remove chat from both users
 Calendar interface for daily reflection notes

--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ Profiles are presented as short episodes rather than a catalog of faces. Each ep
 
 * Daily discovery of short video clips (up to 3 or 6 with subscription)
 * Option to buy 3 extra clips for the day
+* Profiles open as short episodes over three days: reflection, reaction and finally the option to match
 * Monthly subscriptions with visible expiration date and stored purchase date
 * Basic chat between matched profiles with option to unmatch
 * Improved chat layout with timestamps for better readability 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "videotpush",
-  "version": "1.0.45",
+  "version": "1.0.46",
   "description": "A minimal React PWA for swiping short videos and speed dating.",
   "scripts": {
     "start": "npx serve .",

--- a/src/VideotpushApp.jsx
+++ b/src/VideotpushApp.jsx
@@ -20,6 +20,7 @@ import FunctionTestScreen from './components/FunctionTestScreen.jsx';
 import TextLogScreen from './components/TextLogScreen.jsx';
 import TrackUserScreen from './components/TrackUserScreen.jsx';
 import ServerLogScreen from './components/ServerLogScreen.jsx';
+import ProfileEpisode from './components/ProfileEpisode.jsx';
 import { useCollection, requestNotificationPermission, subscribeToWebPush, db, doc, updateDoc, increment, logEvent } from './firebase.js';
 import { getCurrentDate } from './utils.js';
 import { cacheMediaIfNewer } from './cacheMedia.js';
@@ -186,14 +187,20 @@ export default function VideotpushApp() {
             React.createElement(DailyDiscovery, { userId, onSelectProfile: selectProfile, ageRange, onOpenProfile: openProfileSettings })
           ),
           viewProfile && (
-            React.createElement(ProfileSettings, {
-              userId: viewProfile,
-              viewerId: userId,
-              ageRange,
-              onChangeAgeRange: setAgeRange,
-              publicView: true,
-              onBack: viewProfile === userId ? openProfileSettings : openDailyClips
-            })
+            viewProfile === userId ?
+              React.createElement(ProfileSettings, {
+                userId: viewProfile,
+                viewerId: userId,
+                ageRange,
+                onChangeAgeRange: setAgeRange,
+                publicView: true,
+                onBack: openProfileSettings
+              }) :
+              React.createElement(ProfileEpisode, {
+                userId,
+                profileId: viewProfile,
+                onBack: openDailyClips
+              })
           ),
           tab==='chat' && React.createElement(ChatScreen, { userId, onStartCall: id => setVideoCallId(id) }),
           tab==='checkin' && React.createElement(DailyCheckIn, { userId }),

--- a/src/components/ProfileEpisode.jsx
+++ b/src/components/ProfileEpisode.jsx
@@ -1,0 +1,88 @@
+import React, { useState } from 'react';
+import { useDoc, db, doc, setDoc } from '../firebase.js';
+import { getTodayStr } from '../utils.js';
+import { Card } from './ui/card.js';
+import { Button } from './ui/button.js';
+import { Textarea } from './ui/textarea.js';
+import SectionTitle from './SectionTitle.jsx';
+import { useT } from '../i18n.js';
+import ProfileSettings from './ProfileSettings.jsx';
+
+export default function ProfileEpisode({ userId, profileId, onBack }) {
+  const progressId = `${userId}-${profileId}`;
+  const progress = useDoc('episodeProgress', progressId);
+  const profile = useDoc('profiles', profileId);
+  const t = useT();
+  const [reflection, setReflection] = useState('');
+  const [reaction, setReaction] = useState('');
+
+  if (!profile) return null;
+  const stage = progress?.stage || 1;
+  const lastDate = progress?.lastUpdated;
+  const today = getTodayStr();
+
+  const waiting = lastDate === today && stage !== 3;
+
+  const saveReflection = async () => {
+    const text = reflection.trim();
+    if (!text) return;
+    await setDoc(doc(db, 'episodeProgress', progressId), {
+      id: progressId,
+      userId,
+      profileId,
+      stage: 2,
+      lastUpdated: today,
+      reflection: text
+    }, { merge: true });
+  };
+
+  const saveReaction = async () => {
+    const text = reaction.trim();
+    if (!text) return;
+    await setDoc(doc(db, 'episodeProgress', progressId), {
+      id: progressId,
+      userId,
+      profileId,
+      stage: 3,
+      lastUpdated: today,
+      reaction: text
+    }, { merge: true });
+  };
+
+  if (stage >= 3) {
+    return React.createElement(ProfileSettings, {
+      userId: profileId,
+      viewerId: userId,
+      publicView: true,
+      onBack
+    });
+  }
+
+  return React.createElement(Card, { className: 'p-6 m-4 shadow-xl bg-white/90' },
+    React.createElement(Button, { className: 'mb-4 bg-pink-500 text-white', onClick: onBack }, 'Tilbage'),
+    React.createElement(SectionTitle, { title: t('episodeIntro') }),
+    profile.clip && React.createElement('p', { className: 'mb-4' }, `"${profile.clip}"`),
+    stage === 1 && React.createElement(React.Fragment, null,
+      React.createElement(Textarea, {
+        value: reflection,
+        onChange: e => setReflection(e.target.value),
+        placeholder: t('episodeReflectionPrompt'),
+        className: 'mb-4'
+      }),
+      waiting ?
+        React.createElement('p', { className: 'text-sm text-gray-500' }, t('episodeReturnTomorrow')) :
+        React.createElement(Button, { className: 'bg-pink-500 text-white', onClick: saveReflection }, 'Gem')
+    ),
+    stage === 2 && React.createElement(React.Fragment, null,
+      React.createElement(Textarea, {
+        value: reaction,
+        onChange: e => setReaction(e.target.value),
+        placeholder: t('episodeReactionPrompt'),
+        className: 'mb-4'
+      }),
+      waiting ?
+        React.createElement('p', { className: 'text-sm text-gray-500' }, t('episodeReturnTomorrow')) :
+        React.createElement(Button, { className: 'bg-pink-500 text-white', onClick: saveReaction }, 'Gem')
+    )
+  );
+}

--- a/src/i18n.js
+++ b/src/i18n.js
@@ -57,6 +57,11 @@ copyLink:{ en:'Copy link', da:'Kopiér link', sv:'Kopiera länk', es:'Copiar enl
 linkCopied:{ en:'Link copied to clipboard', da:'Link kopieret', sv:'Länk kopierad', es:'Enlace copiado', fr:'Lien copié', de:'Link kopiert' },
   profileCreated:{ en:'Thanks for creating your profile!', da:'Tak fordi du oprettede din profil!', sv:'Tack för att du skapade din profil!', es:'¡Gracias por crear tu perfil!', fr:'Merci d\'avoir créé votre profil !', de:'Danke für das Erstellen deines Profils!' },
   profileCreatedGift:{ en:'You have received 3 months of premium for free.', da:'Du har fået gratis premium i 3 måneder.', sv:'Du har fått 3 månaders premium gratis.', es:'Has recibido 3 meses de premium gratis.', fr:'Vous avez reçu 3 mois de premium gratuit.', de:'Du hast 3 Monate Premium gratis erhalten.' },
+  episodeIntro:{ en:'Introduction', da:'Introduktion', sv:'Introduktion', es:'Introducción', fr:'Introduction', de:'Einführung' },
+  episodeReflectionPrompt:{ en:'Write a short reflection...', da:'Skriv en kort refleksion...', sv:'Skriv en kort reflektion...', es:'Escribe una breve reflexión...', fr:'Écrivez une courte réflexion...', de:'Schreibe eine kurze Reflexion...' },
+  episodeReactionPrompt:{ en:'Send a reaction', da:'Send en reaktion', sv:'Skicka en reaktion', es:'Envía una reacción', fr:'Envoyer une réaction', de:'Sende eine Reaktion' },
+  episodeReturnTomorrow:{ en:'Come back tomorrow to continue', da:'Kom tilbage i morgen for at fortsætte', sv:'Kom tillbaka i morgon för att fortsätta', es:'Vuelve mañana para continuar', fr:'Revenez demain pour continuer', de:'Komm morgen zurück, um fortzufahren' },
+  episodeMatchPrompt:{ en:'Start conversation', da:'Start samtale', sv:'Starta samtal', es:'Iniciar conversación', fr:'Commencer la conversation', de:'Gespräch starten' },
   missingFieldsTitle:{ en:'Missing information', da:'Mangler information', sv:'Saknar information', es:'Falta información', fr:'Informations manquantes', de:'Fehlende Angaben' },
   missingFieldsDesc:{ en:'Please fill out all required fields', da:'Udfyld venligst alle obligatoriske felter', sv:'Vänligen fyll i alla obligatoriska fält', es:'Por favor, completa todos los campos obligatorios', fr:'Veuillez remplir tous les champs obligatoires', de:'Bitte fülle alle Pflichtfelder aus' },
 };

--- a/src/version.js
+++ b/src/version.js
@@ -1,1 +1,1 @@
-export default '1.0.45';
+export default '1.0.46';


### PR DESCRIPTION
## Summary
- support three-day episodes per profile with new `ProfileEpisode` component
- hook into `VideotpushApp` to display the episodic flow
- translate new UI text in `i18n.js`
- document episodic flow in `FEATURES.txt` and `README`
- bump version to 1.0.46

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_687a51311684832dbc3fb8c77c0d0213