### PR TITLE
Enhance profile episode flow

### DIFF
--- a/src/components/ProfileEpisode.jsx
+++ b/src/components/ProfileEpisode.jsx
@@ -15,6 +15,11 @@ export default function ProfileEpisode({ userId, profileId, onBack }) {
   const t = useT();
   const [reflection, setReflection] = useState('');
   const [reaction, setReaction] = useState('');
+  const stepLabels = [
+    t('episodeStageReflection'),
+    t('episodeStageReaction'),
+    t('episodeStageConnect')
+  ];
 
   if (!profile) return null;
   const stage = progress?.stage || 1;
@@ -60,6 +65,13 @@ export default function ProfileEpisode({ userId, profileId, onBack }) {
 
   return React.createElement(Card, { className: 'p-6 m-4 shadow-xl bg-white/90' },
     React.createElement(Button, { className: 'mb-4 bg-pink-500 text-white', onClick: onBack }, 'Tilbage'),
+    React.createElement('div', { className: 'flex justify-center gap-2 mb-2' },
+      stepLabels.map((_, i) => React.createElement('span', {
+        key: i,
+        className: `w-3 h-3 rounded-full ${i < stage ? 'bg-pink-500' : 'bg-gray-300'}`
+      }))
+    ),
+    React.createElement('p', { className:'text-center text-sm text-gray-600 mb-2' }, stepLabels[stage-1]),
     React.createElement(SectionTitle, { title: t('episodeIntro') }),
     profile.clip && React.createElement('p', { className: 'mb-4' }, `"${profile.clip}"`),
     stage === 1 && React.createElement(React.Fragment, null,
@@ -74,6 +86,8 @@ export default function ProfileEpisode({ userId, profileId, onBack }) {
         React.createElement(Button, { className: 'bg-pink-500 text-white', onClick: saveReflection }, 'Gem')
     ),
     stage === 2 && React.createElement(React.Fragment, null,
+      progress?.reflection &&
+        React.createElement('p', { className: 'italic text-gray-700 mb-2' }, `“${progress.reflection}”`),
       React.createElement(Textarea, {
         value: reaction,
         onChange: e => setReaction(e.target.value),

--- a/src/i18n.js
+++ b/src/i18n.js
@@ -62,6 +62,9 @@ linkCopied:{ en:'Link copied to clipboard', da:'Link kopieret', sv:'Länk kopier
   episodeReactionPrompt:{ en:'Send a reaction', da:'Send en reaktion', sv:'Skicka en reaktion', es:'Envía una reacción', fr:'Envoyer une réaction', de:'Sende eine Reaktion' },
   episodeReturnTomorrow:{ en:'Come back tomorrow to continue', da:'Kom tilbage i morgen for at fortsætte', sv:'Kom tillbaka i morgon för att fortsätta', es:'Vuelve mañana para continuar', fr:'Revenez demain pour continuer', de:'Komm morgen zurück, um fortzufahren' },
   episodeMatchPrompt:{ en:'Start conversation', da:'Start samtale', sv:'Starta samtal', es:'Iniciar conversación', fr:'Commencer la conversation', de:'Gespräch starten' },
+  episodeStageReflection:{ en:'Reflection', da:'Refleksion', sv:'Reflektion', es:'Reflexión', fr:'Réflexion', de:'Reflexion' },
+  episodeStageReaction:{ en:'Reaction', da:'Reaktion', sv:'Reaktion', es:'Reacción', fr:'Réaction', de:'Reaktion' },
+  episodeStageConnect:{ en:'Connect', da:'Forbind', sv:'Anslut', es:'Conectar', fr:'Connecter', de:'Verbinden' },
   missingFieldsTitle:{ en:'Missing information', da:'Mangler information', sv:'Saknar information', es:'Falta información', fr:'Informations manquantes', de:'Fehlende Angaben' },
   missingFieldsDesc:{ en:'Please fill out all required fields', da:'Udfyld venligst alle obligatoriske felter', sv:'Vänligen fyll i alla obligatoriska fält', es:'Por favor, completa todos los campos obligatorios', fr:'Veuillez remplir tous les champs obligatoires', de:'Bitte fülle alle Pflichtfelder aus' },
 };


### PR DESCRIPTION
## Summary
- add new i18n entries for episode step labels
- show progress indicator and saved reflection in ProfileEpisode

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_687a582328ac832dbe6d05c7752c41d1