### PR TITLE
Add firebase auth connectivity test

### DIFF
--- a/src/__tests__/firebaseAuth.test.js
+++ b/src/__tests__/firebaseAuth.test.js
@@ -1,0 +1,28 @@
+const admin = require('firebase-admin');
+const fs = require('fs');
+
+const hasCreds = !!process.env.FIREBASE_SERVICE_ACCOUNT_JSON || !!process.env.GOOGLE_APPLICATION_CREDENTIALS;
+
+beforeAll(() => {
+  if (!hasCreds) return;
+  if (admin.apps.length) return;
+
+  let serviceAccount = null;
+  if (process.env.FIREBASE_SERVICE_ACCOUNT_JSON) {
+    try {
+      serviceAccount = JSON.parse(process.env.FIREBASE_SERVICE_ACCOUNT_JSON);
+    } catch {}
+  } else if (process.env.GOOGLE_APPLICATION_CREDENTIALS && fs.existsSync(process.env.GOOGLE_APPLICATION_CREDENTIALS)) {
+    serviceAccount = require(process.env.GOOGLE_APPLICATION_CREDENTIALS);
+  }
+
+  if (serviceAccount) {
+    admin.initializeApp({ credential: admin.credential.cert(serviceAccount) });
+  }
+});
+
+(hasCreds ? test : test.skip)('Firebase auth is accessible', async () => {
+  const list = await admin.auth().listUsers(1);
+  expect(list).toBeDefined();
+  expect(Array.isArray(list.users)).toBe(true);
+});


### PR DESCRIPTION
## Summary
- add a Jest test that attempts to list users via Firebase Auth
- the test is skipped if no service account credentials are provided

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687e225f641c832d843d03996e645204