### PR TITLE
Add help overlay for daily clips

### DIFF
--- a/src/components/DailyDiscovery.jsx
+++ b/src/components/DailyDiscovery.jsx
@@ -67,6 +67,7 @@ export default function DailyDiscovery({ userId, onSelectProfile, ageRange, onOp
   });
 
   const [hoursUntil, setHoursUntil] = useState(0);
+  const [showHelp, setShowHelp] = useState(false);
   const [showPurchase, setShowPurchase] = useState(false);
   const [showInfo, setShowInfo] = useState(false);
   const [matchedProfile, setMatchedProfile] = useState(null);
@@ -129,7 +130,9 @@ export default function DailyDiscovery({ userId, onSelectProfile, ageRange, onOp
   }, []);
 
   return React.createElement(Card, { className: 'p-6 m-4 shadow-xl bg-white/90' },
-    React.createElement(SectionTitle, { title: t('dailyClips') }),
+    React.createElement(SectionTitle, { title: t('dailyClips'), action:
+      React.createElement('span', { className:'text-sm text-blue-500 underline cursor-pointer', onClick:()=>setShowHelp(true) }, t('dailyHelpLabel'))
+    }),
     React.createElement('p', { className: 'text-center text-gray-500 mb-4' }, `Nye klip om ${hoursUntil} timer`),
     React.createElement('p', { className: 'text-center text-gray-500 mb-4' }, `Tag dig god tid til at udforske dagens klip`),
     React.createElement('ul', { className: 'space-y-4' },
@@ -206,6 +209,12 @@ export default function DailyDiscovery({ userId, onSelectProfile, ageRange, onOp
       name: matchedProfile.name,
       onClose: () => setMatchedProfile(null)
     }),
-    activeVideo && React.createElement(VideoOverlay, { src: activeVideo, onClose: () => setActiveVideo(null) })
+    activeVideo && React.createElement(VideoOverlay, { src: activeVideo, onClose: () => setActiveVideo(null) }),
+    showHelp && React.createElement(InfoOverlay, {
+      title: t('dailyHelpTitle'),
+      onClose: () => setShowHelp(false)
+    },
+      React.createElement('p', { className:'text-sm' }, t('dailyHelpText'))
+    )
   );
 }

--- a/src/i18n.js
+++ b/src/i18n.js
@@ -81,6 +81,12 @@ inviteAccepted:{ en:"Profile created", da:"Oprettet", sv:"Skapad", es:"Perfil cr
   helpLevels:{ en:'On the Daily Life page each profile has three levels. Watch clips to unlock more content.', da:'På siden Dagens liv har hver profil tre niveauer. Se klip for at låse mere op.' },
   helpSupport:{ en:'Need assistance? Choose "Report bug" on the About page to contact support.', da:'Brug for hjælp? Vælg \"Fejlmeld\" på Om RealDate-siden for at kontakte support.' },
   helpInvites:{ en:'You can send up to five invitations. Follow each invitation until your friend has created a profile.', da:'Du kan sende op til fem invitationer. Følg hver invitation, indtil din ven har oprettet en profil.' },
+  dailyHelpLabel:{ en:'Need help?', da:'Need help?' },
+  dailyHelpTitle:{ en:'Daily Clips Help', da:'Hjælp til Dagens klip' },
+  dailyHelpText:{
+    en:'Feel the energy and consider carefully before matching. We use video clips and audio to show the person\'s energy and personality. Take your time with the profiles. We support reflection time and want to avoid endless swiping. Therefore you get video/audio one at a time and can look forward to more clips of the same person being released in the next days. To make the videos unique we ask for different content: introduction, biggest interest and free choice.',
+    da:'Føl energien og overvej grundigt inden du matcher. Vi bruger videoklip og lyd til at vise personens energi og personlighed. Brug god tid på profilerne. Vi understøtter tid til refleksion og ønsker at undgå uendelig swipe. Derfor får du video/lyd en af gangen og kan glæde dig til at der næste dage frigives flere klip af samme person. For at gøre videoerne unikke beder vi om forskelligt indhold introduktion, største interesse og frit valg.'
+  },
   level2Watch:{ en:'Watch the new video or sound clip', da:'Se det nye video- eller lydklip', sv:'Titta på det nya video- eller ljudklippet', es:'Mira el nuevo vídeo o clip de sonido', fr:'Regardez la nouvelle vidéo ou le nouveau clip audio', de:'Sieh dir den neuen Video- oder Audioclip an' },
   level2Rate:{ en:'Give a private rating', da:'Giv en privat vurdering', sv:'Ge ett privat betyg', es:'Da una calificación privada', fr:'Donnez une évaluation privée', de:'Gib eine private Bewertung ab' },
   level2Reflect:{ en:'Write a private reflection', da:'Skriv en privat refleksion', sv:'Skriv en privat reflektion', es:'Escribe una reflexión privada', fr:'Écrivez une réflexion privée', de:'Schreibe eine private Reflexion' },


### PR DESCRIPTION
## Summary
- add translation strings for Daily Clips help
- show a **Need help?** link next to Daily Clips section header
- display help overlay with instructions

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_687d214b28cc832db73dd58518a5b2d0