### PR TITLE
Fix birthday overlay closing

### DIFF
--- a/src/components/WelcomeScreen.jsx
+++ b/src/components/WelcomeScreen.jsx
@@ -169,7 +169,11 @@ export default function WelcomeScreen({ onLogin }) {
         onChange: e => setBirthday(e.target.value),
         onBlur: handleBirthdayBlur,
         autoFocus: true
-      })
+      }),
+      React.createElement(Button, {
+        className: 'mt-4 bg-pink-500 text-white px-4 py-2 rounded',
+        onClick: handleBirthdayBlur
+      }, 'Luk')
     ),
     showMissingFields && React.createElement(InfoOverlay, {
       title: t('missingFieldsTitle'),


### PR DESCRIPTION
## Summary
- add button to close birthday overlay after picking a date

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687dfd0671d4832daddb98d742536c64