### PR TITLE
Remove progress dots from profile episode

### DIFF
--- a/src/components/ProfileEpisode.jsx
+++ b/src/components/ProfileEpisode.jsx
@@ -144,12 +144,6 @@ export default function ProfileEpisode({ userId, profileId, onBack }) {
     React.createElement(Card, { className: 'p-6 m-4 shadow-xl bg-white/90' },
     React.createElement(Button, { className: 'mb-4 bg-pink-500 text-white', onClick: onBack }, 'Tilbage'),
     React.createElement('div', { className:'w-[300px] mx-auto text-left border border-gray-300 rounded p-4 mb-4' },
-      React.createElement('div', { className: 'flex justify-start gap-2 mb-2' },
-        stepLabels.map((_, i) => React.createElement('span', {
-          key: i,
-          className: `w-3 h-3 rounded-full ${i < stage ? 'bg-pink-500' : 'bg-gray-300'}`
-        }))
-      ),
       showLevels && React.createElement('p', { className:'text-left text-sm text-gray-600 mb-2' }, stepLabels[stage-1]),
       stage === 1 && React.createElement('p', { className:'text-left text-sm mb-2 text-gray-700 font-medium' }, t('level2Intro').replace('{name}', profile.name || '')),
       // Help details are shown in a popup instead of directly on the page


### PR DESCRIPTION
## Summary
- remove the three-dot progress indicator from the profile episode screen

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687de96acb90832daece7c474f98d872