### PR TITLE
Add personalized invitation recipient

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "videotpush",
-  "version": "1.0.46",
+  "version": "1.0.48",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "videotpush",
-      "version": "1.0.46",
+      "version": "1.0.48",
       "dependencies": {
         "firebase": "^9.23.0",
         "firebase-admin": "^11.10.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "videotpush",
-  "version": "1.0.47",
+  "version": "1.0.49",
   "description": "A minimal React PWA for swiping short videos and speed dating.",
   "scripts": {
     "start": "npx serve .",

--- a/src/components/InviteOverlay.jsx
+++ b/src/components/InviteOverlay.jsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useState } from 'react';
 import { Card } from './ui/card.js';
 import { Button } from './ui/button.js';
 import { useT } from '../i18n.js';
@@ -12,8 +12,11 @@ export default function InviteOverlay({ userId, onClose }) {
   const config = useDoc('config','app') || {};
   const invitesEnabled = config.premiumInvitesEnabled !== false;
   const remaining = 5 - invitesUsed;
+  const [recipient, setRecipient] = useState('');
   const base = window.location.origin + '/VideoTinder/invite.html?id=' + userId;
-  const link = invitesEnabled && remaining > 0 ? base + '&gift=1' : base;
+  const giftParam = invitesEnabled && remaining > 0 ? '&gift=1' : '';
+  const recipientParam = recipient ? `&recipient=${encodeURIComponent(recipient)}` : '';
+  const link = base + giftParam + recipientParam;
 
   const copy = async () => {
     try {
@@ -46,6 +49,13 @@ export default function InviteOverlay({ userId, onClose }) {
     React.createElement(Card, { className: 'bg-white p-6 rounded shadow-xl max-w-sm w-full' },
       React.createElement('h2', { className: 'text-xl font-semibold mb-4 text-pink-600 text-center' }, t('inviteFriend')),
       React.createElement('p', { className: 'text-center text-sm mb-4' }, text),
+      React.createElement('input', {
+        type: 'text',
+        placeholder: t('firstName'),
+        className: 'border p-2 rounded w-full mb-2',
+        value: recipient,
+        onChange: e => setRecipient(e.target.value)
+      }),
       React.createElement('input', { type: 'text', readOnly: true, className: 'border p-2 rounded w-full mb-4', value: link }),
       React.createElement(Button, { className: 'w-full bg-pink-500 text-white mb-2', onClick: share }, t('share')),
       React.createElement(Button, { className: 'w-full', onClick: copy }, t('copyLink')),

--- a/src/invite.js
+++ b/src/invite.js
@@ -4,13 +4,17 @@ async function loadInvite() {
   const params = new URLSearchParams(window.location.search);
   const id = params.get('id');
   const gift = params.has('gift');
+  const recipient = params.get('recipient');
   if (!id) return;
   try {
     const snap = await getDoc(doc(db, 'profiles', id));
     if (!snap.exists()) return;
     const profile = snap.data();
     const inviteText = document.getElementById('invite-text');
-    inviteText.textContent = gift ? `${profile.name} giver dig gratis premium i 3 måneder` : `${profile.name} inviterer dig til RealDate`;
+    const greeting = recipient ? `${recipient}, ` : '';
+    inviteText.textContent = gift
+      ? `${greeting}${profile.name} giver dig gratis premium i 3 måneder`
+      : `${greeting}${profile.name} inviterer dig til RealDate`;
     const picEl = document.getElementById('profile-pic');
     if (profile.photoURL) {
       const img = document.createElement('img');

--- a/src/version.js
+++ b/src/version.js
@@ -1,1 +1,1 @@
-export default '1.0.47';
+export default '1.0.49';


### PR DESCRIPTION
## Summary
- support optional `recipient` param for personal greetings
- allow entering recipient name in Invite overlay
- bump version to 1.0.49

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_687a709e7634832d8fa4fe6274b75f95