### PR TITLE
Fix reflection ordering

### DIFF
--- a/src/components/DailyCheckIn.jsx
+++ b/src/components/DailyCheckIn.jsx
@@ -18,7 +18,9 @@ export default function DailyCheckIn({ userId }) {
   const daysInMonth=new Date(month.getFullYear(),month.getMonth()+1,0).getDate();
   const days=Array.from({length:daysInMonth},(_,i)=>i+1);
   const monthStr = month.toISOString().slice(0,7);
-  const monthRefs = refs.filter(r => (r.date || '').startsWith(monthStr));
+  const monthRefs = refs
+    .filter(r => (r.date || '').startsWith(monthStr))
+    .sort((a, b) => (b.date || '').localeCompare(a.date || ''));
   const [text,setText]=useState('');
 
   const save = async () => {


### PR DESCRIPTION
## Summary
- sort daily reflections by date so newest entries appear first

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687f9f6c70c0832dbe1cc649250eea00