### PR TITLE
Add GitHub Actions test workflow

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,17 @@
+name: Test
+
+on:
+  push:
+    branches: [ '**' ]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 18
+          cache: 'npm'
+      - run: npm ci
+      - run: npm test -- --coverage

--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 # RealDate
+![Test](https://github.com/nyhave/videotpush/actions/workflows/test.yml/badge.svg)
 
 RealDate is a small prototype for experimenting with a slower approach to online dating.
 The **VideotpushApp** demonstrates daily video discovery, chat, reflection notes
@@ -69,6 +70,8 @@ To create a production build run:
 npm run build
 ```
 The compiled files will be placed in the `dist` folder. When changes are pushed to `main`, a GitHub Actions workflow builds the project and publishes the site to **GitHub Pages**. The workflow lives in `.github/workflows/build.yml` where the required secrets, including `FUNCTIONS_BASE_URL`, are written to a `.env` file during the build step so the app can call the Netlify functions.
+
+A separate workflow defined in `.github/workflows/test.yml` installs dependencies and runs the Jest test suite with coverage on every push.
 
 ## Running Tests
 


### PR DESCRIPTION
## Summary
- add test workflow that installs dependencies and runs `npm test -- --coverage`
- document new workflow in README with badge and description

## Testing
- `npm ci`
- `npm test -- --coverage`


------
https://chatgpt.com/codex/tasks/task_e_687b15d18a5c832d9e88164248d00b17