### PR TITLE
Add reveal animation test page

### DIFF
--- a/src/VideotpushApp.jsx
+++ b/src/VideotpushApp.jsx
@@ -17,6 +17,7 @@ import ActiveCallsScreen from './components/ActiveCallsScreen.jsx';
 import ReportedContentScreen from './components/ReportedContentScreen.jsx';
 import AboutScreen from './components/AboutScreen.jsx';
 import FunctionTestScreen from './components/FunctionTestScreen.jsx';
+import RevealTestScreen from './components/RevealTestScreen.jsx';
 import TextLogScreen from './components/TextLogScreen.jsx';
 import TrackUserScreen from './components/TrackUserScreen.jsx';
 import ServerLogScreen from './components/ServerLogScreen.jsx';
@@ -272,7 +273,7 @@ export default function VideotpushApp() {
             taskTrigger: taskClicks
           }),
           tab==='likes' && React.createElement(LikesScreen, { userId, onBack: ()=>setTab('discovery'), onSelectProfile: selectProfile }),
-          tab==='admin' && React.createElement(AdminScreen, { onOpenStats: ()=>setTab('stats'), onOpenBugReports: ()=>setTab('bugs'), onOpenMatchLog: ()=>setTab('matchlog'), onOpenScoreLog: ()=>setTab('scorelog'), onOpenReports: ()=>setTab('reports'), onOpenCallLog: ()=>setTab('calllog'), onOpenFunctionTest: ()=>setTab('functiontest'), onOpenTextLog: ()=>setTab('textlog'), onOpenUserLog: ()=>setTab('trackuser'), onOpenServerLog: ()=>setTab('serverlog'), onOpenRecentLogins: ()=>setTab('recentlogins'), profiles, userId, onSwitchProfile: id=>{ setUserId(id); setLoginMethod('admin'); }, onSaveUserLogout: saveUserAndLogout }),
+          tab==='admin' && React.createElement(AdminScreen, { onOpenStats: ()=>setTab('stats'), onOpenBugReports: ()=>setTab('bugs'), onOpenMatchLog: ()=>setTab('matchlog'), onOpenScoreLog: ()=>setTab('scorelog'), onOpenReports: ()=>setTab('reports'), onOpenCallLog: ()=>setTab('calllog'), onOpenFunctionTest: ()=>setTab('functiontest'), onOpenRevealTest: ()=>setTab('revealtest'), onOpenTextLog: ()=>setTab('textlog'), onOpenUserLog: ()=>setTab('trackuser'), onOpenServerLog: ()=>setTab('serverlog'), onOpenRecentLogins: ()=>setTab('recentlogins'), profiles, userId, onSwitchProfile: id=>{ setUserId(id); setLoginMethod('admin'); }, onSaveUserLogout: saveUserAndLogout }),
           tab==='stats' && React.createElement(StatsScreen, { onBack: ()=>setTab('admin') }),
           tab==='matchlog' && React.createElement(MatchLogScreen, { onBack: ()=>setTab('admin') }),
           tab==='scorelog' && React.createElement(ScoreLogScreen, { onBack: ()=>setTab('admin') }),
@@ -280,6 +281,7 @@ export default function VideotpushApp() {
           tab==='reports' && React.createElement(ReportedContentScreen, { onBack: ()=>setTab('admin') }),
           tab==='bugs' && React.createElement(BugReportsScreen, { onBack: ()=>setTab('admin') }),
           tab==='functiontest' && React.createElement(FunctionTestScreen, { onBack: ()=>setTab('admin') }),
+          tab==='revealtest' && React.createElement(RevealTestScreen, { onBack: ()=>setTab('admin') }),
           tab==='textlog' && React.createElement(TextLogScreen, { onBack: ()=>setTab('admin') }),
           tab==='trackuser' && React.createElement(TrackUserScreen, { onBack: ()=>setTab('admin'), profiles }),
           tab==='serverlog' && React.createElement(ServerLogScreen, { onBack: ()=>setTab('admin') }),

--- a/src/__tests__/AdminScreen.test.js
+++ b/src/__tests__/AdminScreen.test.js
@@ -32,7 +32,7 @@ describe('AdminScreen delete user', () => {
     window.confirm = jest.fn(() => true);
     render(
       <LanguageProvider value={{ lang: 'en', setLang: () => {} }}>
-        <AdminScreen profiles={[{ id: 'u1', name: 'User' }]} userId="u1" onSwitchProfile={() => {}} />
+        <AdminScreen profiles={[{ id: 'u1', name: 'User' }]} userId="u1" onSwitchProfile={() => {}} onOpenRevealTest={() => {}} />
       </LanguageProvider>
     );
     await userEvent.click(screen.getByRole('button', { name: 'Delete user' }));

--- a/src/components/AdminScreen.jsx
+++ b/src/components/AdminScreen.jsx
@@ -10,7 +10,7 @@ import { getToken } from 'firebase/messaging';
 import { fcmReg } from '../swRegistration.js';
 
 
-export default function AdminScreen({ onOpenStats, onOpenBugReports, onOpenMatchLog, onOpenScoreLog, onOpenReports, onOpenCallLog, onOpenFunctionTest, onOpenTextLog, onOpenUserLog, onOpenServerLog, onOpenRecentLogins, profiles = [], userId, onSwitchProfile, onSaveUserLogout }) {
+export default function AdminScreen({ onOpenStats, onOpenBugReports, onOpenMatchLog, onOpenScoreLog, onOpenReports, onOpenCallLog, onOpenFunctionTest, onOpenRevealTest, onOpenTextLog, onOpenUserLog, onOpenServerLog, onOpenRecentLogins, profiles = [], userId, onSwitchProfile, onSaveUserLogout }) {
 
   const { lang, setLang } = useLang();
   const t = useT();
@@ -319,6 +319,9 @@ export default function AdminScreen({ onOpenStats, onOpenBugReports, onOpenMatch
     React.createElement(Button, { className: 'mt-2 bg-blue-500 text-white px-4 py-2 rounded', onClick: onOpenCallLog }, 'Se aktive opkald'),
 
     React.createElement('h3', { className: 'text-xl font-semibold mb-2 mt-4 text-blue-600' }, 'Funktionstest'),
-    React.createElement(Button, { className: 'mt-2 bg-blue-500 text-white px-4 py-2 rounded', onClick: onOpenFunctionTest }, 'Åbn funktionstest')
+    React.createElement(Button, { className: 'mt-2 bg-blue-500 text-white px-4 py-2 rounded', onClick: onOpenFunctionTest }, 'Åbn funktionstest'),
+
+    React.createElement('h3', { className: 'text-xl font-semibold mb-2 mt-4 text-blue-600' }, 'Reveal test'),
+    React.createElement(Button, { className: 'mt-2 bg-blue-500 text-white px-4 py-2 rounded', onClick: onOpenRevealTest }, 'Åbn reveal test')
   );
 }

--- a/src/components/RevealTestScreen.jsx
+++ b/src/components/RevealTestScreen.jsx
@@ -1,0 +1,45 @@
+import React, { useState } from 'react';
+import { Card } from './ui/card.js';
+import { Button } from './ui/button.js';
+import SectionTitle from './SectionTitle.jsx';
+import VideoPreview from './VideoPreview.jsx';
+import { useDoc } from '../firebase.js';
+
+export default function RevealTestScreen({ onBack }) {
+  const profile = useDoc('profiles', '101');
+  const [showReveal, setShowReveal] = useState(false);
+
+  const runTest = () => {
+    setShowReveal(true);
+    const audio = new Audio('/reveal.mp3');
+    audio.play().catch(err => console.error('Failed to play reveal sound', err));
+    setTimeout(() => setShowReveal(false), 1000);
+  };
+
+  if (!profile) {
+    return React.createElement(Card, { className: 'p-6 m-4 shadow-xl bg-white/90' },
+      React.createElement(SectionTitle, { title: 'Reveal test', colorClass: 'text-blue-600', action: React.createElement(Button, { className: 'bg-blue-500 text-white px-4 py-2 rounded', onClick: onBack }, 'Tilbage') }),
+      React.createElement('p', null, 'Indl\u00e6ser...')
+    );
+  }
+
+  const videoURL = profile.videoClips?.[0]?.url || profile.videoClips?.[0] || '';
+  const audioURL = profile.audioClips?.[0]?.url || profile.audioClips?.[0] || '';
+
+  return React.createElement(Card, { className: 'p-6 m-4 shadow-xl bg-white/90' },
+    React.createElement(SectionTitle, { title: 'Reveal test', colorClass: 'text-blue-600', action: React.createElement(Button, { className: 'bg-blue-500 text-white px-4 py-2 rounded', onClick: onBack }, 'Tilbage') }),
+    videoURL && React.createElement('div', { className: `mb-4 ${showReveal ? 'reveal-animation' : ''}` },
+      React.createElement(VideoPreview, { src: videoURL })
+    ),
+    audioURL && React.createElement('div', { className: `mb-4 ${showReveal ? 'reveal-animation' : ''}` },
+      React.createElement('audio', {
+        src: audioURL,
+        controls: true,
+        controlsList: 'nodownload noplaybackrate',
+        onRateChange: e => { e.currentTarget.playbackRate = 1; },
+        className: 'w-full'
+      })
+    ),
+    React.createElement(Button, { className: 'bg-blue-500 text-white px-4 py-2 rounded', onClick: runTest }, 'Test reveal')
+  );
+}


### PR DESCRIPTION
## Summary
- create **RevealTestScreen** component that plays the reveal animation for user 101
- hook RevealTestScreen into admin menu and navigation
- update AdminScreen unit test

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_688098523c20832d95f0d36f4529dc4d