### PR TITLE
Show day labels instead of generic unlock message

### DIFF
--- a/src/components/ProfileEpisode.jsx
+++ b/src/components/ProfileEpisode.jsx
@@ -53,7 +53,7 @@ export default function ProfileEpisode({ userId, profileId, onBack }) {
         userId,
         profileId,
         stage: 1,
-        seenStage: 1,
+        seenStage: 0,
         expiresAt
       }, { merge: true }).catch(err => console.error('Failed to init progress', err));
     }
@@ -162,9 +162,9 @@ export default function ProfileEpisode({ userId, profileId, onBack }) {
         const classes = `w-[30%] flex flex-col items-center justify-end min-h-[160px] relative ${locked ? 'pointer-events-none' : ''} ${showReveal && i === stage - 1 ? 'reveal-animation' : ''}`;
         return React.createElement('div', { key: i, className: classes },
           url && React.createElement(VideoPreview, { src: url, onEnded: () => handleClipEnd(i) }),
-          !locked && i === stage - 1 && React.createElement('span', { className:'absolute top-1 right-1 bg-green-100 text-green-600 text-xs font-semibold px-1 rounded' }, t('newLabel')),
+          !locked && i === stage - 1 && React.createElement('span', { className:'absolute top-1 right-1 bg-green-100 text-green-600 text-xs font-semibold px-1 rounded' }, t('dayLabel').replace('{day}', i + 1)),
           locked && React.createElement('div', { className:'absolute inset-0 bg-black/80 flex items-center justify-center rounded text-center px-2' },
-            React.createElement('span', { className:'text-pink-500 text-xs font-semibold' }, t('unlockHigherLevels'))
+            React.createElement('span', { className:'text-pink-500 text-xs font-semibold' }, t('dayLabel').replace('{day}', i + 1))
           )
         );
       })
@@ -177,16 +177,16 @@ export default function ProfileEpisode({ userId, profileId, onBack }) {
         const aClasses = `flex items-center relative ${locked ? 'pointer-events-none' : ''} ${showReveal && i === stage - 1 ? 'reveal-animation' : ''}`;
         return React.createElement('div', { key: i, className: aClasses },
           React.createElement('audio', { src: url, controls: true, controlsList: 'nodownload noplaybackrate', className: 'flex-1 mr-2' }),
-          !locked && i === stage - 1 && React.createElement('span', { className:'absolute top-1 right-1 bg-green-100 text-green-600 text-xs font-semibold px-1 rounded' }, t('newLabel')),
+          !locked && i === stage - 1 && React.createElement('span', { className:'absolute top-1 right-1 bg-green-100 text-green-600 text-xs font-semibold px-1 rounded' }, t('dayLabel').replace('{day}', i + 1)),
           locked && React.createElement('div', { className:'absolute inset-0 bg-black/80 flex items-center justify-center rounded text-center px-2' },
-            React.createElement('span', { className:'text-pink-500 text-xs font-semibold' }, t('unlockHigherLevels'))
+            React.createElement('span', { className:'text-pink-500 text-xs font-semibold' }, t('dayLabel').replace('{day}', i + 1))
           )
         );
       })
     ),
     React.createElement('div', { className:'relative' },
       React.createElement(Button, { className:`mt-2 w-full bg-pink-500 text-white ${stage < 3 ? 'opacity-50 pointer-events-none' : ''}` }, t('episodeMatchPrompt')),
-      stage < 3 && React.createElement('span', { className:'absolute inset-0 m-auto text-pink-500 text-xs font-semibold flex items-center justify-center text-center px-2' }, t('unlockHigherLevels'))
+      stage < 3 && React.createElement('span', { className:'absolute inset-0 m-auto text-pink-500 text-xs font-semibold flex items-center justify-center text-center px-2' }, t('dayLabel').replace('{day}', 3))
     ),
     stage === 1 && React.createElement('div', { className:'mt-6 p-4 bg-gray-50 rounded-lg border border-gray-300' },
       React.createElement('div', { className: 'flex justify-center gap-1 mb-2' },

--- a/src/components/ProfileSettings.jsx
+++ b/src/components/ProfileSettings.jsx
@@ -390,7 +390,7 @@ export default function ProfileSettings({ userId, ageRange, onChangeAgeRange, pu
                 React.createElement('span', { className:'text-xs text-gray-500 mt-1' }, t('max10Sec'))
               ),
           locked && React.createElement('div', { className:'absolute inset-0 bg-black/80 flex items-center justify-center rounded text-center px-2' },
-            React.createElement('span', { className:'text-pink-500 text-xs font-semibold' }, t('unlockHigherLevels'))
+            React.createElement('span', { className:'text-pink-500 text-xs font-semibold' }, t('dayLabel').replace('{day}', i + 1))
           ),
           url && !publicView && React.createElement(Button, {
             className: 'mt-1 bg-pink-500 text-white p-1 rounded-full flex items-center justify-center',
@@ -425,7 +425,7 @@ export default function ProfileSettings({ userId, ageRange, onChangeAgeRange, pu
         return React.createElement('div', { key: i, className: `flex items-center relative ${locked ? 'pointer-events-none' : ''}` },
           React.createElement('audio', { src: url, controls: true, controlsList: 'nodownload noplaybackrate', className: 'flex-1 mr-2' }),
           locked && React.createElement('div', { className:'absolute inset-0 bg-black/80 flex items-center justify-center rounded text-center px-2' },
-            React.createElement('span', { className:'text-pink-500 text-xs font-semibold' }, t('unlockHigherLevels'))
+            React.createElement('span', { className:'text-pink-500 text-xs font-semibold' }, t('dayLabel').replace('{day}', i + 1))
           ),
           !publicView && React.createElement(Button, {
             className: 'ml-2 bg-pink-500 text-white p-1 rounded w-[20%] flex items-center justify-center',
@@ -519,7 +519,7 @@ export default function ProfileSettings({ userId, ageRange, onChangeAgeRange, pu
             className: `bg-pink-500 text-white ${stage < 3 ? 'opacity-50 pointer-events-none' : ''}`,
             onClick: stage >= 3 ? toggleLike : undefined
           }, liked ? 'Unmatch' : 'Match'),
-          stage < 3 && React.createElement('span', { className:'absolute inset-0 m-auto text-pink-500 text-xs font-semibold flex items-center justify-center text-center px-2' }, t('unlockHigherLevels'))
+          stage < 3 && React.createElement('span', { className:'absolute inset-0 m-auto text-pink-500 text-xs font-semibold flex items-center justify-center text-center px-2' }, t('dayLabel').replace('{day}', 3))
         ),
         publicView && !isOwnProfile && React.createElement(Button, {
           className: 'ml-2 bg-red-500 text-white',

--- a/src/i18n.js
+++ b/src/i18n.js
@@ -98,9 +98,15 @@ inviteAccepted:{ en:"Profile created", da:"Oprettet", sv:"Skapad", es:"Perfil cr
     fr:'Atteignez le niveau 2 avec {name} pour voir plus de contenu',
     de:'Erreiche Level 2 mit {name}, um mehr Inhalte zu sehen'
   },
-  unlockHigherLevels:{ en:'Unlocks at higher levels', da:'L\u00e5ses op p\u00e5 h\u00f8jere niveauer', sv:'L\u00e5ses upp p\u00e5 h\u00f6gre niv\u00e5er', es:'Se desbloquea en niveles superiores', fr:'Se d\u00e9bloque \u00e0 des niveaux sup\u00e9rieurs', de:'Wird auf h\u00f6heren Ebenen freigeschaltet' },
+  dayLabel:{
+    en:'Day {day}',
+    da:'Dag {day}',
+    sv:'Dag {day}',
+    es:'D\u00eda {day}',
+    fr:'Jour {day}',
+    de:'Tag {day}'
+  },
   max10Sec:{ en:'Max 10 sec', da:'Max 10 sek', sv:'Max 10 sek', es:'M\u00e1x 10 seg', fr:'Max 10 s', de:'Max 10 Sek' },
-  newLabel:{ en:'New!', da:'Nyt!', sv:'Nytt!', es:'\u00a1Nuevo!', fr:'Nouveau !', de:'Neu!' },
   qrOpen:{
     en:'Scan to open RealDate',
     da:'Scan for at \u00e5bne RealDate',


### PR DESCRIPTION
## Summary
- replace `unlockHigherLevels` text with new `dayLabel` translation
- display "Dag 1", "Dag 2", "Dag 3" over locked and newly unlocked content
- trigger reveal animation the first time a user opens a profile

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687dde5ddc50832dabfceccf33018868