### PR TITLE
Add char limit for reflection

### DIFF
--- a/src/components/ProfileEpisode.jsx
+++ b/src/components/ProfileEpisode.jsx
@@ -26,6 +26,7 @@ export default function ProfileEpisode({ userId, profileId, onBack }) {
   const [reaction, setReaction] = useState('');
   const [rating, setRating] = useState(0);
   const [showHelp, setShowHelp] = useState(false);
+  const MAX_REFLECTION_LEN = 30;
   const extendExpiry = (current) => {
     const base = current && new Date(current) > getCurrentDate()
       ? new Date(current) : getCurrentDate();
@@ -206,11 +207,14 @@ export default function ProfileEpisode({ userId, profileId, onBack }) {
       React.createElement('p', { className: 'text-sm text-gray-500 mb-2 text-center' }, 'Ratingen er privat'),
       React.createElement(Textarea, {
         value: reflection,
-        onChange: e => setReflection(e.target.value),
+        maxLength: MAX_REFLECTION_LEN,
+        onChange: e => setReflection(e.target.value.slice(0, MAX_REFLECTION_LEN)),
         onBlur: saveReflection,
         placeholder: t('episodeReflectionPrompt'),
-        className: 'mb-4'
-      })
+        className: 'mb-1'
+      }),
+      React.createElement('p', { className:'text-xs text-right text-gray-500 mb-3' },
+        t('charactersLeft').replace('{count}', MAX_REFLECTION_LEN - reflection.length))
     ),
     stage === 2 && React.createElement('div', { className:'mt-6 p-4 bg-gray-50 rounded-lg border border-gray-300' },
       progress?.reflection &&

--- a/src/i18n.js
+++ b/src/i18n.js
@@ -74,6 +74,7 @@ inviteAccepted:{ en:"Profile created", da:"Oprettet", sv:"Skapad", es:"Perfil cr
   episodeIntro:{ en:'Introduction', da:'Introduktion', sv:'Introduktion', es:'Introducción', fr:'Introduction', de:'Einführung' },
   episodeReflectionPrompt:{ en:'Write a short reflection...', da:'Skriv en kort refleksion...', sv:'Skriv en kort reflektion...', es:'Escribe una breve reflexión...', fr:'Écrivez une courte réflexion...', de:'Schreibe eine kurze Reflexion...' },
   episodeReactionPrompt:{ en:'Send a reaction', da:'Send en reaktion', sv:'Skicka en reaktion', es:'Envía una reacción', fr:'Envoyer une réaction', de:'Sende eine Reaktion' },
+  charactersLeft:{ en:'{count} characters left', da:'{count} tegn tilbage', sv:'{count} tecken kvar', es:'Quedan {count} caracteres', fr:'{count} caractères restants', de:'{count} Zeichen übrig' },
   episodeReturnTomorrow:{ en:'Watch another clip to continue', da:'Se et klip mere for at fortsætte', sv:'Titta på ett klipp till för att fortsätta', es:'Mira otro clip para continuar', fr:'Regardez un autre clip pour continuer', de:'Schau einen weiteren Clip, um fortzufahren' },
   episodeMatchPrompt:{ en:'Start conversation', da:'Start samtale', sv:'Starta samtal', es:'Iniciar conversación', fr:'Commencer la conversation', de:'Gespräch starten' },
   episodeStageReflection:{ en:'Reflection', da:'Refleksion', sv:'Reflektion', es:'Reflexión', fr:'Réflexion', de:'Reflexion' },


### PR DESCRIPTION
## Summary
- add translations for `charactersLeft`
- enforce 30 char limit on reflection textarea with counter

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687e079e0a84832da45a5d25f8542180