### PR TITLE
Add global help overlay

### DIFF
--- a/src/VideotpushApp.jsx
+++ b/src/VideotpushApp.jsx
@@ -1,6 +1,6 @@
 import React, { useState, useEffect } from 'react';
 import { LanguageProvider } from './i18n.js';
-import { Home as HomeIcon, User as UserIcon, MessageCircle as ChatIcon, CalendarDays, Heart, Shield } from 'lucide-react';
+import { Home as HomeIcon, User as UserIcon, MessageCircle as ChatIcon, CalendarDays, Heart, Shield, HelpCircle } from 'lucide-react';
 import WelcomeScreen from './components/WelcomeScreen.jsx';
 import DailyDiscovery from './components/DailyDiscovery.jsx';
 import LikesScreen from './components/LikesScreen.jsx';
@@ -21,6 +21,7 @@ import TextLogScreen from './components/TextLogScreen.jsx';
 import TrackUserScreen from './components/TrackUserScreen.jsx';
 import ServerLogScreen from './components/ServerLogScreen.jsx';
 import ProfileEpisode from './components/ProfileEpisode.jsx';
+import HelpOverlay from './components/HelpOverlay.jsx';
 import { useCollection, requestNotificationPermission, subscribeToWebPush, db, doc, updateDoc, increment, logEvent } from './firebase.js';
 import { getCurrentDate } from './utils.js';
 import { cacheMediaIfNewer } from './cacheMedia.js';
@@ -43,6 +44,7 @@ export default function VideotpushApp() {
   const [tab,setTab]=useState('discovery');
   const [viewProfile,setViewProfile]=useState(null);
   const [videoCallId,setVideoCallId]=useState(null);
+  const [showHelp,setShowHelp]=useState(false);
   const unreadCount = chats.filter(c => c.unreadByUser || c.newMatch).length;
   const hasUnread = unreadCount > 0;
   const currentUser = profiles.find(p => p.id === userId) || {};
@@ -169,6 +171,10 @@ export default function VideotpushApp() {
         React.createElement(Shield, { className: 'w-6 h-6 text-white' })
       ),
       'RealDate',
+      React.createElement(HelpCircle, {
+        className: 'absolute top-1/2 right-12 -translate-y-1/2 cursor-pointer',
+        onClick: () => setShowHelp(true)
+      }),
       userId && React.createElement('div', {
         className: 'absolute top-1/2 right-4 -translate-y-1/2 cursor-pointer',
         onClick: openProfileSettings
@@ -238,6 +244,7 @@ export default function VideotpushApp() {
         hasUnread && React.createElement('span', { className: 'absolute -top-1 -right-2 bg-red-500 text-white text-xs rounded-full min-w-4 h-4 flex items-center justify-center px-1' }, unreadCount)
       ),
       React.createElement(CalendarDays, { className: 'w-8 h-8 text-pink-600', onClick: ()=>{setTab('checkin'); setViewProfile(null);} })
-      )
+      ),
+    showHelp && React.createElement(HelpOverlay, { onClose: ()=>setShowHelp(false) })
   ));
 }

--- a/src/components/HelpOverlay.jsx
+++ b/src/components/HelpOverlay.jsx
@@ -1,0 +1,14 @@
+import React from 'react';
+import InfoOverlay from './InfoOverlay.jsx';
+import { useT } from '../i18n.js';
+
+export default function HelpOverlay({ onClose }) {
+  const t = useT();
+  return React.createElement(InfoOverlay, { title: t('helpTitle'), onClose },
+    React.createElement('div', { className: 'space-y-2 text-sm' },
+      React.createElement('p', null, t('helpLevels')),
+      React.createElement('p', null, t('helpSupport')),
+      React.createElement('p', null, t('helpInvites'))
+    )
+  );
+}

--- a/src/i18n.js
+++ b/src/i18n.js
@@ -70,6 +70,10 @@ inviteAccepted:{ en:"Profile created", da:"Oprettet", sv:"Skapad", es:"Perfil cr
   episodeStageConnect:{ en:'Connect', da:'Forbind', sv:'Anslut', es:'Conectar', fr:'Connecter', de:'Verbinden' },
   missingFieldsTitle:{ en:'Missing information', da:'Mangler information', sv:'Saknar information', es:'Falta información', fr:'Informations manquantes', de:'Fehlende Angaben' },
   missingFieldsDesc:{ en:'Please fill out all required fields', da:'Udfyld venligst alle obligatoriske felter', sv:'Vänligen fyll i alla obligatoriska fält', es:'Por favor, completa todos los campos obligatorios', fr:'Veuillez remplir tous les champs obligatoires', de:'Bitte fülle alle Pflichtfelder aus' },
+  helpTitle:{ en:'Help', da:'Hjælp', sv:'Hjälp', es:'Ayuda', fr:'Aide', de:'Hilfe' },
+  helpLevels:{ en:'On the Daily Life page each profile has three levels. Return the next day to unlock more content.', da:'På siden Dagens liv har hver profil tre niveauer. Kom videre ved at vende tilbage dagen efter for at låse mere op.' },
+  helpSupport:{ en:'Need assistance? Choose "Report bug" on the About page to contact support.', da:'Brug for hjælp? Vælg \"Fejlmeld\" på Om RealDate-siden for at kontakte support.' },
+  helpInvites:{ en:'You can send up to five invitations. Follow each invitation until your friend has created a profile.', da:'Du kan sende op til fem invitationer. Følg hver invitation, indtil din ven har oprettet en profil.' },
 };
 
 const LangContext = createContext({ lang: 'en', setLang: () => {} });


### PR DESCRIPTION
## Summary
- add HelpOverlay component for support and tips
- translate help text in i18n
- show a help icon in the header that opens the overlay

## Testing
- `npm install`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_687a7a79eb78832d979aa34acce826dc