### PR TITLE
Add level 2 guidance

### DIFF
--- a/src/components/ProfileEpisode.jsx
+++ b/src/components/ProfileEpisode.jsx
@@ -57,6 +57,9 @@ export default function ProfileEpisode({ userId, profileId, onBack }) {
 
   const daysLeft = progress?.expiresAt ? Math.ceil((new Date(progress.expiresAt) - getCurrentDate())/86400000) : expiryDays;
 
+  const showWatchLine = (profile.videoClips?.length || 0) > 0 || (profile.audioClips?.length || 0) > 0;
+  const showRatingLine = !progress?.rating;
+
   const saveReflection = async () => {
     const text = reflection.trim();
     if (!text) return;
@@ -116,6 +119,13 @@ export default function ProfileEpisode({ userId, profileId, onBack }) {
     ),
     React.createElement('p', { className:'text-center text-sm text-gray-600 mb-2' }, stepLabels[stage-1]),
     React.createElement('p', { className:'text-center text-xs text-yellow-600 mb-2' }, t('expiresIn').replace('{days}', daysLeft)),
+    stage === 1 && React.createElement('ul', { className:'list-disc list-inside text-sm mb-4' },
+      [
+        showWatchLine && React.createElement('li', { key:'watch' }, t('level2Watch')),
+        showRatingLine && React.createElement('li', { key:'rate' }, t('level2Rate')),
+        React.createElement('li', { key:'reflect' }, t('level2Reflect'))
+      ].filter(Boolean)
+    ),
     React.createElement(SectionTitle, { title: t('episodeIntro') }),
     profile.clip && React.createElement('p', { className: 'mb-4' }, `"${profile.clip}"`),
     React.createElement(SectionTitle, { title: t('videoClips') }),
@@ -126,6 +136,7 @@ export default function ProfileEpisode({ userId, profileId, onBack }) {
         const locked = i >= stage;
         return React.createElement('div', { key: i, className:`w-[30%] flex flex-col items-center justify-end min-h-[160px] relative ${locked ? 'filter blur-sm pointer-events-none' : ''}` },
           url && React.createElement(VideoPreview, { src: url, onEnded: () => handleClipEnd(i) }),
+          !locked && i === stage - 1 && React.createElement('span', { className:'absolute top-1 right-1 bg-green-100 text-green-600 text-xs font-semibold px-1 rounded' }, t('newLabel')),
           locked && React.createElement(CalendarClock, { className:'absolute inset-0 m-auto w-8 h-8 text-pink-500' })
         );
       })
@@ -137,6 +148,7 @@ export default function ProfileEpisode({ userId, profileId, onBack }) {
         const locked = i >= stage;
         return React.createElement('div', { key: i, className:`flex items-center relative ${locked ? 'filter blur-sm pointer-events-none' : ''}` },
           React.createElement('audio', { src: url, controls: true, className: 'flex-1 mr-2' }),
+          !locked && i === stage - 1 && React.createElement('span', { className:'absolute top-1 right-1 bg-green-100 text-green-600 text-xs font-semibold px-1 rounded' }, t('newLabel')),
           locked && React.createElement(CalendarClock, { className:'absolute inset-0 m-auto w-6 h-6 text-pink-500' })
         );
       })

--- a/src/i18n.js
+++ b/src/i18n.js
@@ -74,6 +74,10 @@ inviteAccepted:{ en:"Profile created", da:"Oprettet", sv:"Skapad", es:"Perfil cr
   helpLevels:{ en:'On the Daily Life page each profile has three levels. Watch clips to unlock more content.', da:'På siden Dagens liv har hver profil tre niveauer. Se klip for at låse mere op.' },
   helpSupport:{ en:'Need assistance? Choose "Report bug" on the About page to contact support.', da:'Brug for hjælp? Vælg \"Fejlmeld\" på Om RealDate-siden for at kontakte support.' },
   helpInvites:{ en:'You can send up to five invitations. Follow each invitation until your friend has created a profile.', da:'Du kan sende op til fem invitationer. Følg hver invitation, indtil din ven har oprettet en profil.' },
+  level2Watch:{ en:'Watch the new video or sound clip', da:'Se det nye video- eller lydklip', sv:'Titta på det nya video- eller ljudklippet', es:'Mira el nuevo vídeo o clip de sonido', fr:'Regardez la nouvelle vidéo ou le nouveau clip audio', de:'Sieh dir den neuen Video- oder Audioclip an' },
+  level2Rate:{ en:'Give a private rating', da:'Giv en privat vurdering', sv:'Ge ett privat betyg', es:'Da una calificación privada', fr:'Donnez une évaluation privée', de:'Gib eine private Bewertung ab' },
+  level2Reflect:{ en:'Write a private reflection', da:'Skriv en privat refleksion', sv:'Skriv en privat reflektion', es:'Escribe una reflexión privada', fr:'Écrivez une réflexion privée', de:'Schreibe eine private Reflexion' },
+  newLabel:{ en:'New!', da:'Nyt!', sv:'Nytt!', es:'¡Nuevo!', fr:'Nouveau !', de:'Neu!' },
 };
 
 const LangContext = createContext({ lang: 'en', setLang: () => {} });


### PR DESCRIPTION
## Summary
- show 'New!' label on first available video or audio clip
- display list of hints for unlocking level 2
- provide translations for new helper text
- place the level 2 hints near the top of the episode page

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_687a8ffbe734832d9ac5f8ae3028da4d