### PR TITLE
Show saved reflection on same day

### DIFF
--- a/src/components/ProfileEpisode.jsx
+++ b/src/components/ProfileEpisode.jsx
@@ -39,7 +39,10 @@ export default function ProfileEpisode({ userId, profileId, onBack }) {
   };
   useEffect(() => {
     if(progress?.rating) setRating(progress.rating);
-  }, [progress]);
+    if(progress?.lastUpdated === today && progress?.reflection){
+      setReflection(progress.reflection);
+    }
+  }, [progress, today]);
   useEffect(()=>{ reflectionRef.current = reflection; }, [reflection]);
   useEffect(()=>{ ratingRef.current = rating; }, [rating]);
   useEffect(()=>{ progressRef.current = progress; }, [progress]);


### PR DESCRIPTION
## Summary
- keep reflection text when revisiting the same profile on the same day

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6880e5dac214832d8a21738f6ed08105