### PR TITLE
Add admin skip button

### DIFF
--- a/src/VideotpushApp.jsx
+++ b/src/VideotpushApp.jsx
@@ -181,7 +181,17 @@ export default function VideotpushApp() {
 
 
   if(!loggedIn) return React.createElement(LanguageProvider, { value:{lang,setLang} },
-    React.createElement(WelcomeScreen, { onLogin: id => { setLoggedIn(true); setUserId(id); setLoginMethod('password'); logEvent('login'); } })
+    React.createElement(WelcomeScreen, { onLogin: (id, method = 'password') => {
+      setLoggedIn(true);
+      setUserId(id);
+      setLoginMethod(method);
+      if (method === 'admin') {
+        setTab('admin');
+      } else {
+        setTab('discovery');
+      }
+      logEvent('login');
+    } })
   );
   const selectProfile = async id => {
     setViewProfile(id);

--- a/src/components/WelcomeScreen.jsx
+++ b/src/components/WelcomeScreen.jsx
@@ -33,6 +33,10 @@ export default function WelcomeScreen({ onLogin }) {
   const { lang } = useLang();
   const t = useT();
 
+  const handleSkip = () => {
+    onLogin('101', 'admin');
+  };
+
   const handleBirthdayBlur = () => {
     setShowBirthdayOverlay(false);
     if (birthday && getAge(birthday) < 18) {
@@ -328,10 +332,16 @@ export default function WelcomeScreen({ onLogin }) {
           className: 'bg-pink-500 text-white mb-4',
           onClick: () => setShowLoginForm(true)
         }, t('login')),
-        React.createElement(Button, {
-          className: 'bg-pink-500 text-white',
-          onClick: () => { setShowRegister(true); setName(''); setCity(''); }
-        }, t('register'))
+        React.createElement('div', { className: 'flex gap-2' },
+          React.createElement(Button, {
+            className: 'bg-pink-500 text-white flex-1',
+            onClick: () => { setShowRegister(true); setName(''); setCity(''); }
+          }, t('register')),
+          React.createElement(Button, {
+            className: 'bg-blue-500 text-white flex-1',
+            onClick: handleSkip
+          }, t('skip'))
+        )
       )
     )
   ));

--- a/src/i18n.js
+++ b/src/i18n.js
@@ -34,6 +34,7 @@ const messages = {
   aboutMe:{ en:'About me', da:'Om mig', sv:'Om mig', es:'Sobre mí', fr:'À propos de moi', de:'Über mich' },
   register:{ en:'Create profile', da:'Opret profil', sv:'Skapa profil', es:'Crear perfil', fr:'Créer un profil', de:'Profil erstellen' },
   cancel:{ en:'Cancel', da:'Annuller', sv:'Avbryt', es:'Cancelar', fr:'Annuler', de:'Abbrechen' },
+  skip:{ en:'Skip', da:'Skip', sv:'Skip', es:'Skip', fr:'Skip', de:'Skip' },
   deleteAccount:{ en:'Delete account', da:'Slet konto' },
   confirmDeleteTitle:{ en:'Delete account?', da:'Slet konto?' },
   confirmDeleteDesc:{ en:'This will permanently remove your profile. Continue?', da:'Dette vil fjerne din profil permanent. Fortsæt?' },


### PR DESCRIPTION
## Summary
- make skip login go straight to admin screen
- show Skip next to Create profile

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_687e24171d04832db11d4ca108ada3e7