### PR TITLE
Hide level guide details until help popup

### DIFF
--- a/src/components/ProfileEpisode.jsx
+++ b/src/components/ProfileEpisode.jsx
@@ -60,8 +60,6 @@ export default function ProfileEpisode({ userId, profileId, onBack }) {
 
   const daysLeft = progress?.expiresAt ? Math.ceil((new Date(progress.expiresAt) - getCurrentDate())/86400000) : expiryDays;
 
-  const showWatchLine = (profile.videoClips?.length || 0) > 0 || (profile.audioClips?.length || 0) > 0;
-  const showRatingLine = !progress?.rating;
 
   const saveReflection = async () => {
     const text = reflection.trim();
@@ -132,13 +130,7 @@ export default function ProfileEpisode({ userId, profileId, onBack }) {
       ),
       React.createElement('p', { className:'text-left text-sm text-gray-600 mb-2' }, stepLabels[stage-1]),
       stage === 1 && React.createElement('p', { className:'text-left text-sm mb-2 text-gray-700 font-medium' }, t('level2Intro').replace('{name}', profile.name || '')),
-      stage === 1 && React.createElement('ul', { className:'list-disc list-inside text-sm' },
-        [
-          showWatchLine && React.createElement('li', { key:'watch' }, t('level2Watch')),
-          showRatingLine && React.createElement('li', { key:'rate' }, t('level2Rate')),
-          React.createElement('li', { key:'reflect' }, t('level2Reflect'))
-        ].filter(Boolean)
-      ),
+      // Help details are shown in a popup instead of directly on the page
       stage === 1 && React.createElement('p', {
         className:'text-right text-xs text-blue-500 underline cursor-pointer mt-1',
         onClick: ()=>setShowHelp(true)

--- a/src/i18n.js
+++ b/src/i18n.js
@@ -86,7 +86,7 @@ inviteAccepted:{ en:"Profile created", da:"Oprettet", sv:"Skapad", es:"Perfil cr
   level2Reflect:{ en:'Write a private reflection', da:'Skriv en privat refleksion', sv:'Skriv en privat reflektion', es:'Escribe una reflexión privada', fr:'Écrivez une réflexion privée', de:'Schreibe eine private Reflexion' },
   level2Intro:{
     en:'Get to level 2 with {name} to see more content',
-    da:'Kom til niveau 2 med {name} for at se mere indhold',
+    da:'Kom til Niveau 2 med {name} for at se mere indhold',
     sv:'Kom till nivå 2 med {name} för att se mer innehåll',
     es:'Llega al nivel 2 con {name} para ver más contenido',
     fr:'Atteignez le niveau 2 avec {name} pour voir plus de contenu',


### PR DESCRIPTION
## Summary
- localize Danish text to capitalize "Niveau" for level 2 message
- keep level 2 instructions only in the help popup instead of always visible

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687b9ac98384832d81c3f85d24e30168