### PR TITLE
Remove screenshots from build

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -42,11 +42,6 @@ jobs:
           EOF
       - run: npm ci
       - run: npm run build
-      - run: npm run screenshots
-      - uses: actions/upload-artifact@v4
-        with:
-          name: screenshots
-          path: screenshots
       - uses: actions/upload-pages-artifact@v3
         with:
           path: dist

--- a/README.md
+++ b/README.md
@@ -89,11 +89,10 @@ Dette er en test af workflow.
 
 ## Automated Screenshots
 
-During the GitHub Pages build, the workflow runs `npm run screenshots` after the
-production build completes. This command starts a local server from the `dist/`
-folder, visits key routes using Puppeteer and saves screenshots in
-`screenshots/`. The workflow uploads this directory as an artifact so you can
-download the latest overview images from the workflow run page.
+Screenshots of key routes can be generated with `npm run screenshots`. The
+command starts a local server from the `dist/` folder, visits a few routes using
+Puppeteer and saves the result in `screenshots/`. This step is run manually on
+the development server and no longer executes in the GitHub Pages build.
 
 ## Netlify Functions
 


### PR DESCRIPTION
## Summary
- stop generating screenshots during Pages build
- clarify screenshot instructions in README

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_687bc650e248832daaadaf41447ada5a