### PR TITLE
Update level progression

### DIFF
--- a/src/components/ProfileEpisode.jsx
+++ b/src/components/ProfileEpisode.jsx
@@ -57,6 +57,7 @@ export default function ProfileEpisode({ userId, profileId, onBack }) {
         profileId,
         stage: 1,
         seenStage: 0,
+        lastUpdated: today,
         expiresAt
       }, { merge: true }).catch(err => console.error('Failed to init progress', err));
     }
@@ -125,7 +126,6 @@ export default function ProfileEpisode({ userId, profileId, onBack }) {
         id: progressId,
         userId,
         profileId,
-        stage: stage + 1,
         lastUpdated: today,
         expiresAt: extendExpiry(progress?.expiresAt)
       }, { merge: true });


### PR DESCRIPTION
## Summary
- init level progress with `lastUpdated`
- progress level only when visiting Daily Clips a new day
- keep profile episode progress without incrementing level on clip end

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687f2b2dbac4832d8079b1312ed31d0c