### PR TITLE
Fix Babel preset and duplicate export

### DIFF
--- a/babel.config.json
+++ b/babel.config.json
@@ -1,6 +1,6 @@
 {
   "presets": [
-    ["@babel/preset-env", { "targets": { "node": "current" } }],
+    ["@parcel/babel-preset-env", { "targets": { "node": "current" } }],
     ["@babel/preset-react", { "runtime": "automatic" }]
   ]
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -21,6 +21,7 @@
         "@babel/core": "^7.28.0",
         "@babel/preset-env": "^7.28.0",
         "@babel/preset-react": "^7.27.1",
+        "@parcel/babel-preset-env": "^2.15.4",
         "@parcel/packager-raw-url": "^2.15.4",
         "@parcel/transformer-webmanifest": "^2.15.4",
         "@testing-library/jest-dom": "^6.6.3",
@@ -3436,6 +3437,27 @@
       "license": "MIT",
       "dependencies": {
         "@noble/hashes": "^1.1.5"
+      }
+    },
+    "node_modules/@parcel/babel-preset-env": {
+      "version": "2.15.4",
+      "resolved": "https://registry.npmjs.org/@parcel/babel-preset-env/-/babel-preset-env-2.15.4.tgz",
+      "integrity": "sha512-EH474POtVOrYwXT8UpNfFYoMfdatdKMOqEiR+Y2xHZz/S5+pgOEo7hFr+atNteE5CZDUSvSmnar234VOPvYomw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/preset-env": "^7.22.14",
+        "semver": "^7.7.1"
+      },
+      "engines": {
+        "node": ">= 16.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.22.11"
       }
     },
     "node_modules/@parcel/bundler-default": {

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "@babel/core": "^7.28.0",
     "@babel/preset-env": "^7.28.0",
     "@babel/preset-react": "^7.27.1",
+    "@parcel/babel-preset-env": "^2.15.4",
     "@parcel/packager-raw-url": "^2.15.4",
     "@parcel/transformer-webmanifest": "^2.15.4",
     "@testing-library/jest-dom": "^6.6.3",

--- a/src/firebase.js
+++ b/src/firebase.js
@@ -265,5 +265,4 @@ export {
   signOut,
 };
 
-export { useAuth, isAdminUser, signOutUser };
 


### PR DESCRIPTION
## Summary
- replace `@babel/preset-env` with `@parcel/babel-preset-env`
- remove duplicate export from `firebase.js`
- include new dev dependency in `package.json`

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_687e0ed1c0d8832d818922329fcc499a