### PR TITLE
Fix expiry days after day offset change

### DIFF
--- a/src/components/DailyDiscovery.jsx
+++ b/src/components/DailyDiscovery.jsx
@@ -48,7 +48,7 @@ export default function DailyDiscovery({ userId, onSelectProfile, ageRange, onOp
   const progresses = useCollection('episodeProgress','userId', userId);
 
   useEffect(() => {
-    if(!userId) return;
+    if(!userId || !progresses.loaded) return;
     const hasSub = hasActiveSub(user);
     const extra = user.extraClipsDate === today ? 3 : 0;
     const limit = (hasSub ? 6 : 3) + extra;

--- a/src/firebase.js
+++ b/src/firebase.js
@@ -198,15 +198,17 @@ export async function requestNotificationPermission(userId, loginMethod = 'passw
 
 export function useCollection(collectionName, field, value) {
   const [data, setData] = useState([]);
+  const [loaded, setLoaded] = useState(false);
   useEffect(() => {
     const colRef = collection(db, collectionName);
     const q = field && value != null ? query(colRef, where(field, '==', value)) : colRef;
     const unsub = onSnapshot(q, snapshot => {
       setData(snapshot.docs.map(doc => ({ id: doc.id, ...doc.data() })));
+      setLoaded(true);
     });
     return () => unsub();
   }, [collectionName, field, value]);
-  return data;
+  return Object.assign([...data], { loaded });
 }
 
 export function useDoc(collectionName, docId) {


### PR DESCRIPTION
## Summary
- mark when Firestore collections finish loading
- skip DailyDiscovery profile initialization until progress data is loaded

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6881d9d537f4832d8aa7471cafe72f97