### PR TITLE
Fix tester guide not included in build

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "start": "npx serve .",
     "dev": "parcel public/index.html",
     "prebuild": "node scripts/bump-version.js",
-    "build": "parcel build public/index.html public/invite.html --dist-dir dist --public-url ./",
+    "build": "parcel build public/index.html public/invite.html public/testers.html --dist-dir dist --public-url ./",
     "test": "jest",
     "screenshots": "node scripts/capture-screens.js"
   },


### PR DESCRIPTION
## Summary
- ensure testers guide page is bundled by Parcel

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68847588d544832dbe73ada540fd0c53