### PR TITLE
Fix date selector overlay

### DIFF
--- a/src/__tests__/WelcomeScreen.test.js
+++ b/src/__tests__/WelcomeScreen.test.js
@@ -76,6 +76,8 @@ test('calls Firebase and onLogin when registration succeeds', async () => {
   await userEvent.type(screen.getByPlaceholderText('Fornavn'), 'Bob');
   await userEvent.type(screen.getByPlaceholderText('By'), 'Town');
   await userEvent.type(screen.getByPlaceholderText('F\u00f8dselsdag'), '1990-01-01');
+  // Close birthday selector overlay
+  await userEvent.click(screen.getByText('Luk'));
   await userEvent.type(screen.getByPlaceholderText('you@example.com'), 'bob@test.com');
   await userEvent.type(screen.getByPlaceholderText('username'), 'bob');
   await userEvent.type(screen.getByPlaceholderText('********'), 'secret');

--- a/src/components/WelcomeScreen.jsx
+++ b/src/components/WelcomeScreen.jsx
@@ -167,7 +167,6 @@ export default function WelcomeScreen({ onLogin }) {
         className: 'border p-2',
         value: birthday,
         onChange: e => setBirthday(e.target.value),
-        onBlur: handleBirthdayBlur,
         autoFocus: true
       }),
       React.createElement(Button, {


### PR DESCRIPTION
## Summary
- keep birthday date selector open on iOS by removing blur handler
- update tests to close birthday overlay

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687e0526a144832dac84c3f6fbbee8ae