### PR TITLE
Add admin toggle to show or hide level labels

### DIFF
--- a/src/components/AdminScreen.jsx
+++ b/src/components/AdminScreen.jsx
@@ -17,6 +17,7 @@ export default function AdminScreen({ onOpenStats, onOpenBugReports, onOpenMatch
   const [logEnabled, setLogEnabled] = useState(isExtendedLogging());
   const config = useDoc('config', 'app') || {};
   const invitesEnabled = config.premiumInvitesEnabled !== false;
+  const showLevels = config.showLevels !== false;
 
   const toggleLog = () => {
     const val = !logEnabled;
@@ -231,6 +232,15 @@ export default function AdminScreen({ onOpenStats, onOpenBugReports, onOpenMatch
         onChange: () => updateDoc(doc(db, 'config', 'app'), { premiumInvitesEnabled: !invitesEnabled })
       }),
       'Premium invites'
+    ),
+    React.createElement('label', { className: 'flex items-center mb-2' },
+      React.createElement('input', {
+        type: 'checkbox',
+        className: 'mr-2',
+        checked: showLevels,
+        onChange: () => updateDoc(doc(db, 'config', 'app'), { showLevels: !showLevels })
+      }),
+      'View levels'
     ),
     React.createElement(Button, { className: 'mt-2 bg-blue-500 text-white px-4 py-2 rounded', onClick: onOpenTextLog }, 'Se log'),
     React.createElement(Button, { className: 'mt-2 bg-blue-500 text-white px-4 py-2 rounded', onClick: onOpenMatchLog }, 'Se matchlog'),

--- a/src/components/DailyDiscovery.jsx
+++ b/src/components/DailyDiscovery.jsx
@@ -6,7 +6,7 @@ import { Card } from './ui/card.js';
 import { Button } from './ui/button.js';
 import SectionTitle from './SectionTitle.jsx';
 import { useT } from '../i18n.js';
-import { useCollection, db, doc, setDoc, deleteDoc, getDoc, updateDoc, collection } from '../firebase.js';
+import { useCollection, useDoc, db, doc, setDoc, deleteDoc, getDoc, updateDoc, collection } from '../firebase.js';
 import selectProfiles, { scoreProfiles } from '../selectProfiles.js';
 import PurchaseOverlay from './PurchaseOverlay.jsx';
 import MatchOverlay from './MatchOverlay.jsx';
@@ -16,6 +16,8 @@ import StoryLineOverlay from './StoryLineOverlay.jsx';
 export default function DailyDiscovery({ userId, onSelectProfile, ageRange, onOpenProfile }) {
   const profiles = useCollection('profiles');
   const t = useT();
+  const config = useDoc('config', 'app') || {};
+  const showLevels = config.showLevels !== false;
   const user = profiles.find(p => p.id === userId) || {};
   const hasActiveSub = prof =>
     prof.subscriptionExpires && new Date(prof.subscriptionExpires) > getCurrentDate();
@@ -147,7 +149,7 @@ export default function DailyDiscovery({ userId, onSelectProfile, ageRange, onOp
           className: 'p-4 bg-white rounded-lg cursor-pointer shadow-lg border border-gray-200 flex flex-col relative',
           onClick: () => onSelectProfile(p.id)
         },
-          React.createElement('span', { className:'absolute top-2 left-2 bg-pink-100 text-pink-600 text-xs font-semibold px-2 rounded' }, `Level ${stage}`),
+          showLevels && React.createElement('span', { className:'absolute top-2 left-2 bg-pink-100 text-pink-600 text-xs font-semibold px-2 rounded' }, `Level ${stage}`),
           React.createElement('span', { className:'absolute bottom-2 left-2 bg-yellow-100 text-yellow-600 text-xs font-semibold px-2 rounded' }, t('expiresIn').replace('{days}', daysLeft)),
           React.createElement(Heart, {
             className: `w-8 h-8 absolute top-2 right-2 ${likes.some(l => l.profileId === p.id) ? 'text-pink-500' : 'text-gray-400'}`,

--- a/src/components/ProfileEpisode.jsx
+++ b/src/components/ProfileEpisode.jsx
@@ -18,6 +18,8 @@ export default function ProfileEpisode({ userId, profileId, onBack }) {
   const viewer = useDoc('profiles', userId);
   const isOwnProfile = userId === profileId;
   const t = useT();
+  const config = useDoc('config', 'app') || {};
+  const showLevels = config.showLevels !== false;
   const profileHasSub = profile?.subscriptionExpires && new Date(profile.subscriptionExpires) > getCurrentDate();
   const expiryDays = profileHasSub ? 10 : 5;
   const [reflection, setReflection] = useState('');
@@ -141,7 +143,7 @@ export default function ProfileEpisode({ userId, profileId, onBack }) {
           className: `w-3 h-3 rounded-full ${i < stage ? 'bg-pink-500' : 'bg-gray-300'}`
         }))
       ),
-      React.createElement('p', { className:'text-left text-sm text-gray-600 mb-2' }, stepLabels[stage-1]),
+      showLevels && React.createElement('p', { className:'text-left text-sm text-gray-600 mb-2' }, stepLabels[stage-1]),
       stage === 1 && React.createElement('p', { className:'text-left text-sm mb-2 text-gray-700 font-medium' }, t('level2Intro').replace('{name}', profile.name || '')),
       // Help details are shown in a popup instead of directly on the page
       stage === 1 && React.createElement('p', {

--- a/src/seedData.js
+++ b/src/seedData.js
@@ -85,7 +85,10 @@ export default async function seedData() {
   ];
   await Promise.all(reflections.map(r => setDoc(doc(db,'reflections',r.id), r)));
 
-  await setDoc(doc(db,'config','app'),{premiumInvitesEnabled:true});
+  await setDoc(doc(db,'config','app'),{
+    premiumInvitesEnabled:true,
+    showLevels:true
+  });
 
   // Seed login credentials for the example users
   if (typeof window !== 'undefined') {


### PR DESCRIPTION
## Summary
- add `showLevels` flag in seed data
- add checkbox on admin page to toggle showing levels
- hide `Level` badges in Daily Discovery and Profile Episode when disabled

## Testing
- `npm install`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687de1590160832d8c03fa06e502ed55