### PR TITLE
Remove QR code from invite overlay

### DIFF
--- a/src/components/InviteOverlay.jsx
+++ b/src/components/InviteOverlay.jsx
@@ -1,5 +1,4 @@
 import React, { useState, useEffect } from 'react';
-import { QRCodeSVG } from 'qrcode.react';
 import { Card } from './ui/card.js';
 import { Button } from './ui/button.js';
 import { useT } from '../i18n.js';
@@ -108,10 +107,6 @@ export default function InviteOverlay({ userId, onClose }) {
         onChange: e => setRecipient(e.target.value)
       }),
       React.createElement('input', { type: 'text', readOnly: true, className: 'border p-2 rounded w-full mb-2', value: link }),
-      React.createElement('div', { className: 'flex flex-col items-center mb-4' },
-        React.createElement(QRCodeSVG, { value: link, size: 128 }),
-        React.createElement('p', { className: 'text-xs mt-2 text-gray-600' }, t('qrOpen'))
-      ),
       invites.length > 0 && React.createElement('div', { className:'mb-4' },
         React.createElement('h3', { className:'font-semibold text-sm mb-1' }, t('inviteList')),
         React.createElement('ul', { className:'text-sm space-y-1' },


### PR DESCRIPTION
## Summary
- remove QR code display from invite overlay

## Testing
- `npm install`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_687d1a8e1698832d91f69318dd6f1562