### PR TITLE
Replace lock icons with text overlays

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "videotpush",
-  "version": "1.0.50",
+  "version": "1.0.53",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "videotpush",
-      "version": "1.0.50",
+      "version": "1.0.53",
       "dependencies": {
         "firebase": "^9.23.0",
         "firebase-admin": "^11.10.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "videotpush",
-  "version": "1.0.51",
+  "version": "1.0.53",
   "description": "A minimal React PWA for swiping short videos and speed dating.",
   "scripts": {
     "start": "npx serve .",

--- a/src/components/LikesScreen.jsx
+++ b/src/components/LikesScreen.jsx
@@ -1,6 +1,6 @@
 import React, { useState } from 'react';
 import { getAge } from '../utils.js';
-import { User as UserIcon, PlayCircle, Heart, CalendarClock } from 'lucide-react';
+import { User as UserIcon, PlayCircle, Heart } from 'lucide-react';
 import VideoOverlay from './VideoOverlay.jsx';
 import MatchOverlay from './MatchOverlay.jsx';
 import { Card } from './ui/card.js';
@@ -101,7 +101,7 @@ export default function LikesScreen({ userId, onSelectProfile }) {
           React.createElement('li',{className:'text-center text-gray-500'},'Ingen har liket dig endnu')
       )
     ),
-    !hasSubscription && React.createElement(CalendarClock,{className:'absolute inset-0 m-auto w-12 h-12 text-yellow-500 pointer-events-none'}),
+    !hasSubscription && React.createElement('span',{className:'absolute inset-0 m-auto text-yellow-500 text-sm font-semibold pointer-events-none flex items-center justify-center text-center px-2'},'Unlocks at higher levels'),
     !hasSubscription && React.createElement(Button,{className:'mt-4 w-full bg-yellow-500 text-white',onClick:()=>setShowPurchase(true)},'Køb premium'),
     showPurchase && React.createElement(PurchaseOverlay,{title:'Månedligt abonnement', price:'59 kr/md', onClose:()=>setShowPurchase(false), onBuy:handlePurchase},
       React.createElement('ul',{className:'list-disc list-inside text-sm space-y-1'},

--- a/src/components/ProfileEpisode.jsx
+++ b/src/components/ProfileEpisode.jsx
@@ -8,7 +8,7 @@ import SectionTitle from './SectionTitle.jsx';
 import { useT } from '../i18n.js';
 import ProfileSettings from './ProfileSettings.jsx';
 import VideoPreview from './VideoPreview.jsx';
-import { Star, CalendarClock } from 'lucide-react';
+import { Star } from 'lucide-react';
 
 export default function ProfileEpisode({ userId, profileId, onBack }) {
   const progressId = `${userId}-${profileId}`;
@@ -148,8 +148,8 @@ export default function ProfileEpisode({ userId, profileId, onBack }) {
         return React.createElement('div', { key: i, className:`w-[30%] flex flex-col items-center justify-end min-h-[160px] relative ${locked ? 'pointer-events-none' : ''}` },
           url && React.createElement(VideoPreview, { src: url, onEnded: () => handleClipEnd(i) }),
           !locked && i === stage - 1 && React.createElement('span', { className:'absolute top-1 right-1 bg-green-100 text-green-600 text-xs font-semibold px-1 rounded' }, t('newLabel')),
-          locked && React.createElement('div', { className:'absolute inset-0 bg-black/80 flex items-center justify-center rounded' },
-            React.createElement(CalendarClock, { className:'w-8 h-8 text-pink-500' })
+          locked && React.createElement('div', { className:'absolute inset-0 bg-black/80 flex items-center justify-center rounded text-center px-2' },
+            React.createElement('span', { className:'text-pink-500 text-xs font-semibold' }, t('unlockHigherLevels'))
           )
         );
       })
@@ -162,15 +162,15 @@ export default function ProfileEpisode({ userId, profileId, onBack }) {
         return React.createElement('div', { key: i, className:`flex items-center relative ${locked ? 'pointer-events-none' : ''}` },
           React.createElement('audio', { src: url, controls: true, className: 'flex-1 mr-2' }),
           !locked && i === stage - 1 && React.createElement('span', { className:'absolute top-1 right-1 bg-green-100 text-green-600 text-xs font-semibold px-1 rounded' }, t('newLabel')),
-          locked && React.createElement('div', { className:'absolute inset-0 bg-black/80 flex items-center justify-center rounded' },
-            React.createElement(CalendarClock, { className:'w-6 h-6 text-pink-500' })
+          locked && React.createElement('div', { className:'absolute inset-0 bg-black/80 flex items-center justify-center rounded text-center px-2' },
+            React.createElement('span', { className:'text-pink-500 text-xs font-semibold' }, t('unlockHigherLevels'))
           )
         );
       })
     ),
     React.createElement('div', { className:'relative' },
-      React.createElement(Button, { className:`mt-2 w-full bg-pink-500 text-white ${stage < 3 ? 'filter blur-sm pointer-events-none' : ''}` }, t('episodeMatchPrompt')),
-      stage < 3 && React.createElement(CalendarClock, { className:'absolute inset-0 m-auto w-8 h-8 text-pink-500' })
+      React.createElement(Button, { className:`mt-2 w-full bg-pink-500 text-white ${stage < 3 ? 'opacity-50 pointer-events-none' : ''}` }, t('episodeMatchPrompt')),
+      stage < 3 && React.createElement('span', { className:'absolute inset-0 m-auto text-pink-500 text-xs font-semibold flex items-center justify-center text-center px-2' }, t('unlockHigherLevels'))
     ),
     stage === 1 && React.createElement('div', { className:'mt-6 p-4 bg-gray-50 rounded-lg border border-gray-300' },
       React.createElement('div', { className: 'flex justify-center gap-1 mb-2' },

--- a/src/components/ProfileSettings.jsx
+++ b/src/components/ProfileSettings.jsx
@@ -1,7 +1,7 @@
 import React, { useState, useEffect, useRef } from 'react';
 import Slider from 'rc-slider';
 import 'rc-slider/assets/index.css';
-import { Mic, Camera as CameraIcon, User as UserIcon, Trash2 as TrashIcon, Pencil as EditIcon, Heart, Flag, CalendarClock } from 'lucide-react';
+import { Mic, Camera as CameraIcon, User as UserIcon, Trash2 as TrashIcon, Pencil as EditIcon, Heart, Flag } from 'lucide-react';
 import { Card } from './ui/card.js';
 import { Button } from './ui/button.js';
 import { Input } from './ui/input.js';
@@ -348,8 +348,8 @@ export default function ProfileSettings({ userId, ageRange, onChangeAgeRange, pu
                 className: `w-10 h-10 text-gray-400 blinking-thumb ${!publicView ? 'cursor-pointer' : ''}`,
                 onClick: !publicView ? () => setShowSnapVideoRecorder(true) : undefined
               }),
-          locked && React.createElement('div', { className:'absolute inset-0 bg-black/80 flex items-center justify-center rounded' },
-            React.createElement(CalendarClock, { className:'w-8 h-8 text-pink-500' })
+          locked && React.createElement('div', { className:'absolute inset-0 bg-black/80 flex items-center justify-center rounded text-center px-2' },
+            React.createElement('span', { className:'text-pink-500 text-xs font-semibold' }, t('unlockHigherLevels'))
           ),
           url && !publicView && React.createElement(Button, {
             className: 'mt-1 bg-pink-500 text-white p-1 rounded-full flex items-center justify-center',
@@ -382,8 +382,8 @@ export default function ProfileSettings({ userId, ageRange, onChangeAgeRange, pu
         const locked = i >= stage;
         return React.createElement('div', { key: i, className: `flex items-center relative ${locked ? 'pointer-events-none' : ''}` },
           React.createElement('audio', { src: url, controls: true, className: 'flex-1 mr-2' }),
-          locked && React.createElement('div', { className:'absolute inset-0 bg-black/80 flex items-center justify-center rounded' },
-            React.createElement(CalendarClock, { className:'w-6 h-6 text-pink-500' })
+          locked && React.createElement('div', { className:'absolute inset-0 bg-black/80 flex items-center justify-center rounded text-center px-2' },
+            React.createElement('span', { className:'text-pink-500 text-xs font-semibold' }, t('unlockHigherLevels'))
           ),
           !publicView && React.createElement(Button, {
             className: 'ml-2 bg-pink-500 text-white p-1 rounded w-[20%] flex items-center justify-center',
@@ -472,10 +472,10 @@ export default function ProfileSettings({ userId, ageRange, onChangeAgeRange, pu
         }, 'Upload billede'),
         publicView && !isOwnProfile && React.createElement('div', { className:'relative ml-auto' },
           React.createElement(Button, {
-            className: `bg-pink-500 text-white ${stage < 3 ? 'filter blur-sm pointer-events-none' : ''}`,
+            className: `bg-pink-500 text-white ${stage < 3 ? 'opacity-50 pointer-events-none' : ''}`,
             onClick: stage >= 3 ? toggleLike : undefined
           }, liked ? 'Unmatch' : 'Match'),
-          stage < 3 && React.createElement(CalendarClock, { className:'absolute inset-0 m-auto w-8 h-8 text-pink-500' })
+          stage < 3 && React.createElement('span', { className:'absolute inset-0 m-auto text-pink-500 text-xs font-semibold flex items-center justify-center text-center px-2' }, t('unlockHigherLevels'))
         ),
         publicView && !isOwnProfile && React.createElement(Button, {
           className: 'ml-2 bg-red-500 text-white',

--- a/src/i18n.js
+++ b/src/i18n.js
@@ -78,7 +78,8 @@ inviteAccepted:{ en:"Profile created", da:"Oprettet", sv:"Skapad", es:"Perfil cr
   level2Rate:{ en:'Give a private rating', da:'Giv en privat vurdering', sv:'Ge ett privat betyg', es:'Da una calificación privada', fr:'Donnez une évaluation privée', de:'Gib eine private Bewertung ab' },
   level2Reflect:{ en:'Write a private reflection', da:'Skriv en privat refleksion', sv:'Skriv en privat reflektion', es:'Escribe una reflexión privada', fr:'Écrivez une réflexion privée', de:'Schreibe eine private Reflexion' },
   level2Intro:{ en:'Get to level 2 with {name}', da:'Kom til niveau 2 med {name}', sv:'Kom till nivå 2 med {name}', es:'Llega al nivel 2 con {name}', fr:'Atteignez le niveau 2 avec {name}', de:'Erreiche Level 2 mit {name}' },
-  newLabel:{ en:'New!', da:'Nyt!', sv:'Nytt!', es:'¡Nuevo!', fr:'Nouveau !', de:'Neu!' },
+  unlockHigherLevels:{ en:'Unlocks at higher levels', da:'L\u00e5ses op p\u00e5 h\u00f8jere niveauer', sv:'L\u00e5ses upp p\u00e5 h\u00f6gre niv\u00e5er', es:'Se desbloquea en niveles superiores', fr:'Se d\u00e9bloque \u00e0 des niveaux sup\u00e9rieurs', de:'Wird auf h\u00f6heren Ebenen freigeschaltet' },
+  newLabel:{ en:'New!', da:'Nyt!', sv:'Nytt!', es:'\u00a1Nuevo!', fr:'Nouveau !', de:'Neu!' },
 };
 
 const LangContext = createContext({ lang: 'en', setLang: () => {} });

--- a/src/version.js
+++ b/src/version.js
@@ -1,1 +1,1 @@
-export default '1.0.51';
+export default '1.0.53';


### PR DESCRIPTION
## Summary
- show `unlockHigherLevels` text instead of clock icon on locked content
- make Match button inactive without blur effect
- update translations and version

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_687aa6c3f60c832d99c695d39fdba5ec