### PR TITLE
Add close option for console log overlay

### DIFF
--- a/src/components/ConsoleLogPanel.jsx
+++ b/src/components/ConsoleLogPanel.jsx
@@ -3,15 +3,34 @@ import { getLogs, addLogListener, removeLogListener, isConsoleCapture } from '..
 
 export default function ConsoleLogPanel() {
   const [logs, setLogs] = useState(getLogs());
+  const [visible, setVisible] = useState(() => {
+    if (typeof window !== 'undefined') {
+      return localStorage.getItem('consolePanelVisible') !== 'false';
+    }
+    return true;
+  });
+
   useEffect(() => {
     const handler = l => setLogs(l);
     addLogListener(handler);
     return () => removeLogListener(handler);
   }, []);
-  if (!isConsoleCapture()) return null;
+
+  useEffect(() => {
+    if (typeof window !== 'undefined') {
+      localStorage.setItem('consolePanelVisible', visible ? 'true' : 'false');
+    }
+  }, [visible]);
+
+  if (!isConsoleCapture() || !visible) return null;
+
   return React.createElement('div', {
       className: 'fixed left-0 right-0 bottom-0 max-h-40 overflow-y-auto bg-black text-white text-xs p-2 z-50 opacity-80'
     },
+    React.createElement('button', {
+      className: 'absolute right-1 top-1 text-white',
+      onClick: () => setVisible(false)
+    }, '✕'),
     logs.map((l, i) =>
       React.createElement('div', { key: i, className: l.type === 'error' ? 'text-red-400' : '' },
         `[${l.timestamp.split('T')[1].slice(0,8)}] ${l.msg}`


### PR DESCRIPTION
## Summary
- allow ConsoleLogPanel to be dismissed

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_68847615c648832d8a2031fe1729be4c