### PR TITLE
Add overlay icon for blurred sections

### DIFF
--- a/src/components/LikesScreen.jsx
+++ b/src/components/LikesScreen.jsx
@@ -1,6 +1,6 @@
 import React, { useState } from 'react';
 import { getAge } from '../utils.js';
-import { User as UserIcon, PlayCircle, Heart } from 'lucide-react';
+import { User as UserIcon, PlayCircle, Heart, CalendarClock } from 'lucide-react';
 import VideoOverlay from './VideoOverlay.jsx';
 import MatchOverlay from './MatchOverlay.jsx';
 import { Card } from './ui/card.js';
@@ -64,7 +64,7 @@ export default function LikesScreen({ userId, onSelectProfile }) {
     setShowPurchase(false);
   };
 
-  return React.createElement(Card,{className:'p-6 m-4 shadow-xl bg-white/90 flex flex-col'},
+  return React.createElement(Card,{className:'relative p-6 m-4 shadow-xl bg-white/90 flex flex-col'},
     React.createElement(SectionTitle,{title:'Nye personer har liket dig', colorClass:'text-yellow-600'}),
     React.createElement('p',{className:'mb-4 text-gray-500'},`${likedProfiles.length} profiler`),
     React.createElement('div',{className: hasSubscription ? 'flex-1' : 'flex-1 filter blur-sm pointer-events-none'},
@@ -101,6 +101,7 @@ export default function LikesScreen({ userId, onSelectProfile }) {
           React.createElement('li',{className:'text-center text-gray-500'},'Ingen har liket dig endnu')
       )
     ),
+    !hasSubscription && React.createElement(CalendarClock,{className:'absolute inset-0 m-auto w-12 h-12 text-yellow-500 pointer-events-none'}),
     !hasSubscription && React.createElement(Button,{className:'mt-4 w-full bg-yellow-500 text-white',onClick:()=>setShowPurchase(true)},'Køb premium'),
     showPurchase && React.createElement(PurchaseOverlay,{title:'Månedligt abonnement', price:'59 kr/md', onClose:()=>setShowPurchase(false), onBuy:handlePurchase},
       React.createElement('ul',{className:'list-disc list-inside text-sm space-y-1'},

--- a/src/components/ProfileEpisode.jsx
+++ b/src/components/ProfileEpisode.jsx
@@ -8,7 +8,7 @@ import SectionTitle from './SectionTitle.jsx';
 import { useT } from '../i18n.js';
 import ProfileSettings from './ProfileSettings.jsx';
 import VideoPreview from './VideoPreview.jsx';
-import { Star } from 'lucide-react';
+import { Star, CalendarClock } from 'lucide-react';
 
 export default function ProfileEpisode({ userId, profileId, onBack }) {
   const progressId = `${userId}-${profileId}`;
@@ -87,8 +87,9 @@ export default function ProfileEpisode({ userId, profileId, onBack }) {
         const clip = (profile.videoClips || [])[i];
         const url = clip && clip.url ? clip.url : clip;
         const locked = i >= stage;
-        return React.createElement('div', { key: i, className:`w-[30%] flex flex-col items-center justify-end min-h-[160px] ${locked ? 'filter blur-sm pointer-events-none' : ''}` },
-          url && React.createElement(VideoPreview, { src: url })
+        return React.createElement('div', { key: i, className:`w-[30%] flex flex-col items-center justify-end min-h-[160px] relative ${locked ? 'filter blur-sm pointer-events-none' : ''}` },
+          url && React.createElement(VideoPreview, { src: url }),
+          locked && React.createElement(CalendarClock, { className:'absolute inset-0 m-auto w-8 h-8 text-pink-500' })
         );
       })
     ),
@@ -98,11 +99,15 @@ export default function ProfileEpisode({ userId, profileId, onBack }) {
         const url = clip && clip.url ? clip.url : clip;
         const locked = i >= stage;
         return React.createElement('div', { key: i, className:`flex items-center relative ${locked ? 'filter blur-sm pointer-events-none' : ''}` },
-          React.createElement('audio', { src: url, controls: true, className: 'flex-1 mr-2' })
+          React.createElement('audio', { src: url, controls: true, className: 'flex-1 mr-2' }),
+          locked && React.createElement(CalendarClock, { className:'absolute inset-0 m-auto w-6 h-6 text-pink-500' })
         );
       })
     ),
-    React.createElement(Button, { className:`mt-2 w-full bg-pink-500 text-white ${stage < 3 ? 'filter blur-sm pointer-events-none' : ''}` }, t('episodeMatchPrompt')),
+    React.createElement('div', { className:'relative' },
+      React.createElement(Button, { className:`mt-2 w-full bg-pink-500 text-white ${stage < 3 ? 'filter blur-sm pointer-events-none' : ''}` }, t('episodeMatchPrompt')),
+      stage < 3 && React.createElement(CalendarClock, { className:'absolute inset-0 m-auto w-8 h-8 text-pink-500' })
+    ),
     stage === 1 && React.createElement(React.Fragment, null,
       React.createElement('div', { className: 'flex justify-center gap-1 mb-2' },
         [1,2,3].map(n => (

--- a/src/components/ProfileSettings.jsx
+++ b/src/components/ProfileSettings.jsx
@@ -1,7 +1,7 @@
 import React, { useState, useEffect, useRef } from 'react';
 import Slider from 'rc-slider';
 import 'rc-slider/assets/index.css';
-import { Mic, Camera as CameraIcon, User as UserIcon, Trash2 as TrashIcon, Pencil as EditIcon, Heart, Flag } from 'lucide-react';
+import { Mic, Camera as CameraIcon, User as UserIcon, Trash2 as TrashIcon, Pencil as EditIcon, Heart, Flag, CalendarClock } from 'lucide-react';
 import { Card } from './ui/card.js';
 import { Button } from './ui/button.js';
 import { Input } from './ui/input.js';
@@ -348,6 +348,7 @@ export default function ProfileSettings({ userId, ageRange, onChangeAgeRange, pu
                 className: `w-10 h-10 text-gray-400 blinking-thumb ${!publicView ? 'cursor-pointer' : ''}`,
                 onClick: !publicView ? () => setShowSnapVideoRecorder(true) : undefined
               }),
+          locked && React.createElement(CalendarClock, { className:'absolute inset-0 m-auto w-8 h-8 text-pink-500' }),
           url && !publicView && React.createElement(Button, {
             className: 'mt-1 bg-pink-500 text-white p-1 rounded-full flex items-center justify-center',
             onClick: () => deleteFile('videoClips', i)
@@ -379,6 +380,7 @@ export default function ProfileSettings({ userId, ageRange, onChangeAgeRange, pu
         const locked = i >= stage;
         return React.createElement('div', { key: i, className: `flex items-center relative ${locked ? 'filter blur-sm pointer-events-none' : ''}` },
           React.createElement('audio', { src: url, controls: true, className: 'flex-1 mr-2' }),
+          locked && React.createElement(CalendarClock, { className:'absolute inset-0 m-auto w-6 h-6 text-pink-500' }),
           !publicView && React.createElement(Button, {
             className: 'ml-2 bg-pink-500 text-white p-1 rounded w-[20%] flex items-center justify-center',
             onClick: () => deleteFile('audioClips', i)
@@ -464,10 +466,13 @@ export default function ProfileSettings({ userId, ageRange, onChangeAgeRange, pu
           className: 'bg-pink-500 text-white',
           onClick: () => photoRef.current && photoRef.current.click()
         }, 'Upload billede'),
-        publicView && !isOwnProfile && React.createElement(Button, {
-          className: `ml-auto bg-pink-500 text-white ${stage < 3 ? 'filter blur-sm pointer-events-none' : ''}`,
-          onClick: stage >= 3 ? toggleLike : undefined
-        }, liked ? 'Unmatch' : 'Match'),
+        publicView && !isOwnProfile && React.createElement('div', { className:'relative ml-auto' },
+          React.createElement(Button, {
+            className: `bg-pink-500 text-white ${stage < 3 ? 'filter blur-sm pointer-events-none' : ''}`,
+            onClick: stage >= 3 ? toggleLike : undefined
+          }, liked ? 'Unmatch' : 'Match'),
+          stage < 3 && React.createElement(CalendarClock, { className:'absolute inset-0 m-auto w-8 h-8 text-pink-500' })
+        ),
         publicView && !isOwnProfile && React.createElement(Button, {
           className: 'ml-2 bg-red-500 text-white',
           onClick: () => setReportMode(m => !m)


### PR DESCRIPTION
## Summary
- show a `CalendarClock` icon over blurred episode content
- apply same indicator in profile settings
- mark locked likes list with overlay icon

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_687a7b4714d4832d8b09b368ea3e565c