### PR TITLE
Add console log overlay

### DIFF
--- a/src/VideotpushApp.jsx
+++ b/src/VideotpushApp.jsx
@@ -25,6 +25,7 @@ import ServerLogScreen from './components/ServerLogScreen.jsx';
 import RecentLoginsScreen from './components/RecentLoginsScreen.jsx';
 import ProfileEpisode from './components/ProfileEpisode.jsx';
 import HelpOverlay from './components/HelpOverlay.jsx';
+import ConsoleLogPanel from './components/ConsoleLogPanel.jsx';
 import TaskButton from './components/TaskButton.jsx';
 import GraphicsElementsScreen from './components/GraphicsElementsScreen.jsx';
 import { getNextTask } from './tasks.js';
@@ -305,6 +306,7 @@ export default function VideotpushApp() {
       ),
       React.createElement(CalendarDays, { className: 'w-8 h-8 text-pink-600', onClick: ()=>{setTab('checkin'); setViewProfile(null);} })
       ),
-    showHelp && React.createElement(HelpOverlay, { onClose: ()=>setShowHelp(false) })
+    showHelp && React.createElement(HelpOverlay, { onClose: ()=>setShowHelp(false) }),
+    React.createElement(ConsoleLogPanel)
   ));
 }

--- a/src/components/AdminScreen.jsx
+++ b/src/components/AdminScreen.jsx
@@ -5,6 +5,7 @@ import { Button } from './ui/button.js';
 import SectionTitle from './SectionTitle.jsx';
 import seedData from '../seedData.js';
 import { db, collection, getDocs, deleteDoc, updateDoc, doc, getDoc, query, where, storage, listAll, ref, getDownloadURL, deleteObject, messaging, setExtendedLogging, isExtendedLogging, useDoc } from '../firebase.js';
+import { setConsoleCapture, isConsoleCapture } from '../consoleLogs.js';
 import { advanceDay, resetDay, getTodayStr } from '../utils.js';
 import { getToken } from 'firebase/messaging';
 import { fcmReg } from '../swRegistration.js';
@@ -16,6 +17,7 @@ export default function AdminScreen({ onOpenStats, onOpenBugReports, onOpenMatch
   const { lang, setLang } = useLang();
   const t = useT();
   const [logEnabled, setLogEnabled] = useState(isExtendedLogging());
+  const [consoleEnabled, setConsoleEnabled] = useState(isConsoleCapture());
   const config = useDoc('config', 'app') || {};
   const invitesEnabled = config.premiumInvitesEnabled !== false;
   const showLevels = config.showLevels !== false;
@@ -25,6 +27,12 @@ export default function AdminScreen({ onOpenStats, onOpenBugReports, onOpenMatch
     const val = !logEnabled;
     setLogEnabled(val);
     setExtendedLogging(val);
+  };
+
+  const toggleConsole = () => {
+    const val = !consoleEnabled;
+    setConsoleEnabled(val);
+    setConsoleCapture(val);
   };
 
   const sendPush = async body => {
@@ -303,6 +311,10 @@ export default function AdminScreen({ onOpenStats, onOpenBugReports, onOpenMatch
     React.createElement('label', { className: 'flex items-center mb-2' },
       React.createElement('input', { type: 'checkbox', className: 'mr-2', checked: logEnabled, onChange: toggleLog }),
       'Udvidet logning'
+    ),
+    React.createElement('label', { className: 'flex items-center mb-2' },
+      React.createElement('input', { type: 'checkbox', className: 'mr-2', checked: consoleEnabled, onChange: toggleConsole }),
+      'Vis console log'
     ),
     React.createElement('label', { className: 'flex items-center mb-2' },
       React.createElement('input', {

--- a/src/components/ConsoleLogPanel.jsx
+++ b/src/components/ConsoleLogPanel.jsx
@@ -1,0 +1,21 @@
+import React, { useState, useEffect } from 'react';
+import { getLogs, addLogListener, removeLogListener, isConsoleCapture } from '../consoleLogs.js';
+
+export default function ConsoleLogPanel() {
+  const [logs, setLogs] = useState(getLogs());
+  useEffect(() => {
+    const handler = l => setLogs(l);
+    addLogListener(handler);
+    return () => removeLogListener(handler);
+  }, []);
+  if (!isConsoleCapture()) return null;
+  return React.createElement('div', {
+      className: 'fixed left-0 right-0 bottom-0 max-h-40 overflow-y-auto bg-black text-white text-xs p-2 z-50 opacity-80'
+    },
+    logs.map((l, i) =>
+      React.createElement('div', { key: i, className: l.type === 'error' ? 'text-red-400' : '' },
+        `[${l.timestamp.split('T')[1].slice(0,8)}] ${l.msg}`
+      )
+    )
+  );
+}

--- a/src/consoleLogs.js
+++ b/src/consoleLogs.js
@@ -1,0 +1,62 @@
+let capture = false;
+if (typeof window !== 'undefined') {
+  capture = localStorage.getItem('consoleCapture') === 'true';
+}
+
+const listeners = [];
+const logs = [];
+const MAX = 100;
+
+function notify() {
+  listeners.forEach(l => l([...logs]));
+}
+
+function add(type, args) {
+  if (!capture) return;
+  const msg = args.map(a => {
+    if (typeof a === 'object') {
+      try {
+        return JSON.stringify(a);
+      } catch {
+        return String(a);
+      }
+    }
+    return String(a);
+  }).join(' ');
+  logs.push({ type, msg, timestamp: new Date().toISOString() });
+  if (logs.length > MAX) logs.shift();
+  notify();
+}
+
+const origLog = console.log;
+const origError = console.error;
+console.log = (...args) => { add('log', args); origLog(...args); };
+console.error = (...args) => { add('error', args); origError(...args); };
+
+export function getLogs() {
+  return [...logs];
+}
+
+export function addLogListener(fn) {
+  listeners.push(fn);
+}
+
+export function removeLogListener(fn) {
+  const i = listeners.indexOf(fn);
+  if (i >= 0) listeners.splice(i, 1);
+}
+
+export function setConsoleCapture(val) {
+  capture = val;
+  if (typeof window !== 'undefined') {
+    localStorage.setItem('consoleCapture', val ? 'true' : 'false');
+  }
+  if (!val) {
+    logs.length = 0;
+    notify();
+  }
+}
+
+export function isConsoleCapture() {
+  return capture;
+}

--- a/src/index.js
+++ b/src/index.js
@@ -1,5 +1,6 @@
 import React from 'react';
 import ReactDOM from 'react-dom';
+import './consoleLogs.js';
 import VideotpushApp from './VideotpushApp.jsx';
 import { setFcmReg } from './swRegistration.js';
 import { firebaseConfig, logEvent } from './firebase.js';


### PR DESCRIPTION
## Summary
- collect console output in `consoleLogs.js`
- display captured logs on page with `ConsoleLogPanel`
- toggle log overlay visibility from admin screen
- enable log capture through new import in `index.js`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_688468ca1d58832dbc60e6a278f127e1