### PR TITLE
Add account access module for function testing

### DIFF
--- a/docs/function-test-modules.md
+++ b/docs/function-test-modules.md
@@ -9,5 +9,6 @@ The admin page includes a screen for manual function testing. The tests are now 
 3. **Profile Settings** – editing profile info, language preferences and interests.
 4. **Recording & Media** – offline caching, recording limits, countdown timer and reveal animation.
 5. **Admin & Statistics** – seed data, profile switching and various admin statistics screens.
+6. **Account Access** – create profile, password reset and login flow.
 
 Use the admin menu to open *Funktionstest* and choose a module to start testing. Each feature within a module can be marked as OK or Fail with optional comments and screenshot. Submit results when a module is finished before moving on to the next.

--- a/src/components/FunctionTestScreen.jsx
+++ b/src/components/FunctionTestScreen.jsx
@@ -206,6 +206,35 @@ const modules = [
         ]
       }
     ]
+  },
+  {
+    name: 'Account Access',
+    features: [
+      {
+        title: 'Create profile from welcome screen',
+        expected: [
+          'Registration form validates required fields',
+          'Profile is saved in Firestore after sign-up',
+          'Success message appears after creating profile'
+        ]
+      },
+      {
+        title: 'Login with username and password',
+        expected: [
+          'Existing user can log in with correct credentials',
+          'Invalid credentials show an error message',
+          'Successful login opens discovery'
+        ]
+      },
+      {
+        title: 'Reset password with "Forgot Password"',
+        expected: [
+          'Forgot password link opens a form for email',
+          'Sending the form emails a reset link',
+          'Confirmation is shown after sending'
+        ]
+      }
+    ]
   }
 ];
 


### PR DESCRIPTION
## Summary
- include a new **Account Access** module in docs and function test screen
  - covers profile creation, login and forgot password flows

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68824f1e2224832db3e86084485e378c