### PR TITLE
Fix duplicate deleteAccount export

### DIFF
--- a/src/firebase.js
+++ b/src/firebase.js
@@ -304,7 +304,6 @@ export {
   sendPasswordResetEmail,
   onAuthStateChanged,
   signOut,
-  deleteAccount,
 };
 
 


### PR DESCRIPTION
## Summary
- remove redundant `deleteAccount` entry from firebase re-exports

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687e1f3c543c832daf871a90c44de451