### PR TITLE
Fix README GitHub link

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
 # RealDate
-![Test](https://github.com/nyhave/videotpush/actions/workflows/test.yml/badge.svg)
+![Test](https://github.com/nyhave/VideoTinder/actions/workflows/test.yml/badge.svg)
 
 RealDate is a small prototype for experimenting with a slower approach to online dating.
 The **VideotpushApp** demonstrates daily video discovery, chat, reflection notes
 and simple profile management powered by Firebase. The code is hosted on
-[GitHub](https://github.com/nyhave/videotpush) and the live demo is served from
+[GitHub](https://github.com/nyhave/VideoTinder) and the live demo is served from
 GitHub Pages. Serverless functions for push notifications and scoring run on Netlify.
 
 The home page is available at <https://videotpush.netlify.app/> and the app runs from <https://nyhave.github.io/VideoTinder/>.


### PR DESCRIPTION
## Summary
- fix broken GitHub repo link and badge URL in README

## Testing
- `npm install`
- `npx jest`

------
https://chatgpt.com/codex/tasks/task_e_688462b69798832d98b6ffafd827af14