### PR TITLE
Show overlay during reveal test

### DIFF
--- a/src/components/RevealTestScreen.jsx
+++ b/src/components/RevealTestScreen.jsx
@@ -4,10 +4,12 @@ import { Button } from './ui/button.js';
 import SectionTitle from './SectionTitle.jsx';
 import VideoPreview from './VideoPreview.jsx';
 import { useDoc } from '../firebase.js';
+import { useT } from '../i18n.js';
 
 export default function RevealTestScreen({ onBack }) {
   const profile = useDoc('profiles', '101');
   const [showReveal, setShowReveal] = useState(false);
+  const t = useT();
 
   const runTest = () => {
     setShowReveal(true);
@@ -26,19 +28,25 @@ export default function RevealTestScreen({ onBack }) {
   const videoURL = profile.videoClips?.[0]?.url || profile.videoClips?.[0] || '';
   const audioURL = profile.audioClips?.[0]?.url || profile.audioClips?.[0] || '';
 
+  const overlay = React.createElement('div', { className:'absolute inset-0 bg-black/80 flex items-center justify-center rounded text-center px-2' },
+    React.createElement('span', { className:'text-pink-500 text-xs font-semibold' }, t('dayLabel').replace('{day}', 1))
+  );
+
   return React.createElement(Card, { className: 'p-6 m-4 shadow-xl bg-white/90' },
     React.createElement(SectionTitle, { title: 'Reveal test', colorClass: 'text-blue-600', action: React.createElement(Button, { className: 'bg-blue-500 text-white px-4 py-2 rounded', onClick: onBack }, 'Tilbage') }),
-    videoURL && React.createElement('div', { className: `mb-4 ${showReveal ? 'reveal-animation' : ''}` },
-      React.createElement(VideoPreview, { src: videoURL })
+    videoURL && React.createElement('div', { className: `mb-4 relative ${showReveal ? 'reveal-animation' : ''}` },
+      React.createElement(VideoPreview, { src: videoURL }),
+      !showReveal && overlay
     ),
-    audioURL && React.createElement('div', { className: `mb-4 ${showReveal ? 'reveal-animation' : ''}` },
+    audioURL && React.createElement('div', { className: `mb-4 relative ${showReveal ? 'reveal-animation' : ''}` },
       React.createElement('audio', {
         src: audioURL,
         controls: true,
         controlsList: 'nodownload noplaybackrate',
         onRateChange: e => { e.currentTarget.playbackRate = 1; },
         className: 'w-full'
-      })
+      }),
+      !showReveal && overlay
     ),
     React.createElement(Button, { className: 'bg-blue-500 text-white px-4 py-2 rounded', onClick: runTest }, 'Test reveal')
   );


### PR DESCRIPTION
## Summary
- display overlay used in episode reveal on the reveal test screen
- include translation hook for overlay label

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6880b83c84bc832d8838e5fa0a13c4da