### PR TITLE
Add haptic feedback on like and match

### DIFF
--- a/src/components/DailyDiscovery.jsx
+++ b/src/components/DailyDiscovery.jsx
@@ -12,6 +12,7 @@ import PurchaseOverlay from './PurchaseOverlay.jsx';
 import MatchOverlay from './MatchOverlay.jsx';
 import InfoOverlay from './InfoOverlay.jsx';
 import StoryLineOverlay from './StoryLineOverlay.jsx';
+import { triggerHaptic } from '../haptics.js';
 
 export default function DailyDiscovery({ userId, onSelectProfile, ageRange, onOpenProfile }) {
   const profiles = useCollection('profiles');
@@ -95,6 +96,7 @@ export default function DailyDiscovery({ userId, onSelectProfile, ageRange, onOp
       ]);
     } else {
       await setDoc(ref,{id:likeId,userId,profileId});
+      triggerHaptic();
       const otherLike = await getDoc(doc(db,'likes',`${profileId}-${userId}`));
       if(otherLike.exists()){
         const m1 = {
@@ -121,6 +123,7 @@ export default function DailyDiscovery({ userId, onSelectProfile, ageRange, onOp
         ]);
         const prof = profiles.find(p => p.id === profileId);
         if(prof) setMatchedProfile(prof);
+        triggerHaptic([100,50,100]);
       }
     }
   };

--- a/src/components/LikesScreen.jsx
+++ b/src/components/LikesScreen.jsx
@@ -9,6 +9,7 @@ import { Button } from './ui/button.js';
 import SectionTitle from './SectionTitle.jsx';
 import { useCollection, db, doc, setDoc, deleteDoc, getDoc } from '../firebase.js';
 import StoryLineOverlay from './StoryLineOverlay.jsx';
+import { triggerHaptic } from '../haptics.js';
 
 export default function LikesScreen({ userId, onSelectProfile }) {
   const profiles = useCollection('profiles');
@@ -38,6 +39,7 @@ export default function LikesScreen({ userId, onSelectProfile }) {
       ]);
     } else {
       await setDoc(ref,{id:likeId,userId,profileId});
+      triggerHaptic();
       const otherLike = await getDoc(doc(db,'likes',`${profileId}-${userId}`));
       if(otherLike.exists()){
         const m1 = {id:`${userId}-${profileId}`,userId,profileId,lastMessage:'',unreadByUser:false,unreadByProfile:false,newMatch:false};
@@ -48,6 +50,7 @@ export default function LikesScreen({ userId, onSelectProfile }) {
         ]);
         const prof = profiles.find(p => p.id === profileId);
         if(prof) setMatchedProfile(prof);
+        triggerHaptic([100,50,100]);
       }
     }
   };

--- a/src/components/MatchOverlay.jsx
+++ b/src/components/MatchOverlay.jsx
@@ -1,8 +1,12 @@
-import React from 'react';
+import React, { useEffect } from 'react';
 import { Card } from './ui/card.js';
 import { Button } from './ui/button.js';
+import { triggerHaptic } from '../haptics.js';
 
 export default function MatchOverlay({ name, onClose }) {
+  useEffect(() => {
+    triggerHaptic([100, 50, 100]);
+  }, []);
   return React.createElement('div', { className: 'fixed inset-0 z-50 bg-black/50 flex items-center justify-center' },
     React.createElement(Card, { className: 'bg-white p-6 rounded shadow-xl max-w-sm w-full text-center' },
       React.createElement('h2', { className: 'text-2xl font-bold text-pink-600 mb-4' }, 'Det er et match!'),

--- a/src/components/ProfileSettings.jsx
+++ b/src/components/ProfileSettings.jsx
@@ -18,6 +18,7 @@ import MatchOverlay from './MatchOverlay.jsx';
 import { languages, useT } from '../i18n.js';
 import { getInterestCategory } from '../interests.js';
 import { getAge } from '../utils.js';
+import { triggerHaptic } from '../haptics.js';
 
 export default function ProfileSettings({ userId, ageRange, onChangeAgeRange, publicView = false, onViewPublicProfile = () => {}, onOpenAbout = () => {}, onLogout = null, viewerId = userId, onBack, activeTask, taskTrigger = 0 }) {
   const [profile,setProfile]=useState(null);
@@ -327,6 +328,7 @@ export default function ProfileSettings({ userId, ageRange, onChangeAgeRange, pu
       ]);
     } else {
       await setDoc(ref,{id:likeId,userId:currentUserId,profileId:userId});
+      triggerHaptic();
       const otherLike = await getDoc(doc(db,'likes',`${userId}-${currentUserId}`));
       if(otherLike.exists()){
         const m1 = {
@@ -352,6 +354,7 @@ export default function ProfileSettings({ userId, ageRange, onChangeAgeRange, pu
           setDoc(doc(db,'matches',m2.id),m2)
         ]);
         setMatchedProfile(profile);
+        triggerHaptic([100,50,100]);
       }
     }
   };

--- a/src/haptics.js
+++ b/src/haptics.js
@@ -1,0 +1,9 @@
+export function triggerHaptic(pattern = [50]) {
+  try {
+    if (typeof navigator !== 'undefined' && typeof navigator.vibrate === 'function') {
+      navigator.vibrate(pattern);
+    }
+  } catch (err) {
+    // ignore errors, some browsers may not allow vibration
+  }
+}


### PR DESCRIPTION
## Summary
- add a small `haptics` util with a `triggerHaptic` helper
- vibrate when liking profiles and when a match occurs
- vibrate when match overlay is shown

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687dea988a48832d9ceebe813f40dac8