### PR TITLE
Add premium profile listing perk

### DIFF
--- a/public/invite.html
+++ b/public/invite.html
@@ -22,6 +22,7 @@
       <li>🧐 Indsigt i hvem der har liket dig</li>
       <li>📝 Udfoldede profiler – adgang til længere refleksioner, flere videoer</li>
       <li>🎙️ Profilbooster: Få dit klip vist tidligere på dagen</li>
+      <li>⏳ Bliv på profillisten i længere tid, fx 10 dage</li>
     </ul>
     <a id="cta" href="./index.html" class="block bg-pink-500 text-white py-3 rounded-lg font-bold text-center">Prøv <strong>gratis</strong> i 3 måneder</a>
   </div>

--- a/src/components/LikesScreen.jsx
+++ b/src/components/LikesScreen.jsx
@@ -108,7 +108,8 @@ export default function LikesScreen({ userId, onSelectProfile }) {
         React.createElement('li',null,'🔁 Se tidligere klip igen ("Fortryd swipe")'),
         React.createElement('li',null,'🧠 Indsigt i hvem der har liket dig'),
         React.createElement('li',null,'📝 Udfoldede profiler – adgang til længere refleksioner, flere videoer'),
-        React.createElement('li',null,'🎙️ Profilbooster: Få dit klip vist tidligere på dagen')
+        React.createElement('li',null,'🎙️ Profilbooster: Få dit klip vist tidligere på dagen'),
+        React.createElement('li',null,'⏳ Bliv på profillisten i længere tid, fx 10 dage')
       )
     ),
     matchedProfile && React.createElement(MatchOverlay,{name:matchedProfile.name,onClose:()=>setMatchedProfile(null)}),

--- a/src/components/ProfileSettings.jsx
+++ b/src/components/ProfileSettings.jsx
@@ -691,7 +691,8 @@ export default function ProfileSettings({ userId, ageRange, onChangeAgeRange, pu
           React.createElement('li', null, '🔁 Se tidligere klip igen ("Fortryd swipe")'),
           React.createElement('li', null, '🧠 Indsigt i hvem der har liket dig'),
           React.createElement('li', null, '📝 Udfoldede profiler – adgang til længere refleksioner, flere videoer'),
-          React.createElement('li', null, '🎙️ Profilbooster: Få dit klip vist tidligere på dagen')
+          React.createElement('li', null, '🎙️ Profilbooster: Få dit klip vist tidligere på dagen'),
+          React.createElement('li', null, '⏳ Bliv på profillisten i længere tid, fx 10 dage')
         )
       ),
     showInterests && React.createElement(InterestsOverlay, {


### PR DESCRIPTION
## Summary
- highlight new premium perk in invite page
- list extended profile lifetime in purchase overlays

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_687a7c3243d8832d8394064a307d35fc