### PR TITLE
Remove service worker logs

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -11,16 +11,11 @@ if ('serviceWorker' in navigator) {
     // Register the main service worker generated in the production build
     await navigator.serviceWorker
       .register(new URL('../public/service-worker.js', import.meta.url))
-      .then(reg => console.log('SW registered', reg))
       .catch(err => console.error('SW registration failed', err));
 
     // Register the Firebase messaging service worker now located under src
     const fcmReg = await navigator.serviceWorker
       .register(new URL('./firebase-messaging-sw.js', import.meta.url))
-      .then(reg => {
-        console.log('SW registered', reg);
-        return reg;
-      })
       .catch(err => {
         console.error('SW registration failed', err);
         throw err;


### PR DESCRIPTION
## Summary
- remove console logs when registering service workers

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_687a8a0a8c50832d81e26cf15e89426e