### PR TITLE
Ensure admin day shift applies to subscription dates

### DIFF
--- a/src/components/LikesScreen.jsx
+++ b/src/components/LikesScreen.jsx
@@ -1,5 +1,5 @@
 import React, { useState } from 'react';
-import { getAge } from '../utils.js';
+import { getAge, getCurrentDate } from '../utils.js';
 import { User as UserIcon, PlayCircle, Heart } from 'lucide-react';
 import VideoOverlay from './VideoOverlay.jsx';
 import MatchOverlay from './MatchOverlay.jsx';
@@ -20,7 +20,9 @@ export default function LikesScreen({ userId, onSelectProfile }) {
     likes.some(l => l.userId === p.id) && !matchedIds.includes(p.id)
   );
   const currentUser = profiles.find(p => p.id === userId) || {};
-  const hasSubscription = currentUser.subscriptionExpires && new Date(currentUser.subscriptionExpires) > new Date();
+  const hasSubscription =
+    currentUser.subscriptionExpires &&
+    new Date(currentUser.subscriptionExpires) > getCurrentDate();
 
   const [activeVideo, setActiveVideo] = useState(null);
   const [matchedProfile, setMatchedProfile] = useState(null);
@@ -57,7 +59,7 @@ export default function LikesScreen({ userId, onSelectProfile }) {
 
   const [showPurchase, setShowPurchase] = useState(false);
   const handlePurchase = async () => {
-    const now = new Date();
+    const now = getCurrentDate();
     const current = currentUser.subscriptionExpires ? new Date(currentUser.subscriptionExpires) : now;
     const base = current > now ? current : now;
     const expiry = new Date(base);

--- a/src/components/ProfileSettings.jsx
+++ b/src/components/ProfileSettings.jsx
@@ -18,7 +18,7 @@ import SnapVideoRecorder from "./SnapVideoRecorder.jsx";
 import MatchOverlay from './MatchOverlay.jsx';
 import { languages, useT } from '../i18n.js';
 import { getInterestCategory } from '../interests.js';
-import { getAge } from '../utils.js';
+import { getAge, getCurrentDate } from '../utils.js';
 import { triggerHaptic } from '../haptics.js';
 
 export default function ProfileSettings({ userId, ageRange, onChangeAgeRange, publicView = false, onViewPublicProfile = () => {}, onOpenAbout = () => {}, onLogout = null, viewerId = userId, onBack, activeTask, taskTrigger = 0 }) {
@@ -59,7 +59,7 @@ export default function ProfileSettings({ userId, ageRange, onChangeAgeRange, pu
   const stage = isOwnProfile ? 3 : (progress?.stage || 1);
 
   const handlePurchase = async () => {
-    const now = new Date();
+    const now = getCurrentDate();
     const current = profile.subscriptionExpires ? new Date(profile.subscriptionExpires) : now;
     const base = current > now ? current : now;
     const expiry = new Date(base);
@@ -110,7 +110,9 @@ export default function ProfileSettings({ userId, ageRange, onChangeAgeRange, pu
     )
   );
 
-  const subscriptionActive = profile.subscriptionExpires && new Date(profile.subscriptionExpires) > new Date();
+  const subscriptionActive =
+    profile.subscriptionExpires &&
+    new Date(profile.subscriptionExpires) > getCurrentDate();
 
   const maxAudios = (profile.audioClips || []).length >= 3;
 

--- a/src/components/WelcomeScreen.jsx
+++ b/src/components/WelcomeScreen.jsx
@@ -7,7 +7,7 @@ import ForgotPasswordOverlay from './ForgotPasswordOverlay.jsx';
 import { UserPlus, LogIn } from 'lucide-react';
 import { useLang, useT } from '../i18n.js';
 import { auth, db, doc, setDoc, updateDoc, increment, getDoc, createUserWithEmailAndPassword, signInWithEmailAndPassword } from '../firebase.js';
-import { getAge } from '../utils.js';
+import { getAge, getCurrentDate } from '../utils.js';
 
 export default function WelcomeScreen({ onLogin }) {
   const [showRegister, setShowRegister] = useState(false);
@@ -126,7 +126,7 @@ export default function WelcomeScreen({ onLogin }) {
       interests: []
     };
     if (giftFrom && inviteValid) {
-      const now = new Date();
+      const now = getCurrentDate();
       const expiry = new Date(now);
       expiry.setMonth(expiry.getMonth() + 3);
       profile.subscriptionActive = true;

--- a/src/selectProfiles.js
+++ b/src/selectProfiles.js
@@ -1,6 +1,6 @@
 // Filtering helper kept separate so it can also run in a Netlify
 // Function. Netlify Functions support both JavaScript and TypeScript.
-import { getAge, getTodayStr } from './utils.js';
+import { getAge, getTodayStr, getCurrentDate } from './utils.js';
 import { getInterestCategory } from './interests.js';
 
 // Calculate a detailed match score for a single profile. Missing data is handled
@@ -130,7 +130,8 @@ export function scoreProfiles(user, profiles, ageRange) {
 
 export default function selectProfiles(user, profiles, ageRange) {
   const hasSubscription =
-    user.subscriptionExpires && new Date(user.subscriptionExpires) > new Date();
+    user.subscriptionExpires &&
+    new Date(user.subscriptionExpires) > getCurrentDate();
   const today = getTodayStr();
   const extra = user.extraClipsDate === today ? 3 : 0;
   const limit = (hasSubscription ? 6 : 3) + extra;


### PR DESCRIPTION
## Summary
- use `getCurrentDate` for subscription checks and purchases
- adjust premium gift logic to honor day offset

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687f4c1a64dc832dba819d450e259635