### PR TITLE
Enable user deletion in admin panel

### DIFF
--- a/src/__tests__/AdminScreen.test.js
+++ b/src/__tests__/AdminScreen.test.js
@@ -1,0 +1,43 @@
+import React from 'react';
+import '@testing-library/jest-dom';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import AdminScreen from '../components/AdminScreen.jsx';
+import { LanguageProvider } from '../i18n.js';
+import { deleteDoc } from '../firebase.js';
+
+jest.mock('../firebase.js', () => ({
+  db: {},
+  storage: {},
+  messaging: {},
+  collection: jest.fn(() => ({})),
+  getDocs: jest.fn(() => Promise.resolve({ docs: [] })),
+  deleteDoc: jest.fn(() => Promise.resolve()),
+  updateDoc: jest.fn(() => Promise.resolve()),
+  doc: jest.fn((db, col, id) => ({ col, id })),
+  getDoc: jest.fn(() => Promise.resolve({ exists: () => false })),
+  query: jest.fn(() => ({})),
+  where: jest.fn(() => ({})),
+  listAll: jest.fn(() => Promise.resolve({ items: [] })),
+  ref: jest.fn(() => ({})),
+  getDownloadURL: jest.fn(() => Promise.resolve('')),
+  deleteObject: jest.fn(() => Promise.resolve()),
+  setExtendedLogging: jest.fn(),
+  isExtendedLogging: jest.fn(() => false),
+  useDoc: jest.fn(() => ({}))
+}));
+
+describe('AdminScreen delete user', () => {
+  test('clicking delete removes user', async () => {
+    window.confirm = jest.fn(() => true);
+    render(
+      <LanguageProvider value={{ lang: 'en', setLang: () => {} }}>
+        <AdminScreen profiles={[{ id: 'u1', name: 'User' }]} userId="u1" onSwitchProfile={() => {}} />
+      </LanguageProvider>
+    );
+    await userEvent.click(screen.getByRole('button', { name: 'Delete user' }));
+    expect(deleteDoc).toHaveBeenCalled();
+    const called = deleteDoc.mock.calls.some(c => c[0]?.col === 'profiles' && c[0]?.id === 'u1');
+    expect(called).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary
- allow admins to remove users from Firebase
- add Delete user control in AdminScreen
- test deleting a user from the admin interface

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687e1565e778832da78b62b5a3700620