### PR TITLE
Fix profile scroll trigger

### DIFF
--- a/src/VideotpushApp.jsx
+++ b/src/VideotpushApp.jsx
@@ -72,6 +72,7 @@ export default function VideotpushApp() {
   };
 
   const openProfileSettings = () => {
+    setActiveTask(null);
     setTab('profile');
     setViewProfile(null);
   };


### PR DESCRIPTION
## Summary
- avoid carrying over active tasks when just opening profile settings

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_687ca6dff278832db043c842b32a78a8