### PR TITLE
Extend episode expiry for subscribers

### DIFF
--- a/src/components/DailyDiscovery.jsx
+++ b/src/components/DailyDiscovery.jsx
@@ -17,6 +17,7 @@ export default function DailyDiscovery({ userId, onSelectProfile, ageRange, onOp
   const t = useT();
   const user = profiles.find(p => p.id === userId) || {};
   const hasSubscription = user.subscriptionExpires && new Date(user.subscriptionExpires) > new Date();
+  const expiryDays = hasSubscription ? 10 : 5;
   const today = getTodayStr();
   const filtered = selectProfiles(user, profiles, ageRange);
   useEffect(() => {
@@ -46,7 +47,7 @@ export default function DailyDiscovery({ userId, onSelectProfile, ageRange, onOp
       const prog = progresses.find(pr => pr.id === id);
       if(!prog){
         const expires = new Date(getCurrentDate());
-        expires.setDate(expires.getDate() + 5);
+        expires.setDate(expires.getDate() + expiryDays);
         setDoc(doc(db,'episodeProgress', id), {
           id,
           userId,
@@ -133,7 +134,7 @@ export default function DailyDiscovery({ userId, onSelectProfile, ageRange, onOp
       activeProfiles.length ? activeProfiles.map(p => {
         const prog = progresses.find(pr => pr.profileId === p.id);
         const stage = prog?.stage || 1;
-        const daysLeft = prog?.expiresAt ? Math.ceil((new Date(prog.expiresAt) - getCurrentDate())/86400000) : 5;
+        const daysLeft = prog?.expiresAt ? Math.ceil((new Date(prog.expiresAt) - getCurrentDate())/86400000) : expiryDays;
         return React.createElement('li', {
           key: p.id,
           className: 'p-4 bg-white rounded-lg cursor-pointer shadow-lg border border-gray-200 flex flex-col relative',

--- a/src/components/ProfileEpisode.jsx
+++ b/src/components/ProfileEpisode.jsx
@@ -14,6 +14,9 @@ export default function ProfileEpisode({ userId, profileId, onBack }) {
   const progressId = `${userId}-${profileId}`;
   const progress = useDoc('episodeProgress', progressId);
   const profile = useDoc('profiles', profileId);
+  const viewer = useDoc('profiles', userId);
+  const hasSubscription = viewer?.subscriptionExpires && new Date(viewer.subscriptionExpires) > new Date();
+  const expiryDays = hasSubscription ? 10 : 5;
   const t = useT();
   const [reflection, setReflection] = useState('');
   const [reaction, setReaction] = useState('');
@@ -22,7 +25,7 @@ export default function ProfileEpisode({ userId, profileId, onBack }) {
     const base = current && new Date(current) > getCurrentDate()
       ? new Date(current) : getCurrentDate();
     const next = new Date(base);
-    next.setDate(base.getDate() + 5);
+    next.setDate(base.getDate() + expiryDays);
     return next.toISOString();
   };
   useEffect(() => {
@@ -54,7 +57,7 @@ export default function ProfileEpisode({ userId, profileId, onBack }) {
   }, [profile, progress]);
 
   const waiting = lastDate === today && stage !== 3;
-  const daysLeft = progress?.expiresAt ? Math.ceil((new Date(progress.expiresAt) - getCurrentDate())/86400000) : 5;
+  const daysLeft = progress?.expiresAt ? Math.ceil((new Date(progress.expiresAt) - getCurrentDate())/86400000) : expiryDays;
 
   const saveReflection = async () => {
     const text = reflection.trim();


### PR DESCRIPTION
## Summary
- bump view expiration to 10 days for subscribers
- detect user subscription in `ProfileEpisode`
- use subscription-aware expiry in `DailyDiscovery`

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_687a816ef8f4832d978a4d55103f5e99