### PR TITLE
Add graphics showcase

### DIFF
--- a/src/VideotpushApp.jsx
+++ b/src/VideotpushApp.jsx
@@ -26,6 +26,7 @@ import RecentLoginsScreen from './components/RecentLoginsScreen.jsx';
 import ProfileEpisode from './components/ProfileEpisode.jsx';
 import HelpOverlay from './components/HelpOverlay.jsx';
 import TaskButton from './components/TaskButton.jsx';
+import GraphicsElementsScreen from './components/GraphicsElementsScreen.jsx';
 import { getNextTask } from './tasks.js';
 import { useCollection, requestNotificationPermission, subscribeToWebPush, db, doc, updateDoc, increment, logEvent, auth, isAdminUser, signOutUser } from './firebase.js';
 import { getCurrentDate } from './utils.js';
@@ -274,7 +275,7 @@ export default function VideotpushApp() {
             taskTrigger: taskClicks
           }),
           tab==='likes' && React.createElement(LikesScreen, { userId, onBack: ()=>setTab('discovery'), onSelectProfile: selectProfile }),
-          tab==='admin' && React.createElement(AdminScreen, { onOpenStats: ()=>setTab('stats'), onOpenBugReports: ()=>setTab('bugs'), onOpenMatchLog: ()=>setTab('matchlog'), onOpenScoreLog: ()=>setTab('scorelog'), onOpenReports: ()=>setTab('reports'), onOpenCallLog: ()=>setTab('calllog'), onOpenFunctionTest: ()=>setTab('functiontest'), onOpenRevealTest: ()=>setTab('revealtest'), onOpenTextLog: ()=>setTab('textlog'), onOpenTextPieces: ()=>setTab('textpieces'), onOpenUserLog: ()=>setTab('trackuser'), onOpenServerLog: ()=>setTab('serverlog'), onOpenRecentLogins: ()=>setTab('recentlogins'), profiles, userId, onSwitchProfile: id=>{ setUserId(id); setLoginMethod('admin'); }, onSaveUserLogout: saveUserAndLogout }),
+          tab==='admin' && React.createElement(AdminScreen, { onOpenStats: ()=>setTab('stats'), onOpenBugReports: ()=>setTab('bugs'), onOpenMatchLog: ()=>setTab('matchlog'), onOpenScoreLog: ()=>setTab('scorelog'), onOpenReports: ()=>setTab('reports'), onOpenCallLog: ()=>setTab('calllog'), onOpenFunctionTest: ()=>setTab('functiontest'), onOpenRevealTest: ()=>setTab('revealtest'), onOpenTextLog: ()=>setTab('textlog'), onOpenTextPieces: ()=>setTab('textpieces'), onOpenUserLog: ()=>setTab('trackuser'), onOpenServerLog: ()=>setTab('serverlog'), onOpenRecentLogins: ()=>setTab('recentlogins'), onOpenGraphics: ()=>setTab('graphics'), profiles, userId, onSwitchProfile: id=>{ setUserId(id); setLoginMethod('admin'); }, onSaveUserLogout: saveUserAndLogout }),
           tab==='stats' && React.createElement(StatsScreen, { onBack: ()=>setTab('admin') }),
           tab==='matchlog' && React.createElement(MatchLogScreen, { onBack: ()=>setTab('admin') }),
           tab==='scorelog' && React.createElement(ScoreLogScreen, { onBack: ()=>setTab('admin') }),
@@ -288,6 +289,7 @@ export default function VideotpushApp() {
           tab==='trackuser' && React.createElement(TrackUserScreen, { onBack: ()=>setTab('admin'), profiles }),
           tab==='serverlog' && React.createElement(ServerLogScreen, { onBack: ()=>setTab('admin') }),
           tab==='recentlogins' && React.createElement(RecentLoginsScreen, { onBack: ()=>setTab('admin') }),
+          tab==='graphics' && React.createElement(GraphicsElementsScreen, { onBack: ()=>setTab('admin') }),
           tab==='about' && React.createElement(AboutScreen, { userId })
         )
     ),

--- a/src/components/AdminScreen.jsx
+++ b/src/components/AdminScreen.jsx
@@ -11,7 +11,7 @@ import { fcmReg } from '../swRegistration.js';
 import { triggerHaptic } from '../haptics.js';
 
 
-export default function AdminScreen({ onOpenStats, onOpenBugReports, onOpenMatchLog, onOpenScoreLog, onOpenReports, onOpenCallLog, onOpenFunctionTest, onOpenRevealTest, onOpenTextLog, onOpenTextPieces, onOpenUserLog, onOpenServerLog, onOpenRecentLogins, profiles = [], userId, onSwitchProfile, onSaveUserLogout }) {
+export default function AdminScreen({ onOpenStats, onOpenBugReports, onOpenMatchLog, onOpenScoreLog, onOpenReports, onOpenCallLog, onOpenFunctionTest, onOpenRevealTest, onOpenTextLog, onOpenTextPieces, onOpenUserLog, onOpenServerLog, onOpenRecentLogins, onOpenGraphics, profiles = [], userId, onSwitchProfile, onSaveUserLogout }) {
 
   const { lang, setLang } = useLang();
   const t = useT();
@@ -350,6 +350,9 @@ export default function AdminScreen({ onOpenStats, onOpenBugReports, onOpenMatch
     React.createElement(Button, { className: 'mt-2 bg-blue-500 text-white px-4 py-2 rounded', onClick: onOpenFunctionTest }, 'Åbn funktionstest'),
 
     React.createElement('h3', { className: 'text-xl font-semibold mb-2 mt-4 text-blue-600' }, 'Reveal test'),
-    React.createElement(Button, { className: 'mt-2 bg-blue-500 text-white px-4 py-2 rounded', onClick: onOpenRevealTest }, 'Åbn reveal test')
+    React.createElement(Button, { className: 'mt-2 bg-blue-500 text-white px-4 py-2 rounded', onClick: onOpenRevealTest }, 'Åbn reveal test'),
+
+    React.createElement('h3', { className: 'text-xl font-semibold mb-2 mt-4 text-blue-600' }, 'Grafikelementer'),
+    React.createElement(Button, { className: 'mt-2 bg-blue-500 text-white px-4 py-2 rounded', onClick: onOpenGraphics }, 'Alle grafikelementer')
   );
 }

--- a/src/components/GraphicsElementsScreen.jsx
+++ b/src/components/GraphicsElementsScreen.jsx
@@ -1,0 +1,72 @@
+import React, { useState } from 'react';
+import { Card } from './ui/card.js';
+import { Button } from './ui/button.js';
+import { Input } from './ui/input.js';
+import { Textarea } from './ui/textarea.js';
+import SectionTitle from './SectionTitle.jsx';
+import InfoOverlay from './InfoOverlay.jsx';
+import HelpOverlay from './HelpOverlay.jsx';
+import PurchaseOverlay from './PurchaseOverlay.jsx';
+import DeleteAccountOverlay from './DeleteAccountOverlay.jsx';
+
+export default function GraphicsElementsScreen({ onBack }) {
+  const [showInfo, setShowInfo] = useState(false);
+  const [showHelp, setShowHelp] = useState(false);
+  const [showPurchase, setShowPurchase] = useState(false);
+  const [showDelete, setShowDelete] = useState(false);
+  const listItems = ['Liste element 1', 'Liste element 2', 'Liste element 3'];
+  const chatMessages = [
+    { self: true, text: 'Hej med dig', time: '12:34' },
+    { self: false, text: 'Hej hej', time: '12:35' }
+  ];
+
+  return React.createElement(Card, { className: 'p-6 m-4 shadow-xl bg-white/90 overflow-y-auto max-h-[90vh]' },
+    React.createElement(SectionTitle, { title: 'Grafikelementer', colorClass: 'text-blue-600', action: React.createElement(Button, { onClick: onBack, className: 'bg-blue-500 text-white px-4 py-2 rounded' }, 'Tilbage') }),
+
+    React.createElement('div', { className: 'space-x-2 mb-4' },
+      React.createElement(Button, { className: 'bg-green-500 text-white px-4 py-2 rounded', onClick: () => setShowInfo(true) }, 'Åbn infoboks'),
+      React.createElement(Button, { className: 'bg-blue-500 text-white px-4 py-2 rounded', onClick: () => setShowHelp(true) }, 'Åbn hjælp'),
+      React.createElement(Button, { className: 'bg-yellow-500 text-white px-4 py-2 rounded', onClick: () => setShowPurchase(true) }, 'Åbn køb'),
+      React.createElement(Button, { className: 'bg-red-500 text-white px-4 py-2 rounded', onClick: () => setShowDelete(true) }, 'Slet konto')
+    ),
+
+    showInfo && React.createElement(InfoOverlay, { title: 'Eksempel', onClose: () => setShowInfo(false) },
+      React.createElement('p', null, 'Dette er en infoboks')
+    ),
+    showHelp && React.createElement(HelpOverlay, { onClose: () => setShowHelp(false) }),
+    showPurchase && React.createElement(PurchaseOverlay, { title: 'Køb premium', price: '99,-', onBuy: () => setShowPurchase(false), onClose: () => setShowPurchase(false) },
+      React.createElement('p', null, 'Adgang til alle funktioner')
+    ),
+    showDelete && React.createElement(DeleteAccountOverlay, { onDelete: () => setShowDelete(false), onClose: () => setShowDelete(false) }),
+
+    React.createElement('h3', { className: 'text-lg font-semibold mb-2 mt-4' }, 'Liste elementer'),
+    React.createElement('ul', { className: 'list-disc ml-5 mb-4' },
+      listItems.map((item, idx) => React.createElement('li', { key: idx }, item))
+    ),
+
+    React.createElement('h3', { className: 'text-lg font-semibold mb-2' }, 'Chatbobler'),
+    React.createElement('div', { className: 'space-y-2 mb-4' },
+      chatMessages.map((m, i) =>
+        React.createElement('div', { key: i, className: `flex ${m.self ? 'justify-end' : 'justify-start'}` },
+          React.createElement('div', { className: 'space-y-1 max-w-[75%]' },
+            React.createElement('div', { className: 'text-xs text-gray-500' }, m.time),
+            React.createElement('div', { className: `inline-block px-3 py-2 rounded-lg ${m.self ? 'bg-pink-500 text-white' : 'bg-gray-200 text-black'}` }, m.text)
+          )
+        )
+      )
+    ),
+
+    React.createElement('h3', { className: 'text-lg font-semibold mb-2' }, 'Skærmeksempel'),
+    React.createElement(Card, { className: 'p-4 mb-4 bg-gray-100' },
+      React.createElement('p', { className: 'mb-2' }, 'Login skærm'),
+      React.createElement('label', { className: 'block mb-1' }, 'Email'),
+      React.createElement(Input, { className: 'border p-2 mb-2 w-full' }),
+      React.createElement('label', { className: 'block mb-1' }, 'Password'),
+      React.createElement(Input, { type: 'password', className: 'border p-2 mb-4 w-full' }),
+      React.createElement(Button, { className: 'bg-pink-500 text-white px-4 py-2 rounded' }, 'Log ind')
+    ),
+
+    React.createElement('h3', { className: 'text-lg font-semibold mb-2' }, 'Tekstboks'),
+    React.createElement(Textarea, { className: 'border p-2 w-full mb-4', placeholder: 'Skriv noget...' })
+  );
+}


### PR DESCRIPTION
## Summary
- expand `GraphicsElementsScreen` with examples of overlays, chat bubbles and form widgets

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6882693604a0832d9a4f1da40190348b