### PR TITLE
Extend reveal animation duration

### DIFF
--- a/FEATURES.txt
+++ b/FEATURES.txt
@@ -11,6 +11,7 @@ Ability to upload or record video clips
 Ability to upload or record audio clips
 Video/audio duration limited to 10 seconds
 Animated countdown shown while recording audio or video
+Reveal animation highlights newly unlocked content
 Offline support via service worker caching
 PWA manifest for standalone installation
 

--- a/src/style.css
+++ b/src/style.css
@@ -119,7 +119,7 @@ button.btn-outline-red {
 
 /* Reveal animation for newly unlocked content */
 .reveal-animation {
-  animation: reveal-scale 0.5s ease-out;
+  animation: reveal-scale 1s ease-out;
 }
 
 @keyframes reveal-scale {


### PR DESCRIPTION
## Summary
- make reveal animation more visible by increasing duration
- document reveal animation in FEATURES list

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_687de24a7c78832d9fa0c43c83f556f6