### PR TITLE
Fix tester guide link overlap

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -16,7 +16,8 @@
   <noscript>You need to enable JavaScript to run this app.</noscript>
   <link rel="stylesheet" href="../src/style.css" />
   <div id="root"></div>
-  <a href="testers.html" class="fixed bottom-2 right-2 text-xs text-pink-600 bg-white/80 px-2 py-1 rounded shadow z-50">Tester guide</a>
+  <!-- Moved link higher to avoid overlap with navigation icons -->
+  <a href="testers.html" class="fixed top-16 left-2 text-xs text-pink-600 bg-white/80 px-2 py-1 rounded shadow z-50">Tester guide</a>
   <script type="module" src="../src/index.js"></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- move the "Tester guide" link near the top-left so it no longer interferes with bottom navigation

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6883375c3588832d842c03f1e1e218e9