### PR TITLE
Add premium invite stats graph

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ Profiles are presented as short episodes rather than a catalog of faces. Each ep
 * Animation med nedtælling viser hvor lang tid der er tilbage under lyd- og videooptagelse
 * Daglige statistikker gemmes automatisk og vises som grafer i adminområdet
 * Statistik over hvor mange gange profiler bliver åbnet
+* Graf over antallet af premium invitationer
 * Graf over antallet af \u00E5bne fejl pr. dag
 * Matchlog kan åbnes fra adminområdet
 * Mulighed for at følge log for en specifik bruger

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "videotpush",
-  "version": "1.0.45",
+  "version": "1.0.46",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "videotpush",
-      "version": "1.0.45",
+      "version": "1.0.46",
       "dependencies": {
         "firebase": "^9.23.0",
         "firebase-admin": "^11.10.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "videotpush",
-  "version": "1.0.46",
+  "version": "1.0.47",
   "description": "A minimal React PWA for swiping short videos and speed dating.",
   "scripts": {
     "start": "npx serve .",

--- a/src/components/StatsScreen.jsx
+++ b/src/components/StatsScreen.jsx
@@ -28,6 +28,7 @@ export default function StatsScreen({ onBack }) {
       const videoCount = profilesSnap.docs.reduce((acc, d) => acc + ((d.data().videoClips || []).length), 0);
       const audioCount = profilesSnap.docs.reduce((acc, d) => acc + ((d.data().audioClips || []).length), 0);
       const viewCount = profilesSnap.docs.reduce((acc, d) => acc + (d.data().viewCount || 0), 0);
+      const inviteCount = profilesSnap.docs.reduce((acc, d) => acc + (d.data().premiumInvitesUsed || 0), 0);
       const activeSince = Date.now() - 30 * 24 * 60 * 60 * 1000;
       const activeUsers = profilesSnap.docs.filter(d => {
         const last = d.data().lastActive;
@@ -58,7 +59,8 @@ export default function StatsScreen({ onBack }) {
         videos: videoCount,
         audios: audioCount,
         views: viewCount,
-        activeUsers
+        activeUsers,
+        invites: inviteCount
       };
       setStats(data);
 
@@ -84,6 +86,7 @@ export default function StatsScreen({ onBack }) {
       React.createElement(StatsChart, { data: history, fields: ['videos','audios'], title: 'Uploads over tid' }),
       React.createElement(StatsChart, { data: history, fields: 'views', title: 'Profilvisninger over tid' }),
       React.createElement(StatsChart, { data: history, fields: 'activeUsers', title: 'Aktive brugere over tid' }),
+      React.createElement(StatsChart, { data: history, fields: 'invites', title: 'Premium invitationer over tid' }),
       ageDist && React.createElement(AgeDistributionChart, { distribution: ageDist, title: 'Aldersfordeling' })
     ) : React.createElement('p', null, 'Indlæser...')
   );

--- a/src/version.js
+++ b/src/version.js
@@ -1,1 +1,1 @@
-export default '1.0.46';
+export default '1.0.47';


### PR DESCRIPTION
## Summary
- bump version
- track how many premium invites have been used
- show premium invitations over time in admin statistics
- document new premium invite graph in the README

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_687a5d73f434832db904a34c6a0d2a9c