### PR TITLE
Fix spacing between help icon and profile picture

### DIFF
--- a/src/VideotpushApp.jsx
+++ b/src/VideotpushApp.jsx
@@ -172,7 +172,7 @@ export default function VideotpushApp() {
       ),
       'RealDate',
       React.createElement(HelpCircle, {
-        className: 'absolute top-1/2 right-12 -translate-y-1/2 cursor-pointer',
+        className: 'absolute top-1/2 right-16 -translate-y-1/2 cursor-pointer',
         onClick: () => setShowHelp(true)
       }),
       userId && React.createElement('div', {


### PR DESCRIPTION
## Summary
- ensure help icon isn't flush with the profile image

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_687a7e3a5dcc832d9a56f72b982d8b54