### PR TITLE
Add expand area reload button

### DIFF
--- a/src/components/DailyDiscovery.jsx
+++ b/src/components/DailyDiscovery.jsx
@@ -122,7 +122,9 @@ export default function DailyDiscovery({ userId, onSelectProfile, ageRange, onOp
   const [hoursUntil, setHoursUntil] = useState(0);
   const [showHelp, setShowHelp] = useState(false);
   const [showExtend, setShowExtend] = useState(false);
-  const [extendDismissed, setExtendDismissed] = useState(false);
+  const [extendShown, setExtendShown] = useState(() =>
+    window.localStorage.getItem('extendAreaShown') === '1'
+  );
   const [showArchived, setShowArchived] = useState(false);
   const [showPurchase, setShowPurchase] = useState(false);
   const [showInfo, setShowInfo] = useState(false);
@@ -130,10 +132,10 @@ export default function DailyDiscovery({ userId, onSelectProfile, ageRange, onOp
   const [activeVideo, setActiveVideo] = useState(null);
   const [storyProfile, setStoryProfile] = useState(null);
   useEffect(() => {
-    if (!extendDismissed && activeProfiles.length === 0) {
+    if (!extendShown && activeProfiles.length === 0) {
       setShowExtend(true);
     }
-  }, [activeProfiles, extendDismissed]);
+  }, [activeProfiles, extendShown]);
   const handleExtraPurchase = async () => {
     const todayStr = getTodayStr();
     await updateDoc(doc(db, 'profiles', userId), { extraClipsDate: todayStr });
@@ -189,15 +191,21 @@ export default function DailyDiscovery({ userId, onSelectProfile, ageRange, onOp
     const id = `${userId}-${profileId}`;
     await setDoc(doc(db,'episodeProgress', id), { removed: true }, { merge: true });
   };
+  const markExtendShown = () => {
+    setExtendShown(true);
+    window.localStorage.setItem('extendAreaShown', '1');
+  };
   const extendArea = async () => {
     const range = user.distanceRange || [0, 50];
     const newRange = [range[0], (range[1] || 0) + 35];
     await updateDoc(doc(db,'profiles', userId), { distanceRange: newRange });
+    markExtendShown();
     setShowExtend(false);
+    location.reload();
   };
   const dismissExtend = () => {
+    markExtendShown();
     setShowExtend(false);
-    setExtendDismissed(true);
   };
   useEffect(() => {
     const now = getCurrentDate();
@@ -302,6 +310,10 @@ export default function DailyDiscovery({ userId, onSelectProfile, ageRange, onOp
       ),
       React.createElement(Button,{className:'w-full bg-gray-200 text-black',onClick:()=>setShowArchived(false)},t('cancel'))
     ),
+    activeProfiles.length === 0 && extendShown && React.createElement(Button, {
+      className:'mt-4 w-full bg-pink-500 text-white',
+      onClick: extendArea
+    }, t('extendReload')),
     React.createElement(Button, {
       className: 'mt-4 w-full bg-yellow-500 text-white',
       onClick: () => {

--- a/src/i18n.js
+++ b/src/i18n.js
@@ -29,6 +29,14 @@ export const messages = {
     de:'Keine Profile in der Nähe. Bereich um 35 km erweitern?'
   },
   extendArea:{ en:'Expand area', da:'Udvid område', sv:'Utöka område', es:'Ampliar área', fr:'Étendre la zone', de:'Bereich erweitern' },
+  extendReload:{
+    en:'Expand area and reload',
+    da:'Udvid område og genindlæs',
+    sv:'Utöka område och ladda om',
+    es:'Ampliar área y recargar',
+    fr:'Étendre la zone et recharger',
+    de:'Bereich erweitern und neu laden'
+  },
   ok:{ en:'OK', da:'OK', sv:'OK', es:'OK', fr:'OK', de:'OK' },
   language:{ en:'Language', da:'Sprog', sv:'Språk', es:'Idioma', fr:'Langue', de:'Sprache' },
   preferredLanguages:{ en:'Preferred languages', da:'Foretrukne sprog', sv:'Föredragna språk', es:'Idiomas preferidos', fr:'Langues préférées', de:'Bevorzugte Sprachen' },


### PR DESCRIPTION
## Summary
- add new i18n message for `extendReload`
- track if extend prompt has been shown
- show "Expand area and reload" button when no profiles
- update logic so extend overlay only appears once

## Testing
- `npm install`
- `npx jest`

------
https://chatgpt.com/codex/tasks/task_e_68845c5f89c8832da61b46ec7958468c