### PR TITLE
Fix service worker path for Parcel

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -9,9 +9,9 @@ ReactDOM.render(React.createElement(VideotpushApp), document.getElementById('roo
 
 if ('serviceWorker' in navigator) {
   window.addEventListener('load', async () => {
-    // The build outputs the service worker next to the bundled JS
-    // so use a relative path without the "public" folder.
-    const swUrl = new URL('./service-worker.js', import.meta.url);
+    // The service worker file lives in the public folder. Use a
+    // relative path so Parcel can locate it during the build.
+    const swUrl = new URL('../public/service-worker.js', import.meta.url);
     const baseScope = new URL('../', swUrl).pathname;
     // Register the main service worker generated in the production build
     await navigator.serviceWorker


### PR DESCRIPTION
## Summary
- use correct path to `service-worker.js` in `src/index.js`

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6884eb7b3a3c832db6891b027ad58279