### PR TITLE
Add admin flag to push registration

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,10 +144,10 @@ The Netlify functions automatically read these variables and initialize the Fire
 
 `netlify/functions/send-push.js` sends FCM messages to tokens stored in Firestore. Trigger it with a `POST` request containing a `body` and optional `title`. You can also pass a `tokens` array to send to specific devices instead of using the stored tokens. Include `"silent": true` to suppress notification sounds.
 Any token that FCM reports as **unregistered** or **invalid** will automatically
-be removed from the `pushTokens` collection. Temporary failures no longer delete
+be removed from the `pushTokens` collection. Each entry also stores the user's username, operating system, browser and whether the registration was made by an admin. Temporary failures no longer delete
 tokens so testing with multiple recipients does not break subsequent sends.
 
-For iOS PWAs, Safari only supports the standard Web Push API. A separate function (`netlify/functions/send-webpush.js`) sends notifications using VAPID keys defined in `WEB_PUSH_PUBLIC_KEY` and `WEB_PUSH_PRIVATE_KEY`. Subscriptions are stored in the `webPushSubscriptions` collection. Pass `silent: true` to send a Web Push notification without sound.
+For iOS PWAs, Safari only supports the standard Web Push API. A separate function (`netlify/functions/send-webpush.js`) sends notifications using VAPID keys defined in `WEB_PUSH_PUBLIC_KEY` and `WEB_PUSH_PRIVATE_KEY`. Subscriptions are stored in the `webPushSubscriptions` collection along with username, operating system, browser and admin information. Pass `silent: true` to send a Web Push notification without sound.
 
 The helper page (`netlify/functions/test-push.html`) posts data to `/.netlify/functions/send-push` for FCM tokens. To test Web Push on iOS, post to `/.netlify/functions/send-webpush` instead.
 

--- a/src/firebase.js
+++ b/src/firebase.js
@@ -30,6 +30,7 @@ import {
   onMessage
 } from 'firebase/messaging';
 import { fcmReg } from './swRegistration.js';
+import { detectOS, detectBrowser, isAdminViewer } from './utils.js';
 
 let extendedLogging = false;
 if (typeof window !== 'undefined') {
@@ -45,6 +46,21 @@ export function setExtendedLogging(val) {
 
 export function isExtendedLogging() {
   return extendedLogging;
+}
+
+function getUsernameForId(userId) {
+  if (typeof window === 'undefined') return '';
+  try {
+    const creds = JSON.parse(localStorage.getItem('userCreds') || '{}');
+    for (const [name, data] of Object.entries(creds)) {
+      if (data && data.id === userId) {
+        return name;
+      }
+    }
+  } catch (err) {
+    console.error('Failed to read userCreds', err);
+  }
+  return '';
 }
 
 export async function logEvent(event, details = {}) {
@@ -93,7 +109,11 @@ export async function subscribeToWebPush(userId) {
         .replace(/=+$/, '');
     await setDoc(doc(db, 'webPushSubscriptions', safeId), {
       ...sub.toJSON(),
-      userId
+      userId,
+      username: getUsernameForId(userId),
+      os: detectOS(),
+      browser: detectBrowser(),
+      adminViewer: isAdminViewer()
     });
     logEvent('subscribeToWebPush success', { userId });
     return sub;
@@ -141,7 +161,14 @@ export async function requestNotificationPermission(userId) {
       serviceWorkerRegistration: fcmReg
     });
     if (token) {
-      await setDoc(doc(db, 'pushTokens', token), { token, userId }, { merge: true });
+      await setDoc(doc(db, 'pushTokens', token), {
+        token,
+        userId,
+        username: getUsernameForId(userId),
+        os: detectOS(),
+        browser: detectBrowser(),
+        adminViewer: isAdminViewer()
+      }, { merge: true });
     }
     logEvent('requestNotificationPermission success', { userId });
     return token;

--- a/src/utils.js
+++ b/src/utils.js
@@ -29,3 +29,34 @@ export function getAge(birthday){
   }
   return age;
 }
+
+export function detectOS(){
+  if (typeof navigator === 'undefined') return '';
+  const ua = navigator.userAgent || '';
+  if (/android/i.test(ua)) return 'Android';
+  if (/iPad|iPhone|iPod/.test(ua)) return 'iOS';
+  if (/Win/.test(ua)) return 'Windows';
+  if (/Mac/.test(ua)) return 'Mac';
+  if (/Linux/.test(ua)) return 'Linux';
+  return 'Unknown';
+}
+
+export function detectBrowser(){
+  if (typeof navigator === 'undefined') return '';
+  const ua = navigator.userAgent || '';
+  if (/Edg\//.test(ua)) return 'Edge';
+  if (/OPR\//.test(ua)) return 'Opera';
+  if (/Chrome\//.test(ua)) return 'Chrome';
+  if (/Safari\//.test(ua) && !/Chrome\//.test(ua)) return 'Safari';
+  if (/Firefox\//.test(ua)) return 'Firefox';
+  return 'Unknown';
+}
+
+export function isAdminViewer(){
+  if (typeof window === 'undefined') return false;
+  try{
+    return localStorage.getItem('adminAuthorized') === 'true';
+  }catch{
+    return false;
+  }
+}


### PR DESCRIPTION
## Summary
- track whether push tokens or subscriptions were added while in admin mode
- expose `isAdminViewer` helper to check admin impersonation
- document new `adminViewer` field in README

## Testing
- `npm test`
- `npm run test:functions`


------
https://chatgpt.com/codex/tasks/task_e_687b8952088c832db2db5fcf29db1cc2