### PR TITLE
Add StoryLine overlay

### DIFF
--- a/src/components/DailyDiscovery.jsx
+++ b/src/components/DailyDiscovery.jsx
@@ -11,6 +11,7 @@ import selectProfiles, { scoreProfiles } from '../selectProfiles.js';
 import PurchaseOverlay from './PurchaseOverlay.jsx';
 import MatchOverlay from './MatchOverlay.jsx';
 import InfoOverlay from './InfoOverlay.jsx';
+import StoryLineOverlay from './StoryLineOverlay.jsx';
 
 export default function DailyDiscovery({ userId, onSelectProfile, ageRange, onOpenProfile }) {
   const profiles = useCollection('profiles');
@@ -70,6 +71,7 @@ export default function DailyDiscovery({ userId, onSelectProfile, ageRange, onOp
   const [showInfo, setShowInfo] = useState(false);
   const [matchedProfile, setMatchedProfile] = useState(null);
   const [activeVideo, setActiveVideo] = useState(null);
+  const [storyProfile, setStoryProfile] = useState(null);
   const handleExtraPurchase = async () => {
     const todayStr = getTodayStr();
     await updateDoc(doc(db, 'profiles', userId), { extraClipsDate: todayStr });
@@ -160,11 +162,12 @@ export default function DailyDiscovery({ userId, onSelectProfile, ageRange, onOp
               p.clip && React.createElement('p', { className: 'text-sm text-gray-700' }, `“${p.clip}”`)
             )
           ),
-        React.createElement('div', { className: 'flex gap-2 mt-2' },
-            React.createElement(Button, { size: 'sm', variant: 'outline', className: 'flex items-center gap-1', onClick:e=>{e.stopPropagation(); const url=(p.videoClips&&p.videoClips[0])?(p.videoClips[0].url||p.videoClips[0]):null; if(url) setActiveVideo(url); } },
-              React.createElement(PlayCircle, { className: 'w-5 h-5' }), 'Afspil'
+          React.createElement('div', { className: 'flex gap-2 mt-2' },
+              React.createElement(Button, { size: 'sm', variant: 'outline', className: 'flex items-center gap-1', onClick:e=>{e.stopPropagation(); const url=(p.videoClips&&p.videoClips[0])?(p.videoClips[0].url||p.videoClips[0]):null; if(url) setActiveVideo(url); } },
+                React.createElement(PlayCircle, { className: 'w-5 h-5' }), 'Afspil'
+              ),
+              React.createElement(Button, { size: 'sm', variant: 'outline', onClick:e=>{e.stopPropagation(); setStoryProfile(p);} }, 'StoryLine')
             )
-          )
         )
       }) :
         React.createElement('li', { className: 'text-center text-gray-500' }, t('noProfiles'))
@@ -193,6 +196,12 @@ export default function DailyDiscovery({ userId, onSelectProfile, ageRange, onOp
     },
       React.createElement('p', { className: 'text-center text-sm' }, 'Du har allerede købt ekstra klip i dag')
     ),
+    storyProfile && React.createElement(StoryLineOverlay, {
+      profile: storyProfile,
+      progress: progresses.find(pr => pr.profileId === storyProfile.id),
+      onClose: () => setStoryProfile(null),
+      onMatch: id => { toggleLike(id); setStoryProfile(null); }
+    }),
     matchedProfile && React.createElement(MatchOverlay, {
       name: matchedProfile.name,
       onClose: () => setMatchedProfile(null)

--- a/src/components/LikesScreen.jsx
+++ b/src/components/LikesScreen.jsx
@@ -8,6 +8,7 @@ import PurchaseOverlay from './PurchaseOverlay.jsx';
 import { Button } from './ui/button.js';
 import SectionTitle from './SectionTitle.jsx';
 import { useCollection, db, doc, setDoc, deleteDoc, getDoc } from '../firebase.js';
+import StoryLineOverlay from './StoryLineOverlay.jsx';
 
 export default function LikesScreen({ userId, onSelectProfile }) {
   const profiles = useCollection('profiles');
@@ -22,6 +23,8 @@ export default function LikesScreen({ userId, onSelectProfile }) {
 
   const [activeVideo, setActiveVideo] = useState(null);
   const [matchedProfile, setMatchedProfile] = useState(null);
+  const [storyProfile, setStoryProfile] = useState(null);
+  const progresses = useCollection('episodeProgress','userId', userId);
   const toggleLike = async profileId => {
     const likeId = `${userId}-${profileId}`;
     const exists = likes.some(l => l.profileId === profileId);
@@ -94,7 +97,8 @@ export default function LikesScreen({ userId, onSelectProfile }) {
             React.createElement('div',{className:'flex gap-2 mt-2'},
               React.createElement(Button,{size:'sm',variant:'outline',className:'flex items-center gap-1',onClick:e=>{e.stopPropagation();const url=(p.videoClips&&p.videoClips[0])?(p.videoClips[0].url||p.videoClips[0]):null;if(url)setActiveVideo(url);}},
                 React.createElement(PlayCircle,{className:'w-5 h-5'}),'Afspil'
-              )
+              ),
+              React.createElement(Button,{size:'sm',variant:'outline',onClick:e=>{e.stopPropagation();setStoryProfile(p);}},'StoryLine')
             )
           )
         )) :
@@ -110,6 +114,7 @@ export default function LikesScreen({ userId, onSelectProfile }) {
         React.createElement('li',null,'⏳ Bliv på set i længere tid på listen af profiler (+5 dage)')
       )
     ),
+    storyProfile && React.createElement(StoryLineOverlay,{profile:storyProfile, progress: progresses.find(pr=>pr.profileId===storyProfile.id), onClose:()=>setStoryProfile(null), onMatch:id=>{toggleLike(id); setStoryProfile(null);}}),
     matchedProfile && React.createElement(MatchOverlay,{name:matchedProfile.name,onClose:()=>setMatchedProfile(null)}),
     activeVideo && React.createElement(VideoOverlay,{src:activeVideo,onClose:()=>setActiveVideo(null)})
   );

--- a/src/components/StoryLineOverlay.jsx
+++ b/src/components/StoryLineOverlay.jsx
@@ -1,0 +1,50 @@
+import React, { useState, useEffect } from 'react';
+import { Card } from './ui/card.js';
+import { Button } from './ui/button.js';
+import { Star } from 'lucide-react';
+
+export default function StoryLineOverlay({ profile, progress, onClose, onMatch }) {
+  const [step, setStep] = useState(0); // 0 video,1 clip,2 audio,3 rating
+  const [fade, setFade] = useState(false);
+  const [showButton, setShowButton] = useState(false);
+
+  useEffect(() => {
+    if(step < 3){
+      const timer = setTimeout(() => {
+        setFade(true);
+        setTimeout(() => {
+          setStep(step + 1);
+          setFade(false);
+        }, 500);
+      }, 3000);
+      return () => clearTimeout(timer);
+    } else {
+      const btnTimer = setTimeout(() => setShowButton(true), 2000);
+      return () => clearTimeout(btnTimer);
+    }
+  }, [step]);
+
+  const videoUrl = (profile.videoClips && profile.videoClips[0]) ? (profile.videoClips[0].url || profile.videoClips[0]) : null;
+  const audioUrl = (profile.audioClips && profile.audioClips[0]) ? (profile.audioClips[0].url || profile.audioClips[0]) : null;
+
+  return React.createElement('div', { className:'fixed inset-0 z-50 bg-black/70 flex items-center justify-center' },
+    React.createElement(Card, { className:'bg-white p-6 rounded shadow-xl max-w-sm w-full text-center' },
+      React.createElement('div', { className:`transition-opacity duration-500 ${fade ? 'opacity-0' : 'opacity-100'}` },
+        step === 0 && videoUrl && React.createElement('video', { src: videoUrl, autoPlay:true, className:'w-full rounded' }),
+        step === 1 && React.createElement('p', { className:'text-lg mb-2' }, `“${profile.clip || ''}”`),
+        step === 2 && audioUrl && React.createElement('audio', { src: audioUrl, autoPlay:true, className:'w-full', controls:false }),
+        step === 3 && React.createElement('div', { className:'space-y-2' },
+          progress?.rating && React.createElement('div', { className:'flex justify-center gap-1' },
+            [1,2,3].map(n => React.createElement(Star, {
+              key:n,
+              className:`w-5 h-5 ${n <= progress.rating ? 'fill-pink-500 stroke-pink-500' : 'stroke-gray-400'}`
+            }))
+          ),
+          progress?.reflection && React.createElement('p', { className:'italic' }, `“${progress.reflection}”`)
+        )
+      ),
+      step === 3 && showButton && React.createElement(Button, { className:'w-full bg-pink-500 text-white mt-4', onClick:()=>onMatch && onMatch(profile.id) }, 'Match now?'),
+      React.createElement(Button, { className:'w-full mt-2', onClick:onClose }, 'Close')
+    )
+  );
+}


### PR DESCRIPTION
## Summary
- add new `StoryLineOverlay` for sequential profile preview
- show StoryLine button on DailyDiscovery and Likes lists
- allow viewing short video, clip, audio and rating with fade effects

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_687b2d9a6e80832dbc086f0a9b121f34