### PR TITLE
Fix duplicate firebase exports

### DIFF
--- a/src/firebase.js
+++ b/src/firebase.js
@@ -200,7 +200,6 @@ export {
   getDownloadURL,
   listAll,
   deleteObject,
-  messaging,
   onMessage,
   requestNotificationPermission,
   subscribeToWebPush,
@@ -210,4 +209,3 @@ export {
   logEvent
 };
 
-export { storage };


### PR DESCRIPTION
## Summary
- remove redundant messaging and storage exports in `src/firebase.js`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687b18f2c094832dae11a19d3c555b56