### PR TITLE
Add recent logins admin screen

### DIFF
--- a/src/VideotpushApp.jsx
+++ b/src/VideotpushApp.jsx
@@ -20,6 +20,7 @@ import FunctionTestScreen from './components/FunctionTestScreen.jsx';
 import TextLogScreen from './components/TextLogScreen.jsx';
 import TrackUserScreen from './components/TrackUserScreen.jsx';
 import ServerLogScreen from './components/ServerLogScreen.jsx';
+import RecentLoginsScreen from './components/RecentLoginsScreen.jsx';
 import ProfileEpisode from './components/ProfileEpisode.jsx';
 import HelpOverlay from './components/HelpOverlay.jsx';
 import TaskButton from './components/TaskButton.jsx';
@@ -258,7 +259,7 @@ export default function VideotpushApp() {
             activeTask
           }),
           tab==='likes' && React.createElement(LikesScreen, { userId, onBack: ()=>setTab('discovery'), onSelectProfile: selectProfile }),
-          tab==='admin' && React.createElement(AdminScreen, { onOpenStats: ()=>setTab('stats'), onOpenBugReports: ()=>setTab('bugs'), onOpenMatchLog: ()=>setTab('matchlog'), onOpenScoreLog: ()=>setTab('scorelog'), onOpenReports: ()=>setTab('reports'), onOpenCallLog: ()=>setTab('calllog'), onOpenFunctionTest: ()=>setTab('functiontest'), onOpenTextLog: ()=>setTab('textlog'), onOpenUserLog: ()=>setTab('trackuser'), onOpenServerLog: ()=>setTab('serverlog'), profiles, userId, onSwitchProfile: id=>setUserId(id), onSaveUserLogout: saveUserAndLogout }),
+          tab==='admin' && React.createElement(AdminScreen, { onOpenStats: ()=>setTab('stats'), onOpenBugReports: ()=>setTab('bugs'), onOpenMatchLog: ()=>setTab('matchlog'), onOpenScoreLog: ()=>setTab('scorelog'), onOpenReports: ()=>setTab('reports'), onOpenCallLog: ()=>setTab('calllog'), onOpenFunctionTest: ()=>setTab('functiontest'), onOpenTextLog: ()=>setTab('textlog'), onOpenUserLog: ()=>setTab('trackuser'), onOpenServerLog: ()=>setTab('serverlog'), onOpenRecentLogins: ()=>setTab('recentlogins'), profiles, userId, onSwitchProfile: id=>setUserId(id), onSaveUserLogout: saveUserAndLogout }),
           tab==='stats' && React.createElement(StatsScreen, { onBack: ()=>setTab('admin') }),
           tab==='matchlog' && React.createElement(MatchLogScreen, { onBack: ()=>setTab('admin') }),
           tab==='scorelog' && React.createElement(ScoreLogScreen, { onBack: ()=>setTab('admin') }),
@@ -269,6 +270,7 @@ export default function VideotpushApp() {
           tab==='textlog' && React.createElement(TextLogScreen, { onBack: ()=>setTab('admin') }),
           tab==='trackuser' && React.createElement(TrackUserScreen, { onBack: ()=>setTab('admin'), profiles }),
           tab==='serverlog' && React.createElement(ServerLogScreen, { onBack: ()=>setTab('admin') }),
+          tab==='recentlogins' && React.createElement(RecentLoginsScreen, { onBack: ()=>setTab('admin') }),
           tab==='about' && React.createElement(AboutScreen, { userId })
         )
     ),

--- a/src/components/AdminScreen.jsx
+++ b/src/components/AdminScreen.jsx
@@ -10,7 +10,7 @@ import { getToken } from 'firebase/messaging';
 import { fcmReg } from '../swRegistration.js';
 
 
-export default function AdminScreen({ onOpenStats, onOpenBugReports, onOpenMatchLog, onOpenScoreLog, onOpenReports, onOpenCallLog, onOpenFunctionTest, onOpenTextLog, onOpenUserLog, onOpenServerLog, profiles = [], userId, onSwitchProfile, onSaveUserLogout }) {
+export default function AdminScreen({ onOpenStats, onOpenBugReports, onOpenMatchLog, onOpenScoreLog, onOpenReports, onOpenCallLog, onOpenFunctionTest, onOpenTextLog, onOpenUserLog, onOpenServerLog, onOpenRecentLogins, profiles = [], userId, onSwitchProfile, onSaveUserLogout }) {
 
   const { lang, setLang } = useLang();
   const t = useT();
@@ -246,6 +246,8 @@ export default function AdminScreen({ onOpenStats, onOpenBugReports, onOpenMatch
     React.createElement(Button, { className: 'mt-2 bg-blue-500 text-white px-4 py-2 rounded', onClick: showPushInfo }, 'Show push info'),
     React.createElement(Button, { className: 'mt-2 bg-blue-500 text-white px-4 py-2 rounded', onClick: onOpenServerLog }, 'Server log'),
 
+    React.createElement('h3', { className: 'text-xl font-semibold mb-2 mt-4 text-blue-600' }, 'Seneste logins'),
+    React.createElement(Button, { className: 'mt-2 bg-blue-500 text-white px-4 py-2 rounded', onClick: onOpenRecentLogins }, 'Se seneste logins'),
 
     React.createElement('h3', { className: 'text-xl font-semibold mb-2 mt-4 text-blue-600' }, 'Aktive opkald'),
     React.createElement(Button, { className: 'mt-2 bg-blue-500 text-white px-4 py-2 rounded', onClick: onOpenCallLog }, 'Se aktive opkald'),

--- a/src/components/RecentLoginsScreen.jsx
+++ b/src/components/RecentLoginsScreen.jsx
@@ -1,0 +1,38 @@
+import React, { useState } from 'react';
+import { Card } from './ui/card.js';
+import { Button } from './ui/button.js';
+import SectionTitle from './SectionTitle.jsx';
+import { useCollection } from '../firebase.js';
+
+function formatDate(iso){
+  if(!iso) return 'Ukendt';
+  try{
+    return new Date(iso).toLocaleString('da-DK',{ dateStyle:'short', timeStyle:'short' });
+  }catch{
+    return iso;
+  }
+}
+
+export default function RecentLoginsScreen({ onBack }){
+  const profiles = useCollection('profiles');
+  const sorted = profiles
+    .filter(p => p.lastActive)
+    .sort((a,b)=> new Date(b.lastActive) - new Date(a.lastActive));
+  const [showAll, setShowAll] = useState(false);
+  const list = showAll ? sorted : sorted.slice(0,10);
+
+  return React.createElement(Card,{ className:'p-6 m-4 shadow-xl bg-white/90 overflow-y-auto max-h-[90vh]' },
+    React.createElement(SectionTitle,{ title:'Seneste logins', colorClass:'text-blue-600', action: React.createElement(Button,{onClick:onBack},'Tilbage') }),
+    list.length ? (
+      React.createElement('ul',{ className:'space-y-2 mt-4' },
+        list.map(p=>React.createElement('li',{ key:p.id, className:'border-b pb-1 text-sm' },
+          React.createElement('div',null,p.name || p.id),
+          React.createElement('div',{ className:'text-xs text-gray-500' }, formatDate(p.lastActive))
+        ))
+      )
+    ) : (
+      React.createElement('p',{ className:'text-center mt-4 text-gray-500' },'Ingen aktive brugere')
+    ),
+    !showAll && sorted.length>10 && React.createElement(Button,{ className:'mt-4 bg-blue-500 text-white px-4 py-2 rounded', onClick:()=>setShowAll(true) },'Vis alle')
+  );
+}


### PR DESCRIPTION
## Summary
- allow admin to view recent profile logins
- open recent login view from the admin menu

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687b805e609c832d89f8f4a46ba1cea5