### PR TITLE
Track login method with push token

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,10 +144,10 @@ The Netlify functions automatically read these variables and initialize the Fire
 
 `netlify/functions/send-push.js` sends FCM messages to tokens stored in Firestore. Trigger it with a `POST` request containing a `body` and optional `title`. You can also pass a `tokens` array to send to specific devices instead of using the stored tokens. Include `"silent": true` to suppress notification sounds.
 Any token that FCM reports as **unregistered** or **invalid** will automatically
-be removed from the `pushTokens` collection. Each entry also stores the user's username, operating system and browser. Temporary failures no longer delete
-tokens so testing with multiple recipients does not break subsequent sends.
+be removed from the `pushTokens` collection. Each entry also stores the user's username, operating system, browser **and login method** ("password" or "admin").
+Temporary failures no longer delete tokens so testing with multiple recipients does not break subsequent sends.
 
-For iOS PWAs, Safari only supports the standard Web Push API. A separate function (`netlify/functions/send-webpush.js`) sends notifications using VAPID keys defined in `WEB_PUSH_PUBLIC_KEY` and `WEB_PUSH_PRIVATE_KEY`. Subscriptions are stored in the `webPushSubscriptions` collection along with username, operating system and browser information. Pass `silent: true` to send a Web Push notification without sound.
+For iOS PWAs, Safari only supports the standard Web Push API. A separate function (`netlify/functions/send-webpush.js`) sends notifications using VAPID keys defined in `WEB_PUSH_PUBLIC_KEY` and `WEB_PUSH_PRIVATE_KEY`. Subscriptions are stored in the `webPushSubscriptions` collection along with username, operating system, browser information and the login method used when registering. Pass `silent: true` to send a Web Push notification without sound.
 
 The helper page (`netlify/functions/test-push.html`) posts data to `/.netlify/functions/send-push` for FCM tokens. To test Web Push on iOS, post to `/.netlify/functions/send-webpush` instead.
 

--- a/src/VideotpushApp.jsx
+++ b/src/VideotpushApp.jsx
@@ -43,6 +43,7 @@ export default function VideotpushApp() {
   const DEFAULT_USER_ID = '101';
   const LAST_USER_KEY = 'preferredUserId';
   const [userId, setUserId] = useState(null);
+  const [loginMethod, setLoginMethod] = useState('password');
   const profiles = useCollection('profiles');
   const chats = useCollection('matches', 'userId', userId);
   const [ageRange,setAgeRange]=useState([35,55]);
@@ -101,12 +102,14 @@ export default function VideotpushApp() {
       localStorage.setItem(LAST_USER_KEY, userId);
     }
     setLoggedIn(false);
+    setLoginMethod('password');
     setTab('discovery');
     setViewProfile(null);
   };
 
   const logout = () => {
     setLoggedIn(false);
+    setLoginMethod('password');
     setTab('discovery');
     setViewProfile(null);
   };
@@ -154,11 +157,11 @@ export default function VideotpushApp() {
   useEffect(() => {
     if (loggedIn && userId) {
       (async () => {
-        await requestNotificationPermission(userId);
-        await subscribeToWebPush(userId);
+        await requestNotificationPermission(userId, loginMethod);
+        await subscribeToWebPush(userId, loginMethod);
       })();
     }
-  }, [loggedIn, userId]);
+  }, [loggedIn, userId, loginMethod]);
 
   useEffect(() => {
     profiles.forEach(p => {
@@ -180,7 +183,7 @@ export default function VideotpushApp() {
 
 
   if(!loggedIn) return React.createElement(LanguageProvider, { value:{lang,setLang} },
-    React.createElement(WelcomeScreen, { onLogin: id => { setLoggedIn(true); setUserId(id); logEvent('login'); } })
+    React.createElement(WelcomeScreen, { onLogin: id => { setLoggedIn(true); setUserId(id); setLoginMethod('password'); logEvent('login'); } })
   );
   const selectProfile = async id => {
     setViewProfile(id);
@@ -259,7 +262,7 @@ export default function VideotpushApp() {
             activeTask
           }),
           tab==='likes' && React.createElement(LikesScreen, { userId, onBack: ()=>setTab('discovery'), onSelectProfile: selectProfile }),
-          tab==='admin' && React.createElement(AdminScreen, { onOpenStats: ()=>setTab('stats'), onOpenBugReports: ()=>setTab('bugs'), onOpenMatchLog: ()=>setTab('matchlog'), onOpenScoreLog: ()=>setTab('scorelog'), onOpenReports: ()=>setTab('reports'), onOpenCallLog: ()=>setTab('calllog'), onOpenFunctionTest: ()=>setTab('functiontest'), onOpenTextLog: ()=>setTab('textlog'), onOpenUserLog: ()=>setTab('trackuser'), onOpenServerLog: ()=>setTab('serverlog'), onOpenRecentLogins: ()=>setTab('recentlogins'), profiles, userId, onSwitchProfile: id=>setUserId(id), onSaveUserLogout: saveUserAndLogout }),
+          tab==='admin' && React.createElement(AdminScreen, { onOpenStats: ()=>setTab('stats'), onOpenBugReports: ()=>setTab('bugs'), onOpenMatchLog: ()=>setTab('matchlog'), onOpenScoreLog: ()=>setTab('scorelog'), onOpenReports: ()=>setTab('reports'), onOpenCallLog: ()=>setTab('calllog'), onOpenFunctionTest: ()=>setTab('functiontest'), onOpenTextLog: ()=>setTab('textlog'), onOpenUserLog: ()=>setTab('trackuser'), onOpenServerLog: ()=>setTab('serverlog'), onOpenRecentLogins: ()=>setTab('recentlogins'), profiles, userId, onSwitchProfile: id=>{ setUserId(id); setLoginMethod('admin'); }, onSaveUserLogout: saveUserAndLogout }),
           tab==='stats' && React.createElement(StatsScreen, { onBack: ()=>setTab('admin') }),
           tab==='matchlog' && React.createElement(MatchLogScreen, { onBack: ()=>setTab('admin') }),
           tab==='scorelog' && React.createElement(ScoreLogScreen, { onBack: ()=>setTab('admin') }),

--- a/src/firebase.js
+++ b/src/firebase.js
@@ -87,7 +87,7 @@ function urlB64ToUint8Array(base64String) {
   return outputArray;
 }
 
-export async function subscribeToWebPush(userId) {
+export async function subscribeToWebPush(userId, loginMethod = 'password') {
   if (typeof window === 'undefined') return null;
   if (Notification.permission !== 'granted') return null;
 
@@ -112,7 +112,8 @@ export async function subscribeToWebPush(userId) {
       userId,
       username: getUsernameForId(userId),
       os: detectOS(),
-      browser: detectBrowser()
+      browser: detectBrowser(),
+      loginMethod
     });
     logEvent('subscribeToWebPush success', { userId });
     return sub;
@@ -139,7 +140,7 @@ if (typeof window !== 'undefined') {
   messaging = getMessaging(app);
 }
 
-export async function requestNotificationPermission(userId) {
+export async function requestNotificationPermission(userId, loginMethod = 'password') {
 
   if (!messaging || Notification.permission === 'denied') return null;
   let permission = Notification.permission;
@@ -165,7 +166,8 @@ export async function requestNotificationPermission(userId) {
         userId,
         username: getUsernameForId(userId),
         os: detectOS(),
-        browser: detectBrowser()
+        browser: detectBrowser(),
+        loginMethod
       }, { merge: true });
     }
     logEvent('requestNotificationPermission success', { userId });


### PR DESCRIPTION
## Summary
- store login method when registering push tokens
- support login method for web push tokens
- expose login method in React app and pass to registration
- document new login method field

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687b94319eec832d850d0214ded06156