### PR TITLE
Add help overlay to ProfileEpisode

### DIFF
--- a/src/components/ProfileEpisode.jsx
+++ b/src/components/ProfileEpisode.jsx
@@ -9,6 +9,7 @@ import { useT } from '../i18n.js';
 import ProfileSettings from './ProfileSettings.jsx';
 import VideoPreview from './VideoPreview.jsx';
 import { Star } from 'lucide-react';
+import InfoOverlay from './InfoOverlay.jsx';
 
 export default function ProfileEpisode({ userId, profileId, onBack }) {
   const progressId = `${userId}-${profileId}`;
@@ -21,6 +22,7 @@ export default function ProfileEpisode({ userId, profileId, onBack }) {
   const [reflection, setReflection] = useState('');
   const [reaction, setReaction] = useState('');
   const [rating, setRating] = useState(0);
+  const [showHelp, setShowHelp] = useState(false);
   const extendExpiry = (current) => {
     const base = current && new Date(current) > getCurrentDate()
       ? new Date(current) : getCurrentDate();
@@ -118,7 +120,8 @@ export default function ProfileEpisode({ userId, profileId, onBack }) {
     });
   }
 
-  return React.createElement(Card, { className: 'p-6 m-4 shadow-xl bg-white/90' },
+  return React.createElement(React.Fragment, null,
+    React.createElement(Card, { className: 'p-6 m-4 shadow-xl bg-white/90' },
     React.createElement(Button, { className: 'mb-4 bg-pink-500 text-white', onClick: onBack }, 'Tilbage'),
     React.createElement('div', { className:'w-[300px] mx-auto text-left border border-gray-300 rounded p-4 mb-4' },
       React.createElement('div', { className: 'flex justify-start gap-2 mb-2' },
@@ -135,7 +138,11 @@ export default function ProfileEpisode({ userId, profileId, onBack }) {
           showRatingLine && React.createElement('li', { key:'rate' }, t('level2Rate')),
           React.createElement('li', { key:'reflect' }, t('level2Reflect'))
         ].filter(Boolean)
-      )
+      ),
+      stage === 1 && React.createElement('p', {
+        className:'text-right text-xs text-blue-500 underline cursor-pointer mt-1',
+        onClick: ()=>setShowHelp(true)
+      }, 'Need help?')
     ),
     React.createElement(SectionTitle, { title: `${profile.name || ''}, ${profile.birthday ? getAge(profile.birthday) : profile.age || ''}${profile.city ? ', ' + profile.city : ''}` }),
     React.createElement('p', { className:'text-left text-xs text-yellow-600 mb-2' }, t('expiresIn').replace('{days}', daysLeft)),
@@ -215,5 +222,19 @@ export default function ProfileEpisode({ userId, profileId, onBack }) {
       }),
       React.createElement(Button, { className: 'bg-pink-500 text-white', onClick: saveReaction }, 'Gem')
     )
-  );
+  ),
+  showHelp && React.createElement(InfoOverlay, {
+    title: 'Need help?',
+    onClose: ()=>setShowHelp(false)
+  },
+    React.createElement('div', { className:'space-y-2 text-sm' },
+      React.createElement('p', null, t('level2Intro').replace('{name}', profile.name || '')),
+      React.createElement('ul', { className:'list-disc list-inside' },
+        React.createElement('li', null, t('level2Watch')),
+        React.createElement('li', null, t('level2Rate')),
+        React.createElement('li', null, t('level2Reflect'))
+      )
+    )
+  )
+);
 }

--- a/src/i18n.js
+++ b/src/i18n.js
@@ -77,7 +77,14 @@ inviteAccepted:{ en:"Profile created", da:"Oprettet", sv:"Skapad", es:"Perfil cr
   level2Watch:{ en:'Watch the new video or sound clip', da:'Se det nye video- eller lydklip', sv:'Titta på det nya video- eller ljudklippet', es:'Mira el nuevo vídeo o clip de sonido', fr:'Regardez la nouvelle vidéo ou le nouveau clip audio', de:'Sieh dir den neuen Video- oder Audioclip an' },
   level2Rate:{ en:'Give a private rating', da:'Giv en privat vurdering', sv:'Ge ett privat betyg', es:'Da una calificación privada', fr:'Donnez une évaluation privée', de:'Gib eine private Bewertung ab' },
   level2Reflect:{ en:'Write a private reflection', da:'Skriv en privat refleksion', sv:'Skriv en privat reflektion', es:'Escribe una reflexión privada', fr:'Écrivez une réflexion privée', de:'Schreibe eine private Reflexion' },
-  level2Intro:{ en:'Get to level 2 with {name}', da:'Kom til niveau 2 med {name}', sv:'Kom till nivå 2 med {name}', es:'Llega al nivel 2 con {name}', fr:'Atteignez le niveau 2 avec {name}', de:'Erreiche Level 2 mit {name}' },
+  level2Intro:{
+    en:'Get to level 2 with {name} to see more content',
+    da:'Kom til niveau 2 med {name} for at se mere indhold',
+    sv:'Kom till nivå 2 med {name} för att se mer innehåll',
+    es:'Llega al nivel 2 con {name} para ver más contenido',
+    fr:'Atteignez le niveau 2 avec {name} pour voir plus de contenu',
+    de:'Erreiche Level 2 mit {name}, um mehr Inhalte zu sehen'
+  },
   unlockHigherLevels:{ en:'Unlocks at higher levels', da:'L\u00e5ses op p\u00e5 h\u00f8jere niveauer', sv:'L\u00e5ses upp p\u00e5 h\u00f6gre niv\u00e5er', es:'Se desbloquea en niveles superiores', fr:'Se d\u00e9bloque \u00e0 des niveaux sup\u00e9rieurs', de:'Wird auf h\u00f6heren Ebenen freigeschaltet' },
   newLabel:{ en:'New!', da:'Nyt!', sv:'Nytt!', es:'\u00a1Nuevo!', fr:'Nouveau !', de:'Neu!' },
 };


### PR DESCRIPTION
## Summary
- show help overlay in ProfileEpisode
- update level 2 intro translations to mention unlocking content

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_687ab0d55a58832db6f7dfb8242e2018