### PR TITLE
Fix hook order in ProfileSettings

### DIFF
--- a/src/components/ProfileSettings.jsx
+++ b/src/components/ProfileSettings.jsx
@@ -51,7 +51,7 @@ export default function ProfileSettings({ userId, ageRange, onChangeAgeRange, pu
   const [reportMode, setReportMode] = useState(false);
   const [reportItem, setReportItem] = useState(null);
   const progressId = publicView && viewerId && viewerId !== userId ? `${viewerId}-${userId}` : null;
-  const progress = progressId ? useDoc('episodeProgress', progressId) : null;
+  const progress = useDoc('episodeProgress', progressId);
   const stage = isOwnProfile ? 3 : (progress?.stage || 1);
 
   const handlePurchase = async () => {


### PR DESCRIPTION
## Summary
- prevent conditional hook invocation for progress state

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687c8192dfc8832dbaec5102a459cf7e