### PR TITLE
Add admin page button for docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ GitHub Pages. Serverless functions for push notifications and scoring run on Net
 The home page is available at <https://videotpush.netlify.app/> and the app runs from <https://nyhave.github.io/VideoTinder/>.
 
 For more background on the guiding principles, see [Vision for "Dagens profiler"](docs/vision.md).
+Der findes også en dansk [beskrivelse af appens sider](docs/app-pages-da.md).
 Profiles are presented as short episodes rather than a catalog of faces. Each episode guides you through introduction, a behind-the-scenes prompt answer, a glimpse of daily life and space for your reaction.
 
 ## Features

--- a/docs/app-pages-da.md
+++ b/docs/app-pages-da.md
@@ -1,0 +1,74 @@
+# Beskrivelse af appens sider
+
+## Brugerens profil
+- **Overordnede aktioner**
+  - Log ud og vend tilbage til loginskærmen.
+  - Vis offentlig profil som andre ser den.
+  - Gå til siden "Om RealDate".
+- **Informationer der kan uploades efter redigering**
+  - Profilbillede
+  - Videoklip 1 ("Introduktion")
+  - Kort tekst om brugeren ("clip")
+  - Videoklip 2 og 3
+- En hjælpefunktion i toppen guider brugeren gennem disse skridt.
+- Brugeren kan slette sin profil.
+- Videoklip kan maksimalt vare 10 sekunder, og en timer tæller ned under optagelsen.
+
+## Dagens klip
+- Ved indgang vises listen med kandidatprofiler samt eventuelle arkiverede profiler.
+- Listen indeholder aktive profiler fra tidligere dage plus dagens nye (3 eller 6).
+- Hvis serveren returnerer for få nye profiler, kan brugeren udvide maks-afstanden.
+- **Handlinger på kandidatlisten**
+  - Åbn en profil for at se den offentlige kandidatprofil.
+  - Vælg "Like" (kan blive til et match).
+  - Vælg "Remove" for at fjerne profilen helt, medmindre rating 3 eller 4 er givet 
+    (så vises den under arkiverede profiler).
+- Brugeren kan én gang dagligt købe ekstra profiler.
+
+### Offentlig kandidatprofil
+- Brugerens clip er altid tilgængeligt, men videoen afsløres gradvist:
+  - Dag 1: kun video 1
+  - Dag 2: video 1 og 2
+  - Efterfølgende dage: alt materiale
+- Brugeren kan se tilgængeligt materiale og skrive en refleksion med rating 1–4
+  samt give et like.
+
+## Chat
+- Matchede profiler vises på en liste.
+- Chat med matchede brugere.
+- Start videokald.
+- Mulighed for at unmatche.
+
+## Om RealDate
+- Fejlmelding med mulighed for vedhæftet skærmbillede.
+- Inviter op til fem venner og tilbyd gratis premium-abonnement. 
+  Når en invitation er sendt, følges der med i, om brugeren opretter profil.
+
+## Du er blevet liket
+- Viser en liste over kandidatprofiler, hvis brugeren har premium.
+- Uden premium er listen sløret, og brugeren får tilbud om at købe premium.
+
+## Login og opret bruger
+- Log ind med e-mail, Facebook eller Google.
+
+## Uden for app’en hos Netlify
+- Hjemmeside med baggrund og link til appen.
+- Pushnotifikationer håndteres herfra.
+- Funktion til at hente dagens profiler fra databasen og score dem.
+- **Scoresystem**
+  - Udfyldt profil
+  - Fælles interesser
+
+## Adminsiden
+- Håndtering af anmeldt materiale og sletning af brugere.
+  - Se antal anmeldelser og brugernes kommentarer.
+  - Slet eller frigiv indhold.
+- Statistik over brug af appen:
+  - Grafer over udvikling i brugerantal, uploads, likes, matches, chats, 
+    refleksioner og ratings.
+  - Øjebliksbillede af aldersfordeling.
+- Kombineret test og fejlmelding:
+  - Mulighed for at se appen som en bestemt bruger.
+  - Mulighed for at spole datoen tilbage lokalt for at teste dagsflowet.
+  - Bemærk at refleksioner gemmes i fremtiden, hvis funktionen benyttes.
+- Verifikation af teknisk opsætning, eksempelvis pushnotifikationer.

--- a/src/components/AdminScreen.jsx
+++ b/src/components/AdminScreen.jsx
@@ -19,6 +19,7 @@ export default function AdminScreen({ onOpenStats, onOpenBugReports, onOpenMatch
   const config = useDoc('config', 'app') || {};
   const invitesEnabled = config.premiumInvitesEnabled !== false;
   const showLevels = config.showLevels !== false;
+  const pageInfoUrl = 'https://raw.githubusercontent.com/nyhave/VideoTinder/main/docs/app-pages-da.md';
 
   const toggleLog = () => {
     const val = !logEnabled;
@@ -353,6 +354,9 @@ export default function AdminScreen({ onOpenStats, onOpenBugReports, onOpenMatch
     React.createElement(Button, { className: 'mt-2 bg-blue-500 text-white px-4 py-2 rounded', onClick: onOpenRevealTest }, 'Åbn reveal test'),
 
     React.createElement('h3', { className: 'text-xl font-semibold mb-2 mt-4 text-blue-600' }, 'Grafikelementer'),
-    React.createElement(Button, { className: 'mt-2 bg-blue-500 text-white px-4 py-2 rounded', onClick: onOpenGraphics }, 'Alle grafikelementer')
+    React.createElement(Button, { className: 'mt-2 bg-blue-500 text-white px-4 py-2 rounded', onClick: onOpenGraphics }, 'Alle grafikelementer'),
+
+    React.createElement('h3', { className: 'text-xl font-semibold mb-2 mt-4 text-blue-600' }, 'Sideoversigt'),
+    React.createElement(Button, { className: 'mt-2 bg-blue-500 text-white px-4 py-2 rounded', onClick: () => window.open(pageInfoUrl, '_blank') }, 'Åbn sideinfo')
   );
 }


### PR DESCRIPTION
## Summary
- open a new window with the Danish page overview from the admin screen

## Testing
- `npm install`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6883c45f0958832dbc7d8bf79558b6e6