### PR TITLE
Correct tester guide link path

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -16,8 +16,6 @@
   <noscript>You need to enable JavaScript to run this app.</noscript>
   <link rel="stylesheet" href="../src/style.css" />
   <div id="root"></div>
-  <!-- Moved link higher to avoid overlap with navigation icons -->
-  <a href="testers.html" class="fixed top-16 left-2 text-xs text-pink-600 bg-white/80 px-2 py-1 rounded shadow z-50">Tester guide</a>
   <script type="module" src="../src/index.js"></script>
 </body>
 </html>

--- a/src/components/AboutScreen.jsx
+++ b/src/components/AboutScreen.jsx
@@ -22,6 +22,7 @@ export default function AboutScreen({ userId }) {
       React.createElement(Button, { className: 'bg-blue-500 text-white w-full mb-2', onClick: () => setShowInvite(true) }, t('inviteFriend')),
       React.createElement(Button, { className: 'bg-pink-500 text-white w-full mb-2', onClick: () => setShowReport(true) }, 'Fejlmeld'),
       React.createElement(Button, { className: 'bg-green-500 text-white w-full mb-2', onClick: () => window.open('https://videotpush.netlify.app/', '_blank') }, t('visitWebsite')),
+      React.createElement(Button, { className: 'bg-purple-500 text-white w-full mb-2', onClick: () => window.location.href = '/testers.html' }, 'Tester guide'),
       React.createElement('div', { className: 'flex flex-col items-center mt-4' },
         React.createElement(QRCodeSVG, { value: new URL('./index.html', window.location.href).href, size: 128 }),
         React.createElement('p', { className: 'text-xs mt-2 text-gray-600' }, t('qrOpen')),


### PR DESCRIPTION
## Summary
- link Tester guide button to `/testers.html` so it works from About page

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68845b8e9b28832daa9a5d3f08506dff