### PR TITLE
Fix blank page when profile data missing

### DIFF
--- a/src/components/ProfileEpisode.jsx
+++ b/src/components/ProfileEpisode.jsx
@@ -115,7 +115,9 @@ export default function ProfileEpisode({ userId, profileId, onBack }) {
     };
   }, []);
 
-  if (!profile) return null;
+  if (!profile) {
+    return React.createElement(Card, { className:'p-6 m-4 shadow-xl bg-white/90 text-center' }, 'Profile not found');
+  }
 
   const daysLeft = progress?.daysLeft ?? expiryDays;
 


### PR DESCRIPTION
## Summary
- display a helpful message if a profile isn't found

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68845a589ef0832d89e332ddd9e5d373