### PR TITLE
Fix service worker registration path

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -9,7 +9,9 @@ ReactDOM.render(React.createElement(VideotpushApp), document.getElementById('roo
 
 if ('serviceWorker' in navigator) {
   window.addEventListener('load', async () => {
-    const swUrl = new URL('../public/service-worker.js', import.meta.url);
+    // The build outputs the service worker next to the bundled JS
+    // so use a relative path without the "public" folder.
+    const swUrl = new URL('./service-worker.js', import.meta.url);
     const baseScope = new URL('../', swUrl).pathname;
     // Register the main service worker generated in the production build
     await navigator.serviceWorker


### PR DESCRIPTION
## Summary
- ensure service worker path matches built output

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6884b7c40bb8832d8f9252882d4e42f6