### PR TITLE
Fix expiry countdown

### DIFF
--- a/src/__tests__/utils.test.js
+++ b/src/__tests__/utils.test.js
@@ -1,4 +1,4 @@
-import { getCurrentDate, getAge, getTodayStr } from '../utils.js';
+import { getCurrentDate, getAge, getTodayStr, getDaysLeft } from '../utils.js';
 
 // Control time for deterministic tests
 beforeEach(() => {
@@ -32,4 +32,11 @@ test('getAge calculates age relative to getCurrentDate', () => {
   // Birthday after the mocked current date this year
   const birthStr = '2000-05-21';
   expect(getAge(birthStr)).toBe(23);
+});
+
+test('getDaysLeft rounds down at midnight', () => {
+  const expires = '2024-05-25T12:00:00Z';
+  expect(getDaysLeft(expires)).toBe(5);
+  jest.setSystemTime(new Date('2024-05-21T08:00:00Z'));
+  expect(getDaysLeft(expires)).toBe(4);
 });

--- a/src/components/DailyDiscovery.jsx
+++ b/src/components/DailyDiscovery.jsx
@@ -1,5 +1,5 @@
 import React, { useState, useEffect } from 'react';
-import { getAge, getTodayStr, getCurrentDate } from '../utils.js';
+import { getAge, getTodayStr, getCurrentDate, getDaysLeft } from '../utils.js';
 import { User, PlayCircle, Star } from 'lucide-react';
 import VideoOverlay from './VideoOverlay.jsx';
 import { Card } from './ui/card.js';
@@ -201,7 +201,7 @@ export default function DailyDiscovery({ userId, onSelectProfile, ageRange, onOp
         const prog = progresses.find(pr => pr.profileId === p.id);
         const stage = prog?.stage || 1;
         const defaultDays = hasActiveSub(p) ? 10 : 5;
-        const daysLeft = prog?.expiresAt ? Math.ceil((new Date(prog.expiresAt) - getCurrentDate())/86400000) : defaultDays;
+        const daysLeft = prog?.expiresAt ? getDaysLeft(prog.expiresAt) : defaultDays;
         return React.createElement('li', {
           key: p.id,
           className: 'p-4 bg-white rounded-lg cursor-pointer shadow-lg border border-gray-200 flex flex-col relative',

--- a/src/components/ProfileEpisode.jsx
+++ b/src/components/ProfileEpisode.jsx
@@ -1,6 +1,6 @@
 import React, { useState, useEffect, useRef } from 'react';
 import { useDoc, db, doc, setDoc } from '../firebase.js';
-import { getTodayStr, getCurrentDate, getAge } from '../utils.js';
+import { getTodayStr, getCurrentDate, getAge, getDaysLeft } from '../utils.js';
 import { Card } from './ui/card.js';
 import { Button } from './ui/button.js';
 import { Textarea } from './ui/textarea.js';
@@ -126,7 +126,7 @@ export default function ProfileEpisode({ userId, profileId, onBack }) {
 
   if (!profile) return null;
 
-  const daysLeft = progress?.expiresAt ? Math.ceil((new Date(progress.expiresAt) - getCurrentDate())/86400000) : expiryDays;
+  const daysLeft = progress?.expiresAt ? getDaysLeft(progress.expiresAt) : expiryDays;
 
 
   const saveReflection = async (givenRating = rating) => {

--- a/src/utils.js
+++ b/src/utils.js
@@ -5,6 +5,15 @@ export function getCurrentDate(){
   return d;
 }
 
+export function getDaysLeft(expiresAt){
+  if(!expiresAt) return 0;
+  const now = getCurrentDate();
+  const exp = new Date(expiresAt);
+  now.setHours(0,0,0,0);
+  exp.setHours(0,0,0,0);
+  return Math.ceil((exp - now)/86400000);
+}
+
 export function getTodayStr(){
   return getCurrentDate().toISOString().split('T')[0];
 }


### PR DESCRIPTION
## Summary
- ensure day countdown decrements at midnight
- use new `getDaysLeft` helper across the app
- test midnight behavior for countdown

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68831933a500832dbdd6a479234bf697