### PR TITLE
Add silent push notifications

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,9 +120,9 @@ The profile filtering logic used on the Daily Discovery page lives in `src/selec
 Firebase Cloud Messaging delivers updates on Android and desktop browsers. Notifications are sent using the HTTP **v1** API authenticated with a service account. Provide the service account path via `GOOGLE_APPLICATION_CREDENTIALS` or store the JSON in `FIREBASE_SERVICE_ACCOUNT_JSON`.
 The Netlify functions automatically read these variables and initialize the Firebase Admin SDK if present.
 
-`netlify/functions/send-push.js` sends FCM messages to tokens stored in Firestore. Trigger it with a `POST` request containing a `body` and optional `title`. You can also pass a `tokens` array to send to specific devices instead of using the stored tokens.
+`netlify/functions/send-push.js` sends FCM messages to tokens stored in Firestore. Trigger it with a `POST` request containing a `body` and optional `title`. You can also pass a `tokens` array to send to specific devices instead of using the stored tokens. Include `"silent": true` to suppress notification sounds.
 
-For iOS PWAs, Safari only supports the standard Web Push API. A separate function (`netlify/functions/send-webpush.js`) sends notifications using VAPID keys defined in `WEB_PUSH_PUBLIC_KEY` and `WEB_PUSH_PRIVATE_KEY`. Subscriptions are stored in the `webPushSubscriptions` collection.
+For iOS PWAs, Safari only supports the standard Web Push API. A separate function (`netlify/functions/send-webpush.js`) sends notifications using VAPID keys defined in `WEB_PUSH_PUBLIC_KEY` and `WEB_PUSH_PRIVATE_KEY`. Subscriptions are stored in the `webPushSubscriptions` collection. Pass `silent: true` to send a Web Push notification without sound.
 
 The helper page (`netlify/functions/test-push.html`) posts data to `/.netlify/functions/send-push` for FCM tokens. To test Web Push on iOS, post to `/.netlify/functions/send-webpush` instead.
 
@@ -149,7 +149,7 @@ The functions will be available at `http://localhost:8888`. You can send a test 
 ```bash
 curl -X POST http://localhost:8888/.netlify/functions/send-push \
   -H "Content-Type: application/json" \
-  -d '{"body":"Hello from local","tokens":["YOUR_TOKEN"]}'
+  -d '{"body":"Hello from local","tokens":["YOUR_TOKEN"],"silent":true}'
 ```
 
 Make sure the Firebase credentials (`FIREBASE_*`) and VAPID keys (`WEB_PUSH_PUBLIC_KEY` and `WEB_PUSH_PRIVATE_KEY`) are set in your `.env` file so the functions can authenticate.

--- a/netlify/functions/send-webpush.js
+++ b/netlify/functions/send-webpush.js
@@ -71,7 +71,7 @@ exports.handler = async function(event) {
   }
 
   try {
-    const { title = 'RealDate', body, userId } = parsedBody;
+    const { title = 'RealDate', body, userId, silent } = parsedBody;
     if (!body) {
       return { statusCode: 400, headers, body: 'Invalid payload: body required' };
     }
@@ -82,7 +82,7 @@ exports.handler = async function(event) {
     subsSnap = await db.collection('webPushSubscriptions').get();
   }
   const subs = subsSnap.docs.map(d => d.data());
-  const payload = JSON.stringify({ title, body });
+  const payload = JSON.stringify({ title, body, silent: !!silent });
   const failed = [];
   await Promise.all(
     subs.map(async sub => {

--- a/netlify/functions/test-push.html
+++ b/netlify/functions/test-push.html
@@ -15,6 +15,7 @@ button{margin-top:1em;padding:0.5em 1em;}
 <h1>Send Test Push</h1>
 <label>Title <input id="title" type="text" placeholder="Optional" /></label>
 <label>Body <input id="body" type="text" placeholder="Notification text" /></label>
+<label><input id="silent" type="checkbox" /> Silent</label>
 <fieldset style="margin-top:1em;">
   <legend>Send to</legend>
   <label><input type="radio" name="target" value="ios" checked /> iOS</label>
@@ -38,6 +39,7 @@ button{margin-top:1em;padding:0.5em 1em;}
   document.getElementById('send').addEventListener('click', async () => {
     const title = document.getElementById('title').value;
     const body = document.getElementById('body').value;
+    const silent = document.getElementById('silent').checked;
     const target = document.querySelector('input[name="target"]:checked').value;
     const statusEl = document.getElementById('status');
     const subsEl = document.getElementById('subs');
@@ -46,14 +48,14 @@ button{margin-top:1em;padding:0.5em 1em;}
     try {
       const parts = [];
       if (target === 'ios' || target === 'both') {
-        const data = await post('/.netlify/functions/send-webpush', { title, body });
+        const data = await post('/.netlify/functions/send-webpush', { title, body, silent });
         parts.push('iOS: ' + (data.count ?? '?') + ' subscriptions');
         if (Array.isArray(data.subscriptions)) {
           subsEl.textContent = JSON.stringify(data.subscriptions, null, 2);
         }
       }
       if (target === 'other' || target === 'both') {
-        const data = await post('/.netlify/functions/send-push', { title, body });
+        const data = await post('/.netlify/functions/send-push', { title, body, silent });
         parts.push('Andre: ' + (data.successCount ?? '?') + ' sent');
       }
       statusEl.textContent = parts.join(' | ');

--- a/src/firebase-messaging-sw.js
+++ b/src/firebase-messaging-sw.js
@@ -16,11 +16,13 @@ function handleBackgroundMessages() {
   if (!messaging) return;
   messaging.onBackgroundMessage(payload => {
     const n = payload.notification || {};
+    const d = payload.data || {};
     const title = n.title || 'RealDate';
     const body = n.body || title;
     self.registration.showNotification(title, {
       body,
-      icon: 'icon-192.png'
+      icon: 'icon-192.png',
+      silent: d.silent === 'true' || n.silent === true
     });
   });
 }
@@ -35,7 +37,8 @@ self.addEventListener('push', event => {
   event.waitUntil((async () => {
     await self.registration.showNotification(title, {
       body,
-      icon: 'icon-192.png'
+      icon: 'icon-192.png',
+      silent: data.silent === true || data.silent === 'true'
     });
     const clientsArr = await self.clients.matchAll({ type: 'window', includeUncontrolled: true });
     for (const client of clientsArr) {


### PR DESCRIPTION
## Summary
- support a `silent` option in push notification functions
- allow silent pushes via test page
- show notifications without sound in the service worker
- document silent push option in README

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_687a8aa0b2b8832d8abe224c7c8b9af3