### PR TITLE
Add invitations module to functional tests

### DIFF
--- a/docs/function-test-modules.md
+++ b/docs/function-test-modules.md
@@ -10,5 +10,6 @@ The admin page includes a screen for manual function testing. The tests are now 
 4. **Recording & Media** – offline caching, recording limits, countdown timer and reveal animation.
 5. **Admin & Statistics** – seed data, profile switching and various admin statistics screens.
 6. **Account Access** – create profile, password reset and login flow.
+7. **Invitations** – send invites, gift premium access and track invite status.
 
 Use the admin menu to open *Funktionstest* and choose a module to start testing. Each feature within a module can be marked as OK or Fail with optional comments and screenshot. Submit results when a module is finished before moving on to the next.

--- a/src/components/FunctionTestScreen.jsx
+++ b/src/components/FunctionTestScreen.jsx
@@ -235,6 +235,35 @@ const modules = [
         ]
       }
     ]
+  },
+  {
+    name: 'Invitations',
+    features: [
+      {
+        title: 'Send invitation with a shareable link',
+        expected: [
+          'Generating an invite creates a unique link',
+          'Link can be copied or shared via the browser',
+          'Invite list shows the entered recipient'
+        ]
+      },
+      {
+        title: 'Gift 3 months of premium with up to five invites',
+        expected: [
+          'Premium gift enabled when invites are available',
+          'Remaining gift count is displayed',
+          'Gift status updates when the invite is used'
+        ]
+      },
+      {
+        title: 'Invite list displays pending and accepted',
+        expected: [
+          'All created invites are listed',
+          'Accepted invites are marked as created',
+          'Pending invites remain until your friend signs up'
+        ]
+      }
+    ]
   }
 ];
 


### PR DESCRIPTION
## Summary
- add an "Invitations" module to manual function test list
- document the new module in **Function Test Modules** guide

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6882538add40832db4e501095e5d932e