### PR TITLE
Adjust reveal animation

### DIFF
--- a/src/components/ProfileEpisode.jsx
+++ b/src/components/ProfileEpisode.jsx
@@ -205,11 +205,11 @@ export default function ProfileEpisode({ userId, profileId, onBack }) {
         const clip = (profile.videoClips || [])[i];
         const url = clip && clip.url ? clip.url : clip;
         const locked = i >= stage;
-        const classes = `w-[30%] flex flex-col items-center justify-end min-h-[160px] relative ${locked ? 'pointer-events-none' : ''} ${showReveal && i === stage - 1 ? 'reveal-animation' : ''}`;
+        const classes = `w-[30%] flex flex-col items-center justify-end min-h-[160px] relative ${locked ? 'pointer-events-none' : ''}`;
         return React.createElement('div', { key: i, className: classes },
           url && React.createElement(VideoPreview, { src: url, onEnded: () => handleClipEnd(i) }),
           !locked && i === stage - 1 && React.createElement('span', { className:'absolute top-1 right-1 bg-green-100 text-green-600 text-xs font-semibold px-1 rounded' }, t('dayLabel').replace('{day}', i + 1)),
-          locked && React.createElement('div', { className:'absolute inset-0 bg-black/80 flex items-center justify-center rounded text-center px-2' },
+          (locked || (showReveal && i === stage - 1)) && React.createElement('div', { className:`absolute inset-0 bg-black/80 flex items-center justify-center rounded text-center px-2 ${showReveal && i === stage - 1 ? 'reveal-animation' : ''}` },
             React.createElement('span', { className:'text-pink-500 text-xs font-semibold' }, t('dayLabel').replace('{day}', i + 1))
           )
         );
@@ -220,11 +220,11 @@ export default function ProfileEpisode({ userId, profileId, onBack }) {
       (profile.audioClips || []).slice(0,3).map((clip, i) => {
         const url = clip && clip.url ? clip.url : clip;
         const locked = i >= stage;
-        const aClasses = `flex items-center relative ${locked ? 'pointer-events-none' : ''} ${showReveal && i === stage - 1 ? 'reveal-animation' : ''}`;
+        const aClasses = `flex items-center relative ${locked ? 'pointer-events-none' : ''}`;
         return React.createElement('div', { key: i, className: aClasses },
           React.createElement('audio', { src: url, controls: true, controlsList: 'nodownload noplaybackrate', onRateChange:e=>{e.currentTarget.playbackRate=1;}, className: 'flex-1 mr-2' }),
           !locked && i === stage - 1 && React.createElement('span', { className:'absolute top-1 right-1 bg-green-100 text-green-600 text-xs font-semibold px-1 rounded' }, t('dayLabel').replace('{day}', i + 1)),
-          locked && React.createElement('div', { className:'absolute inset-0 bg-black/80 flex items-center justify-center rounded text-center px-2' },
+          (locked || (showReveal && i === stage - 1)) && React.createElement('div', { className:`absolute inset-0 bg-black/80 flex items-center justify-center rounded text-center px-2 ${showReveal && i === stage - 1 ? 'reveal-animation' : ''}` },
             React.createElement('span', { className:'text-pink-500 text-xs font-semibold' }, t('dayLabel').replace('{day}', i + 1))
           )
         );

--- a/src/components/RevealTestScreen.jsx
+++ b/src/components/RevealTestScreen.jsx
@@ -28,17 +28,17 @@ export default function RevealTestScreen({ onBack }) {
   const videoURL = profile.videoClips?.[0]?.url || profile.videoClips?.[0] || '';
   const audioURL = profile.audioClips?.[0]?.url || profile.audioClips?.[0] || '';
 
-  const overlay = React.createElement('div', { className:'absolute inset-0 bg-black/80 flex items-center justify-center rounded text-center px-2' },
+  const overlay = React.createElement('div', { className:`absolute inset-0 bg-black/80 flex items-center justify-center rounded text-center px-2 ${showReveal ? 'reveal-animation pointer-events-none' : ''}` },
     React.createElement('span', { className:'text-pink-500 text-xs font-semibold' }, t('dayLabel').replace('{day}', 1))
   );
 
   return React.createElement(Card, { className: 'p-6 m-4 shadow-xl bg-white/90' },
     React.createElement(SectionTitle, { title: 'Reveal test', colorClass: 'text-blue-600', action: React.createElement(Button, { className: 'bg-blue-500 text-white px-4 py-2 rounded', onClick: onBack }, 'Tilbage') }),
-    videoURL && React.createElement('div', { className: `mb-4 relative ${showReveal ? 'reveal-animation' : ''}` },
+    videoURL && React.createElement('div', { className: 'mb-4 relative' },
       React.createElement(VideoPreview, { src: videoURL }),
-      !showReveal && overlay
+      overlay
     ),
-    audioURL && React.createElement('div', { className: `mb-4 relative ${showReveal ? 'reveal-animation' : ''}` },
+    audioURL && React.createElement('div', { className: 'mb-4 relative' },
       React.createElement('audio', {
         src: audioURL,
         controls: true,
@@ -46,7 +46,7 @@ export default function RevealTestScreen({ onBack }) {
         onRateChange: e => { e.currentTarget.playbackRate = 1; },
         className: 'w-full'
       }),
-      !showReveal && overlay
+      overlay
     ),
     React.createElement(Button, { className: 'bg-blue-500 text-white px-4 py-2 rounded', onClick: runTest }, 'Test reveal')
   );

--- a/src/style.css
+++ b/src/style.css
@@ -119,10 +119,10 @@ button.btn-outline-red {
 
 /* Reveal animation for newly unlocked content */
 .reveal-animation {
-  animation: reveal-scale 1s ease-out;
+  animation: overlay-fade 1s ease-out forwards;
 }
 
-@keyframes reveal-scale {
-  from { opacity: 0; transform: scale(0.8); }
-  to { opacity: 1; transform: scale(1); }
+@keyframes overlay-fade {
+  from { opacity: 1; }
+  to { opacity: 0; }
 }


### PR DESCRIPTION
## Summary
- fade overlay on reveal instead of scaling video
- update reveal test screen overlay behavior

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6880be0cba9c832d96b5dcf2970da120