### PR TITLE
Move help link next to back button

### DIFF
--- a/src/components/ProfileEpisode.jsx
+++ b/src/components/ProfileEpisode.jsx
@@ -142,7 +142,13 @@ export default function ProfileEpisode({ userId, profileId, onBack }) {
 
   return React.createElement(React.Fragment, null,
     React.createElement(Card, { className: 'p-6 m-4 shadow-xl bg-white/90' },
-    React.createElement(Button, { className: 'mb-4 bg-pink-500 text-white', onClick: onBack }, 'Tilbage'),
+    React.createElement('div', { className: 'flex justify-between items-start mb-4' },
+      React.createElement(Button, { className: 'bg-pink-500 text-white', onClick: onBack }, 'Tilbage'),
+      stage === 1 && React.createElement('p', {
+        className: 'text-xs text-blue-500 underline cursor-pointer',
+        onClick: () => setShowHelp(true)
+      }, 'Need help?')
+    ),
     React.createElement('div', { className:'w-[300px] mx-auto text-left border border-gray-300 rounded p-4 mb-4' },
       React.createElement('div', { className: 'flex justify-start gap-2 mb-2' },
         stepLabels.map((_, i) => React.createElement('span', {
@@ -153,10 +159,6 @@ export default function ProfileEpisode({ userId, profileId, onBack }) {
       showLevels && React.createElement('p', { className:'text-left text-sm text-gray-600 mb-2' }, stepLabels[stage-1]),
       stage === 1 && React.createElement('p', { className:'text-left text-sm mb-2 text-gray-700 font-medium' }, t('level2Intro').replace('{name}', profile.name || '')),
       // Help details are shown in a popup instead of directly on the page
-      stage === 1 && React.createElement('p', {
-        className:'text-right text-xs text-blue-500 underline cursor-pointer mt-1',
-        onClick: ()=>setShowHelp(true)
-      }, 'Need help?')
     ),
     React.createElement(SectionTitle, { title: `${profile.name || ''}, ${profile.birthday ? getAge(profile.birthday) : profile.age || ''}${profile.city ? ', ' + profile.city : ''}` }),
     React.createElement('p', { className:'text-left text-xs text-yellow-600 mb-2' }, t('expiresIn').replace('{days}', daysLeft)),


### PR DESCRIPTION
## Summary
- place help link to the top-right of the candidate profile card

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687de9b5d9f0832da3e8271317062bb2