### PR TITLE
Move expiry label and add level prompt

### DIFF
--- a/src/components/ProfileEpisode.jsx
+++ b/src/components/ProfileEpisode.jsx
@@ -119,7 +119,7 @@ export default function ProfileEpisode({ userId, profileId, onBack }) {
       }))
     ),
     React.createElement('p', { className:'text-center text-sm text-gray-600 mb-2' }, stepLabels[stage-1]),
-    React.createElement('p', { className:'text-center text-xs text-yellow-600 mb-2' }, t('expiresIn').replace('{days}', daysLeft)),
+    stage === 1 && React.createElement('p', { className:'text-center text-sm mb-2 text-gray-700 font-medium' }, t('level2Intro').replace('{name}', profile.name || '')),
     stage === 1 && React.createElement('ul', { className:'list-disc list-inside text-sm mb-4' },
       [
         showWatchLine && React.createElement('li', { key:'watch' }, t('level2Watch')),
@@ -128,6 +128,7 @@ export default function ProfileEpisode({ userId, profileId, onBack }) {
       ].filter(Boolean)
     ),
     React.createElement(SectionTitle, { title: `${profile.name || ''}, ${profile.birthday ? getAge(profile.birthday) : profile.age || ''}${profile.city ? ', ' + profile.city : ''}` }),
+    React.createElement('p', { className:'text-center text-xs text-yellow-600 mb-2' }, t('expiresIn').replace('{days}', daysLeft)),
     React.createElement(SectionTitle, { title: t('episodeIntro') }),
     profile.clip && React.createElement('p', { className: 'mb-4' }, `"${profile.clip}"`),
     React.createElement(SectionTitle, { title: t('videoClips') }),

--- a/src/i18n.js
+++ b/src/i18n.js
@@ -77,6 +77,7 @@ inviteAccepted:{ en:"Profile created", da:"Oprettet", sv:"Skapad", es:"Perfil cr
   level2Watch:{ en:'Watch the new video or sound clip', da:'Se det nye video- eller lydklip', sv:'Titta på det nya video- eller ljudklippet', es:'Mira el nuevo vídeo o clip de sonido', fr:'Regardez la nouvelle vidéo ou le nouveau clip audio', de:'Sieh dir den neuen Video- oder Audioclip an' },
   level2Rate:{ en:'Give a private rating', da:'Giv en privat vurdering', sv:'Ge ett privat betyg', es:'Da una calificación privada', fr:'Donnez une évaluation privée', de:'Gib eine private Bewertung ab' },
   level2Reflect:{ en:'Write a private reflection', da:'Skriv en privat refleksion', sv:'Skriv en privat reflektion', es:'Escribe una reflexión privada', fr:'Écrivez une réflexion privée', de:'Schreibe eine private Reflexion' },
+  level2Intro:{ en:'Get to level 2 with {name}', da:'Kom til niveau 2 med {name}', sv:'Kom till nivå 2 med {name}', es:'Llega al nivel 2 con {name}', fr:'Atteignez le niveau 2 avec {name}', de:'Erreiche Level 2 mit {name}' },
   newLabel:{ en:'New!', da:'Nyt!', sv:'Nytt!', es:'¡Nuevo!', fr:'Nouveau !', de:'Neu!' },
 };
 


### PR DESCRIPTION
## Summary
- show a prompt to reach level 2 with the profile name
- move the expiry notice below the name heading

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_687aa22f0dc0832db2d069a864612f73