### PR TITLE
Fix crash when opening profile with unset user

### DIFF
--- a/src/firebase.js
+++ b/src/firebase.js
@@ -168,6 +168,10 @@ export function useCollection(collectionName, field, value) {
 export function useDoc(collectionName, docId) {
   const [data, setData] = useState(null);
   useEffect(() => {
+    if (!docId) {
+      setData(null);
+      return;
+    }
     const d = doc(db, collectionName, docId);
     const unsub = onSnapshot(d, snap => {
       setData(snap.exists() ? { id: snap.id, ...snap.data() } : null);


### PR DESCRIPTION
## Summary
- prevent `useDoc` from calling Firestore with an empty document id

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_687a88b59760832d806503a917f9f37d