### PR TITLE
Add tester guide page

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -16,6 +16,7 @@
   <noscript>You need to enable JavaScript to run this app.</noscript>
   <link rel="stylesheet" href="../src/style.css" />
   <div id="root"></div>
+  <a href="testers.html" class="fixed bottom-2 right-2 text-xs text-pink-600 bg-white/80 px-2 py-1 rounded shadow z-50">Tester guide</a>
   <script type="module" src="../src/index.js"></script>
 </body>
 </html>

--- a/public/testers.html
+++ b/public/testers.html
@@ -1,0 +1,25 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover" />
+  <meta name="theme-color" content="#ff4957" />
+  <script src="https://cdn.tailwindcss.com"></script>
+  <title>RealDate Tester Guide</title>
+  <link rel="stylesheet" href="../src/style.css" />
+</head>
+<body class="bg-gradient-to-br from-pink-100 to-white min-h-screen flex items-center justify-center p-4">
+  <div class="bg-white/90 p-6 rounded-lg shadow-xl max-w-md w-full">
+    <h1 class="text-3xl font-bold text-pink-600 text-center mb-4">Tester Guide</h1>
+    <p class="mb-4 text-gray-700">Install RealDate on your phone for the best experience.</p>
+    <h2 class="text-xl font-semibold text-pink-600 mt-4 mb-2">Add to Home Screen</h2>
+    <ol class="list-decimal list-inside text-left mb-4 space-y-1 text-gray-700">
+      <li>Open RealDate in your browser.</li>
+      <li>Tap the menu and choose <strong>Add to Home Screen</strong> or <strong>Install App</strong>.</li>
+      <li>Confirm the installation.</li>
+    </ol>
+    <p class="mb-4 text-gray-700">When you open the installed app allow notifications to get updates and matches.</p>
+    <a href="./index.html" class="block bg-pink-500 text-white py-3 rounded-lg font-bold text-center">Back to RealDate</a>
+  </div>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- create dedicated tester guide with instructions for saving the PWA to the home screen
- link to the tester guide from the homepage

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68829ca5eb48832db48be972320d43f2