### PR TITLE
Show liked profiles in archive list

### DIFF
--- a/src/components/DailyDiscovery.jsx
+++ b/src/components/DailyDiscovery.jsx
@@ -109,8 +109,13 @@ export default function DailyDiscovery({ userId, onSelectProfile, ageRange, onOp
     grace.setDate(grace.getDate() - 1);
     return new Date(prog.expiresAt) >= grace;
   });
+  const likedIds = new Set(likes.map(l => l.profileId));
   const archivedProfiles = progresses
-    .filter(pr => (pr.removed || (pr.expiresAt && new Date(pr.expiresAt) < getCurrentDate())) && pr.rating >= 3)
+    .filter(pr => {
+      const expired = pr.expiresAt && new Date(pr.expiresAt) < getCurrentDate();
+      const shouldShow = pr.rating >= 3 || likedIds.has(pr.profileId);
+      return (pr.removed || expired) && shouldShow;
+    })
     .map(pr => profiles.find(p => p.id === pr.profileId))
     .filter(Boolean);
 


### PR DESCRIPTION
## Summary
- include liked profiles when listing archived profiles

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68824a6627d4832d993c5607fda12254