### PR TITLE
Automatically update days left when admin advances day

### DIFF
--- a/src/components/DailyDiscovery.jsx
+++ b/src/components/DailyDiscovery.jsx
@@ -13,6 +13,7 @@ import MatchOverlay from './MatchOverlay.jsx';
 import InfoOverlay from './InfoOverlay.jsx';
 import StoryLineOverlay from './StoryLineOverlay.jsx';
 import { triggerHaptic } from '../haptics.js';
+import useDayOffset from '../useDayOffset.js';
 
 export default function DailyDiscovery({ userId, onSelectProfile, ageRange, onOpenProfile }) {
   const profiles = useCollection('profiles');
@@ -20,6 +21,8 @@ export default function DailyDiscovery({ userId, onSelectProfile, ageRange, onOp
   const config = useDoc('config', 'app') || {};
   const showLevels = config.showLevels !== false;
   const user = profiles.find(p => p.id === userId) || {};
+  // Trigger re-renders when the admin changes the virtual date
+  useDayOffset();
   const hasActiveSub = prof =>
     prof.subscriptionExpires && new Date(prof.subscriptionExpires) > getCurrentDate();
   const today = getTodayStr();

--- a/src/components/ProfileEpisode.jsx
+++ b/src/components/ProfileEpisode.jsx
@@ -10,6 +10,7 @@ import ProfileSettings from './ProfileSettings.jsx';
 import VideoPreview from './VideoPreview.jsx';
 import { Star } from 'lucide-react';
 import InfoOverlay from './InfoOverlay.jsx';
+import useDayOffset from '../useDayOffset.js';
 
 export default function ProfileEpisode({ userId, profileId, onBack }) {
   const progressId = `${userId}-${profileId}`;
@@ -17,6 +18,8 @@ export default function ProfileEpisode({ userId, profileId, onBack }) {
   const profile = useDoc('profiles', profileId);
   const viewer = useDoc('profiles', userId);
   const isOwnProfile = userId === profileId;
+  // Listen for day changes from admin page
+  useDayOffset();
   const t = useT();
   const config = useDoc('config', 'app') || {};
   const showLevels = config.showLevels !== false;

--- a/src/useDayOffset.js
+++ b/src/useDayOffset.js
@@ -1,0 +1,19 @@
+import { useState, useEffect } from 'react';
+
+export default function useDayOffset(){
+  const read = () => parseInt(localStorage.getItem('dayOffset') || '0', 10);
+  const [offset, setOffset] = useState(read());
+  useEffect(() => {
+    const handler = e => {
+      if (e.key && e.key !== 'dayOffset') return;
+      setOffset(read());
+    };
+    window.addEventListener('storage', handler);
+    window.addEventListener('dayOffsetChange', handler);
+    return () => {
+      window.removeEventListener('storage', handler);
+      window.removeEventListener('dayOffsetChange', handler);
+    };
+  }, []);
+  return offset;
+}

--- a/src/utils.js
+++ b/src/utils.js
@@ -12,10 +12,12 @@ export function getTodayStr(){
 export function advanceDay(){
   const off = parseInt(localStorage.getItem('dayOffset') || '0', 10) + 1;
   localStorage.setItem('dayOffset', off);
+  window.dispatchEvent(new Event('dayOffsetChange'));
 }
 
 export function resetDay(){
   localStorage.removeItem('dayOffset');
+  window.dispatchEvent(new Event('dayOffsetChange'));
 }
 
 export function getAge(birthday){


### PR DESCRIPTION
## Summary
- add a `useDayOffset` hook listening for `storage` and custom events
- fire `dayOffsetChange` whenever day offset is modified
- use the new hook in `DailyDiscovery` and `ProfileEpisode` so they rerender when the day offset changes

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6881d5d94818832d9c5b2da9bbb3b73d