### PR TITLE
Fix progress initialization when viewing profile

### DIFF
--- a/src/components/ProfileEpisode.jsx
+++ b/src/components/ProfileEpisode.jsx
@@ -54,7 +54,7 @@ export default function ProfileEpisode({ userId, profileId, onBack }) {
 
   useEffect(() => {
     if(!profile || isOwnProfile) return;
-    if(!progress) {
+    if(!progress || progress.stage === undefined) {
       setDoc(doc(db,'episodeProgress', progressId), {
         id: progressId,
         userId,


### PR DESCRIPTION
## Summary
- ensure episode progress records initialize if a stage is missing

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6884640e4990832db5cbb8cdbddbc6f9