### PR TITLE
Display login method for recent users

### DIFF
--- a/src/VideotpushApp.jsx
+++ b/src/VideotpushApp.jsx
@@ -153,13 +153,14 @@ export default function VideotpushApp() {
   },[loggedIn, profiles, userId]);
 
   useEffect(() => {
-    if(loggedIn && userId){
+    if (loggedIn && userId) {
       logEvent('active user', { userId });
       updateDoc(doc(db, 'profiles', userId), {
-        lastActive: getCurrentDate().toISOString()
+        lastActive: getCurrentDate().toISOString(),
+        lastLoginMethod: loginMethod
       }).catch(err => console.error('Failed to update lastActive', err));
     }
-  }, [loggedIn, userId]);
+  }, [loggedIn, userId, loginMethod]);
 
   useEffect(() => {
     if (loggedIn && userId) {

--- a/src/components/RecentLoginsScreen.jsx
+++ b/src/components/RecentLoginsScreen.jsx
@@ -27,7 +27,8 @@ export default function RecentLoginsScreen({ onBack }){
       React.createElement('ul',{ className:'space-y-2 mt-4' },
         list.map(p=>React.createElement('li',{ key:p.id, className:'border-b pb-1 text-sm' },
           React.createElement('div',null,p.name || p.id),
-          React.createElement('div',{ className:'text-xs text-gray-500' }, formatDate(p.lastActive))
+          React.createElement('div',{ className:'text-xs text-gray-500' }, formatDate(p.lastActive)),
+          React.createElement('div',{ className:'text-xs text-gray-500' }, p.lastLoginMethod === 'admin' ? 'Administrator' : 'Bruger')
         ))
       )
     ) : (


### PR DESCRIPTION
## Summary
- record the login method on user profiles when updating `lastActive`
- show whether a profile was accessed by the administrator or by the user on the **Seneste logins** page

## Testing
- `npm test --silent -- -w=1`


------
https://chatgpt.com/codex/tasks/task_e_687ce14692fc832dab60f9d61bd71db0