### PR TITLE
Implement level progression with blurred media

### DIFF
--- a/src/components/DailyDiscovery.jsx
+++ b/src/components/DailyDiscovery.jsx
@@ -37,6 +37,7 @@ export default function DailyDiscovery({ userId, onSelectProfile, ageRange, onOp
   }, [userId, profiles, ageRange]);
 
   const likes = useCollection('likes','userId',userId);
+  const progresses = useCollection('episodeProgress','userId', userId);
 
   const [hoursUntil, setHoursUntil] = useState(0);
   const [showPurchase, setShowPurchase] = useState(false);
@@ -105,12 +106,15 @@ export default function DailyDiscovery({ userId, onSelectProfile, ageRange, onOp
     React.createElement('p', { className: 'text-center text-gray-500 mb-4' }, `Nye klip om ${hoursUntil} timer`),
     React.createElement('p', { className: 'text-center text-gray-500 mb-4' }, `Tag dig god tid til at udforske dagens klip`),
     React.createElement('ul', { className: 'space-y-4' },
-      filtered.length ? filtered.map(p => (
-        React.createElement('li', {
+      filtered.length ? filtered.map(p => {
+        const prog = progresses.find(pr => pr.profileId === p.id);
+        const stage = prog?.stage || 1;
+        return React.createElement('li', {
           key: p.id,
           className: 'p-4 bg-white rounded-lg cursor-pointer shadow-lg border border-gray-200 flex flex-col relative',
           onClick: () => onSelectProfile(p.id)
         },
+          React.createElement('span', { className:'absolute top-2 left-2 bg-pink-100 text-pink-600 text-xs font-semibold px-2 rounded' }, `Level ${stage}`),
           React.createElement(Heart, {
             className: `w-8 h-8 absolute top-2 right-2 ${likes.some(l => l.profileId === p.id) ? 'text-pink-500' : 'text-gray-400'}`,
             onClick: e => { e.stopPropagation(); toggleLike(p.id); }
@@ -134,7 +138,7 @@ export default function DailyDiscovery({ userId, onSelectProfile, ageRange, onOp
             )
           )
         )
-      )) :
+      }) :
         React.createElement('li', { className: 'text-center text-gray-500' }, t('noProfiles'))
     ),
     showBest && React.createElement('ul', { className: 'space-y-4 mt-4' },

--- a/src/components/ProfileEpisode.jsx
+++ b/src/components/ProfileEpisode.jsx
@@ -7,6 +7,7 @@ import { Textarea } from './ui/textarea.js';
 import SectionTitle from './SectionTitle.jsx';
 import { useT } from '../i18n.js';
 import ProfileSettings from './ProfileSettings.jsx';
+import VideoPreview from './VideoPreview.jsx';
 import { Star } from 'lucide-react';
 
 export default function ProfileEpisode({ userId, profileId, onBack }) {
@@ -21,9 +22,9 @@ export default function ProfileEpisode({ userId, profileId, onBack }) {
     if(progress?.rating) setRating(progress.rating);
   }, [progress]);
   const stepLabels = [
-    t('episodeStageReflection'),
-    t('episodeStageReaction'),
-    t('episodeStageConnect')
+    'Level 1',
+    'Level 2',
+    'Level 3'
   ];
 
   if (!profile) return null;
@@ -80,6 +81,28 @@ export default function ProfileEpisode({ userId, profileId, onBack }) {
     React.createElement('p', { className:'text-center text-sm text-gray-600 mb-2' }, stepLabels[stage-1]),
     React.createElement(SectionTitle, { title: t('episodeIntro') }),
     profile.clip && React.createElement('p', { className: 'mb-4' }, `"${profile.clip}"`),
+    React.createElement(SectionTitle, { title: t('videoClips') }),
+    React.createElement('div', { className: 'flex items-center gap-4 mb-4 justify-between' },
+      Array.from({ length: 3 }).map((_, i) => {
+        const clip = (profile.videoClips || [])[i];
+        const url = clip && clip.url ? clip.url : clip;
+        const locked = i >= stage;
+        return React.createElement('div', { key: i, className:`w-[30%] flex flex-col items-center justify-end min-h-[160px] ${locked ? 'filter blur-sm pointer-events-none' : ''}` },
+          url && React.createElement(VideoPreview, { src: url })
+        );
+      })
+    ),
+    React.createElement(SectionTitle, { title: t('audioClips') }),
+    React.createElement('div', { className: 'space-y-2 mb-4' },
+      (profile.audioClips || []).slice(0,3).map((clip, i) => {
+        const url = clip && clip.url ? clip.url : clip;
+        const locked = i >= stage;
+        return React.createElement('div', { key: i, className:`flex items-center relative ${locked ? 'filter blur-sm pointer-events-none' : ''}` },
+          React.createElement('audio', { src: url, controls: true, className: 'flex-1 mr-2' })
+        );
+      })
+    ),
+    React.createElement(Button, { className:`mt-2 w-full bg-pink-500 text-white ${stage < 3 ? 'filter blur-sm pointer-events-none' : ''}` }, t('episodeMatchPrompt')),
     stage === 1 && React.createElement(React.Fragment, null,
       React.createElement('div', { className: 'flex justify-center gap-1 mb-2' },
         [1,2,3].map(n => (


### PR DESCRIPTION
## Summary
- introduce level labels on profile overview
- show available video and audio clips per level
- blur match button until level 3

## Testing
- `npm install`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_687a7354a910832d8209c24b7d1f26fb