### PR TITLE
Fix duplicate auth export

### DIFF
--- a/src/firebase.js
+++ b/src/firebase.js
@@ -235,7 +235,6 @@ export {
   listAll,
   deleteObject,
   onMessage,
-  auth,
   createUserWithEmailAndPassword,
   signInWithEmailAndPassword,
   sendPasswordResetEmail,


### PR DESCRIPTION
## Summary
- remove extra `auth` export from firebase helpers

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687dfe119070832da15883583428fc1b