### PR TITLE
Fix push body missing in notifications

### DIFF
--- a/netlify/functions/notify-new-clips.js
+++ b/netlify/functions/notify-new-clips.js
@@ -82,7 +82,8 @@ async function sendAll(userId, title, body, tokensByUser, subsByUser) {
     try {
       const res = await admin.messaging().sendEachForMulticast({
         tokens,
-        notification: { title, body }
+        notification: { title, body },
+        data: { title, body }
       });
       const bad = res.responses
         .map((r, i) => (!r.success ? tokens[i] : null))

--- a/netlify/functions/send-push.js
+++ b/netlify/functions/send-push.js
@@ -77,9 +77,13 @@ exports.handler = async function(event) {
       }).catch(() => {});
       return { statusCode: 200, headers, body: 'No tokens' };
     }
-    const message = silent
-      ? { tokens, data: { title, body, silent: 'true' } }
-      : { tokens, notification: { title, body } };
+    const message = {
+      tokens,
+      data: { title, body, silent: silent ? 'true' : 'false' }
+    };
+    if (!silent) {
+      message.notification = { title, body };
+    }
     const res = await admin.messaging().sendEachForMulticast(message);
 
     const badTokens = res.responses


### PR DESCRIPTION
## Summary
- include data payload when sending push notifications so our service worker can show the body text

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_687a8e7e244c832d9d7dc89ffc0398f4