### PR TITLE
Fix local video stopping when participant disconnects

### DIFF
--- a/src/components/RealettenCallScreen.jsx
+++ b/src/components/RealettenCallScreen.jsx
@@ -159,7 +159,6 @@ export default function RealettenCallScreen({ interest, userId, onEnd }) {
       const data = pcsRef.current[uid];
       if (!data) return;
       const { pc, unsubOff, unsubAns, callDoc, offerCandidates, answerCandidates } = data;
-      pc.getSenders().forEach(s => s.track && s.track.stop());
       pc.close();
       unsubOff && unsubOff();
       unsubAns && unsubAns();


### PR DESCRIPTION
## Summary
- ensure Realetten group call cleanup doesn't stop local stream tracks

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6884fbfbe43c832da5059e2bdc291d61