### PR TITLE
Handle rating data in daily reflections

### DIFF
--- a/src/components/DailyCheckIn.jsx
+++ b/src/components/DailyCheckIn.jsx
@@ -67,7 +67,10 @@ export default function DailyCheckIn({ userId }) {
     React.createElement('ul', { className: 'list-disc list-inside mb-4' },
       monthRefs.map(r => {
         const d = parseInt(r.date.split('-')[2],10);
-        return React.createElement('li', { key: r.id }, `${d}: ${r.text}`);
+        let info = `${d}: ${r.text}`;
+        if(r.profileName) info += ` \u2013 ${r.profileName}`;
+        if(r.rating) info += ` (${r.rating}\u2605)`;
+        return React.createElement('li', { key: r.id }, info);
       })
     ),
     React.createElement(Textarea, {

--- a/src/components/ProfileEpisode.jsx
+++ b/src/components/ProfileEpisode.jsx
@@ -104,7 +104,9 @@ export default function ProfileEpisode({ userId, profileId, onBack }) {
         id: refId,
         userId,
         date: today,
-        text
+        text,
+        rating: givenRating,
+        profileName: profile?.name
       }, { merge: true });
     }
   };


### PR DESCRIPTION
## Summary
- attach rating and profile name when saving reflections from profile episodes
- display that rating info on the daily reflection page

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687f62e88e28832dbd08e6dca3d83cde