### PR TITLE
Add homepage link button

### DIFF
--- a/src/components/AboutScreen.jsx
+++ b/src/components/AboutScreen.jsx
@@ -21,6 +21,7 @@ export default function AboutScreen({ userId }) {
       React.createElement('p', { className: 'text-gray-500 text-sm text-center mb-4' }, `Version ${version}`),
       React.createElement(Button, { className: 'bg-blue-500 text-white w-full mb-2', onClick: () => setShowInvite(true) }, t('inviteFriend')),
       React.createElement(Button, { className: 'bg-pink-500 text-white w-full mb-2', onClick: () => setShowReport(true) }, 'Fejlmeld'),
+      React.createElement(Button, { className: 'bg-green-500 text-white w-full mb-2', onClick: () => window.open('https://videotpush.netlify.app/', '_blank') }, t('visitWebsite')),
       React.createElement('div', { className: 'flex flex-col items-center mt-4' },
         React.createElement(QRCodeSVG, { value: new URL('./index.html', window.location.href).href, size: 128 }),
         React.createElement('p', { className: 'text-xs mt-2 text-gray-600' }, t('qrOpen')),

--- a/src/i18n.js
+++ b/src/i18n.js
@@ -74,6 +74,7 @@ inviteDesc:{ en:'Share the link below to invite others to RealDate', da:'Del lin
 share:{ en:'Share', da:'Del', sv:'Dela', es:'Compartir', fr:'Partager', de:'Teilen' },
 copyLink:{ en:'Copy link', da:'Kopiér link', sv:'Kopiera länk', es:'Copiar enlace', fr:'Copier le lien', de:'Link kopieren' },
 linkCopied:{ en:'Link copied to clipboard', da:'Link kopieret', sv:'Länk kopierad', es:'Enlace copiado', fr:'Lien copié', de:'Link kopiert' },
+visitWebsite:{ en:'Visit website', da:'Besøg hjemmesiden', sv:'Besök webbplatsen', es:'Visitar el sitio web', fr:'Visiter le site web', de:'Website besuchen' },
 inviteList:{ en:"Invitations", da:"Invitationer", sv:"Inbjudningar", es:"Invitaciones", fr:"Invitations", de:"Einladungen" },
 invitePending:{ en:"Pending", da:"Afventer", sv:"V\u00e4ntar", es:"Pendiente", fr:"En attente", de:"Ausstehend" },
 inviteAccepted:{ en:"Profile created", da:"Oprettet", sv:"Skapad", es:"Perfil creado", fr:"Profil cr\u00e9\u00e9", de:"Profil erstellt" },


### PR DESCRIPTION
## Summary
- add a "visit website" button on the About screen
- translate new string for multiple languages

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6882567eff00832d9db198d7aafc2edf