### PR TITLE
Fix path-to-regexp issue in screenshot script

### DIFF
--- a/scripts/capture-screens.js
+++ b/scripts/capture-screens.js
@@ -6,7 +6,8 @@ const puppeteer = require('puppeteer');
 async function startServer(distPath, port) {
   const app = express();
   app.use(express.static(distPath));
-  app.get('*', (req, res) => {
+  // For client-side routing in the built SPA
+  app.use((req, res) => {
     res.sendFile(path.join(distPath, 'index.html'));
   });
   return new Promise(resolve => {
@@ -21,7 +22,8 @@ async function capture() {
 
   const browser = await puppeteer.launch({
     headless: 'new',
-    executablePath: process.env.PUPPETEER_EXECUTABLE_PATH
+    executablePath: process.env.PUPPETEER_EXECUTABLE_PATH,
+    args: ['--no-sandbox']
   });
   const page = await browser.newPage();
   const routes = ['/', '/profile', '/chat', '/admin'];


### PR DESCRIPTION
## Summary
- update capture-screens server routes for express 5
- allow Puppeteer to run as root

## Testing
- `npm test`
- `npm run test:functions`
- `node scripts/capture-screens.js` *(fails to find dist but no path-to-regexp error)*

------
https://chatgpt.com/codex/tasks/task_e_687b3961c5e4832d9624bb1472f30f78