### PR TITLE
Add private profile rating

### DIFF
--- a/FEATURES.txt
+++ b/FEATURES.txt
@@ -1,5 +1,6 @@
 Daily discovery of short video clips or sound clips
 Three-day episodic flow for each profile (reflection, reaction, connection)
+Three-star rating stored with each reflection (ratings are private)
 Basic chat between matched profiles
 Unmatch to remove chat from both users
 Calendar interface for daily reflection notes

--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ Profiles are presented as short episodes rather than a catalog of faces. Each ep
 * Daily discovery of short video clips (up to 3 or 6 with subscription)
 * Option to buy 3 extra clips for the day
 * Profiles open as short episodes over three days: reflection, reaction and finally the option to match
+* Rate each profile with up to three stars when writing your reflection (ratings are private)
 * Monthly subscriptions with visible expiration date and stored purchase date
 * Basic chat between matched profiles with option to unmatch
 * Improved chat layout with timestamps for better readability 

--- a/src/components/ProfileEpisode.jsx
+++ b/src/components/ProfileEpisode.jsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useState, useEffect } from 'react';
 import { useDoc, db, doc, setDoc } from '../firebase.js';
 import { getTodayStr } from '../utils.js';
 import { Card } from './ui/card.js';
@@ -7,6 +7,7 @@ import { Textarea } from './ui/textarea.js';
 import SectionTitle from './SectionTitle.jsx';
 import { useT } from '../i18n.js';
 import ProfileSettings from './ProfileSettings.jsx';
+import { Star } from 'lucide-react';
 
 export default function ProfileEpisode({ userId, profileId, onBack }) {
   const progressId = `${userId}-${profileId}`;
@@ -15,6 +16,10 @@ export default function ProfileEpisode({ userId, profileId, onBack }) {
   const t = useT();
   const [reflection, setReflection] = useState('');
   const [reaction, setReaction] = useState('');
+  const [rating, setRating] = useState(0);
+  useEffect(() => {
+    if(progress?.rating) setRating(progress.rating);
+  }, [progress]);
   const stepLabels = [
     t('episodeStageReflection'),
     t('episodeStageReaction'),
@@ -37,7 +42,8 @@ export default function ProfileEpisode({ userId, profileId, onBack }) {
       profileId,
       stage: 2,
       lastUpdated: today,
-      reflection: text
+      reflection: text,
+      rating
     }, { merge: true });
   };
 
@@ -75,6 +81,16 @@ export default function ProfileEpisode({ userId, profileId, onBack }) {
     React.createElement(SectionTitle, { title: t('episodeIntro') }),
     profile.clip && React.createElement('p', { className: 'mb-4' }, `"${profile.clip}"`),
     stage === 1 && React.createElement(React.Fragment, null,
+      React.createElement('div', { className: 'flex justify-center gap-1 mb-2' },
+        [1,2,3].map(n => (
+          React.createElement(Star, {
+            key: n,
+            className: `w-6 h-6 cursor-pointer ${n <= rating ? 'fill-pink-500 stroke-pink-500' : 'stroke-gray-400'}`,
+            onClick: () => setRating(n)
+          })
+        ))
+      ),
+      React.createElement('p', { className: 'text-sm text-gray-500 mb-2 text-center' }, 'Ratingen er privat'),
       React.createElement(Textarea, {
         value: reflection,
         onChange: e => setReflection(e.target.value),
@@ -88,6 +104,14 @@ export default function ProfileEpisode({ userId, profileId, onBack }) {
     stage === 2 && React.createElement(React.Fragment, null,
       progress?.reflection &&
         React.createElement('p', { className: 'italic text-gray-700 mb-2' }, `“${progress.reflection}”`),
+      progress?.rating && React.createElement('div', { className:'flex justify-center gap-1 mb-2' },
+        [1,2,3].map(n => (
+          React.createElement(Star, {
+            key:n,
+            className:`w-5 h-5 ${n <= progress.rating ? 'fill-pink-500 stroke-pink-500' : 'stroke-gray-400'}`
+          })
+        ))
+      ),
       React.createElement(Textarea, {
         value: reaction,
         onChange: e => setReaction(e.target.value),


### PR DESCRIPTION
## Summary
- rate profiles with up to three stars during the reflection stage
- show stored rating when returning for a reaction
- document the new rating feature

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_687a6cc1881c832dbe2f4247a7b4238a