### PR TITLE
Add login credentials to seed data

### DIFF
--- a/src/seedData.js
+++ b/src/seedData.js
@@ -86,4 +86,13 @@ export default async function seedData() {
   await Promise.all(reflections.map(r => setDoc(doc(db,'reflections',r.id), r)));
 
   await setDoc(doc(db,'config','app'),{premiumInvitesEnabled:true});
+
+  // Seed login credentials for the example users
+  if (typeof window !== 'undefined') {
+    const creds = {};
+    for (const u of testUsers) {
+      creds[`user${u.id}`] = { id: u.id, password: '' };
+    }
+    localStorage.setItem('userCreds', JSON.stringify(creds));
+  }
 }


### PR DESCRIPTION
## Summary
- seed empty-password login credentials when resetting database
- remove unused `testdata` directory

## Testing
- `npm install`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_687bc4c91f68832d8793f19b3bcd68e3