### PR TITLE
Disable download and playback speed controls

### DIFF
--- a/src/components/ProfileEpisode.jsx
+++ b/src/components/ProfileEpisode.jsx
@@ -162,7 +162,7 @@ export default function ProfileEpisode({ userId, profileId, onBack }) {
         const url = clip && clip.url ? clip.url : clip;
         const locked = i >= stage;
         return React.createElement('div', { key: i, className:`flex items-center relative ${locked ? 'pointer-events-none' : ''}` },
-          React.createElement('audio', { src: url, controls: true, className: 'flex-1 mr-2' }),
+          React.createElement('audio', { src: url, controls: true, controlsList: 'nodownload noplaybackrate', className: 'flex-1 mr-2' }),
           !locked && i === stage - 1 && React.createElement('span', { className:'absolute top-1 right-1 bg-green-100 text-green-600 text-xs font-semibold px-1 rounded' }, t('newLabel')),
           locked && React.createElement('div', { className:'absolute inset-0 bg-black/80 flex items-center justify-center rounded text-center px-2' },
             React.createElement('span', { className:'text-pink-500 text-xs font-semibold' }, t('unlockHigherLevels'))

--- a/src/components/ProfileSettings.jsx
+++ b/src/components/ProfileSettings.jsx
@@ -381,7 +381,7 @@ export default function ProfileSettings({ userId, ageRange, onChangeAgeRange, pu
         const url = clip && clip.url ? clip.url : clip;
         const locked = i >= stage;
         return React.createElement('div', { key: i, className: `flex items-center relative ${locked ? 'pointer-events-none' : ''}` },
-          React.createElement('audio', { src: url, controls: true, className: 'flex-1 mr-2' }),
+          React.createElement('audio', { src: url, controls: true, controlsList: 'nodownload noplaybackrate', className: 'flex-1 mr-2' }),
           locked && React.createElement('div', { className:'absolute inset-0 bg-black/80 flex items-center justify-center rounded text-center px-2' },
             React.createElement('span', { className:'text-pink-500 text-xs font-semibold' }, t('unlockHigherLevels'))
           ),

--- a/src/components/ReportedContentScreen.jsx
+++ b/src/components/ReportedContentScreen.jsx
@@ -66,7 +66,7 @@ export default function ReportedContentScreen({ onBack }) {
     React.createElement('ul', { className:'space-y-4 overflow-y-auto max-h-[70vh]' },
       detailItems.map((item,i)=>
         React.createElement('li', { key:i, className:'border p-2 rounded' },
-          item.clipURL && React.createElement('video', { src:item.clipURL, controls:true, className:'w-full mb-2' }),
+          item.clipURL && React.createElement('video', { src:item.clipURL, controls:true, controlsList:'nodownload noplaybackrate', className:'w-full mb-2' }),
           item.text && React.createElement('p', { className:'mb-2' }, item.text),
           React.createElement('p', { className:'text-sm text-gray-600 mb-1' }, `Antal anmeldelser: ${item.reports.length}`),
           React.createElement('ul', { className:'mb-2 list-disc list-inside text-sm' },

--- a/src/components/VideoOverlay.jsx
+++ b/src/components/VideoOverlay.jsx
@@ -4,7 +4,7 @@ import { X } from 'lucide-react';
 export default function VideoOverlay({ src, onClose }) {
   return React.createElement('div', { className:'fixed inset-0 z-50 bg-black/70 flex items-center justify-center' },
     React.createElement('div', { className:'relative w-full max-w-md mx-4' },
-      React.createElement('video', { src, controls:true, className:'w-full rounded' }),
+      React.createElement('video', { src, controls:true, controlsList:'nodownload noplaybackrate', className:'w-full rounded' }),
       React.createElement('button', { onClick:onClose, className:'absolute top-2 right-2 text-white bg-black/40 rounded-full p-1' },
         React.createElement(X,{className:'w-6 h-6'})
       )

--- a/src/components/VideoPreview.jsx
+++ b/src/components/VideoPreview.jsx
@@ -4,6 +4,7 @@ export default function VideoPreview({ src, onEnded }) {
   return React.createElement('video', {
     src,
     controls: true,
+    controlsList: 'nodownload noplaybackrate',
     className: 'w-full rounded',
     onEnded
   });


### PR DESCRIPTION
## Summary
- hide download and speed controls for video/audio players

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_687ab02e8288832d85368a45d0f95828