### PR TITLE
Add admin listing for group calls

### DIFF
--- a/src/VideotpushApp.jsx
+++ b/src/VideotpushApp.jsx
@@ -15,6 +15,7 @@ import BugReportsScreen from './components/BugReportsScreen.jsx';
 import MatchLogScreen from './components/MatchLogScreen.jsx';
 import ScoreLogScreen from './components/ScoreLogScreen.jsx';
 import ActiveCallsScreen from './components/ActiveCallsScreen.jsx';
+import ActiveGroupCallsScreen from './components/ActiveGroupCallsScreen.jsx';
 import ReportedContentScreen from './components/ReportedContentScreen.jsx';
 import AboutScreen from './components/AboutScreen.jsx';
 import FunctionTestScreen from './components/FunctionTestScreen.jsx';
@@ -279,11 +280,12 @@ export default function VideotpushApp() {
             taskTrigger: taskClicks
           }),
           tab==='likes' && React.createElement(LikesScreen, { userId, onBack: ()=>setTab('discovery'), onSelectProfile: selectProfile }),
-          tab==='admin' && React.createElement(AdminScreen, { onOpenStats: ()=>setTab('stats'), onOpenBugReports: ()=>setTab('bugs'), onOpenMatchLog: ()=>setTab('matchlog'), onOpenScoreLog: ()=>setTab('scorelog'), onOpenReports: ()=>setTab('reports'), onOpenCallLog: ()=>setTab('calllog'), onOpenFunctionTest: ()=>setTab('functiontest'), onOpenRevealTest: ()=>setTab('revealtest'), onOpenTextLog: ()=>setTab('textlog'), onOpenTextPieces: ()=>setTab('textpieces'), onOpenUserLog: ()=>setTab('trackuser'), onOpenServerLog: ()=>setTab('serverlog'), onOpenRecentLogins: ()=>setTab('recentlogins'), profiles, userId, onSwitchProfile: id=>{ setUserId(id); setLoginMethod('admin'); }, onSaveUserLogout: saveUserAndLogout }),
+          tab==='admin' && React.createElement(AdminScreen, { onOpenStats: ()=>setTab('stats'), onOpenBugReports: ()=>setTab('bugs'), onOpenMatchLog: ()=>setTab('matchlog'), onOpenScoreLog: ()=>setTab('scorelog'), onOpenReports: ()=>setTab('reports'), onOpenCallLog: ()=>setTab('calllog'), onOpenGroupCallLog: ()=>setTab('groupcalllog'), onOpenFunctionTest: ()=>setTab('functiontest'), onOpenRevealTest: ()=>setTab('revealtest'), onOpenTextLog: ()=>setTab('textlog'), onOpenTextPieces: ()=>setTab('textpieces'), onOpenUserLog: ()=>setTab('trackuser'), onOpenServerLog: ()=>setTab('serverlog'), onOpenRecentLogins: ()=>setTab('recentlogins'), profiles, userId, onSwitchProfile: id=>{ setUserId(id); setLoginMethod('admin'); }, onSaveUserLogout: saveUserAndLogout }),
           tab==='stats' && React.createElement(StatsScreen, { onBack: ()=>setTab('admin') }),
           tab==='matchlog' && React.createElement(MatchLogScreen, { onBack: ()=>setTab('admin') }),
           tab==='scorelog' && React.createElement(ScoreLogScreen, { onBack: ()=>setTab('admin') }),
           tab==='calllog' && React.createElement(ActiveCallsScreen, { onBack: ()=>setTab('admin') }),
+          tab==='groupcalllog' && React.createElement(ActiveGroupCallsScreen, { onBack: ()=>setTab('admin') }),
           tab==='reports' && React.createElement(ReportedContentScreen, { onBack: ()=>setTab('admin') }),
           tab==='bugs' && React.createElement(BugReportsScreen, { onBack: ()=>setTab('admin') }),
           tab==='functiontest' && React.createElement(FunctionTestScreen, { onBack: ()=>setTab('admin') }),

--- a/src/components/ActiveGroupCallsScreen.jsx
+++ b/src/components/ActiveGroupCallsScreen.jsx
@@ -1,0 +1,39 @@
+import React from 'react';
+import { Card } from './ui/card.js';
+import { Button } from './ui/button.js';
+import SectionTitle from './SectionTitle.jsx';
+import { useCollection } from '../firebase.js';
+import { useT } from '../i18n.js';
+
+export default function ActiveGroupCallsScreen({ onBack }) {
+  const groups = useCollection('realetten');
+  const profiles = useCollection('profiles');
+  const t = useT();
+
+  const profileMap = Object.fromEntries(profiles.map(p => [p.id, p]));
+
+  const formatName = id => profileMap[id]?.name || id;
+
+  const activeGroups = groups.filter(g => (g.participants || []).length);
+  const sortedGroups = [...activeGroups].sort((a,b)=> (b.participants?.length||0) - (a.participants?.length||0));
+
+  return React.createElement(Card, { className: 'p-6 m-4 shadow-xl bg-white/90' },
+    React.createElement(SectionTitle, {
+      title: t('groupCallsTitle'),
+      colorClass: 'text-blue-600',
+      action: React.createElement(Button, { onClick: onBack }, t('back'))
+    }),
+    sortedGroups.length ? (
+      React.createElement('ul', { className: 'space-y-4 mt-4 overflow-y-auto max-h-[70vh]' },
+        sortedGroups.map(g => (
+          React.createElement('li', { key: g.id, className: 'border p-2 rounded' },
+            React.createElement('div', { className: 'font-bold' }, g.interest || g.id),
+            React.createElement('div', { className: 'mt-2 text-sm' }, (g.participants || []).map(formatName).join(', '))
+          )
+        ))
+      )
+    ) : (
+      React.createElement('p', { className: 'text-center mt-4 text-gray-500' }, 'Ingen aktive opkald')
+    )
+  );
+}

--- a/src/components/AdminScreen.jsx
+++ b/src/components/AdminScreen.jsx
@@ -13,7 +13,7 @@ import { fcmReg } from '../swRegistration.js';
 import { triggerHaptic } from '../haptics.js';
 
 
-export default function AdminScreen({ onOpenStats, onOpenBugReports, onOpenMatchLog, onOpenScoreLog, onOpenReports, onOpenCallLog, onOpenFunctionTest, onOpenRevealTest, onOpenTextLog, onOpenTextPieces, onOpenUserLog, onOpenServerLog, onOpenRecentLogins, profiles = [], userId, onSwitchProfile, onSaveUserLogout }) {
+export default function AdminScreen({ onOpenStats, onOpenBugReports, onOpenMatchLog, onOpenScoreLog, onOpenReports, onOpenCallLog, onOpenGroupCallLog, onOpenFunctionTest, onOpenRevealTest, onOpenTextLog, onOpenTextPieces, onOpenUserLog, onOpenServerLog, onOpenRecentLogins, profiles = [], userId, onSwitchProfile, onSaveUserLogout }) {
 
   const { lang, setLang } = useLang();
   const t = useT();
@@ -362,7 +362,8 @@ export default function AdminScreen({ onOpenStats, onOpenBugReports, onOpenMatch
     React.createElement(Button, { className: 'mt-2 bg-blue-500 text-white px-4 py-2 rounded', onClick: showPushInfo }, 'Show push info'),
     React.createElement(Button, { className: 'mt-2 bg-blue-500 text-white px-4 py-2 rounded', onClick: checkAuthAccess }, 'Check Firebase Auth'),
     React.createElement(Button, { className: 'mt-2 bg-blue-500 text-white px-4 py-2 rounded', onClick: onOpenServerLog }, 'Server log'),
-    React.createElement(Button, { className: 'mt-2 bg-blue-500 text-white px-4 py-2 rounded', onClick: onOpenCallLog }, 'Se aktive opkald')
+    React.createElement(Button, { className: 'mt-2 bg-blue-500 text-white px-4 py-2 rounded', onClick: onOpenCallLog }, 'Se aktive opkald'),
+    React.createElement(Button, { className: 'mt-2 bg-blue-500 text-white px-4 py-2 rounded', onClick: onOpenGroupCallLog }, 'Se gruppeopkald')
   ),
     showBugReport && React.createElement(BugReportOverlay, { onClose: () => setShowBugReport(false) })
   );

--- a/src/i18n.js
+++ b/src/i18n.js
@@ -169,6 +169,7 @@ inviteAccepted:{ en:"Profile created", da:"Oprettet", sv:"Skapad", es:"Perfil cr
   premiumTitle:{ en:'Premium', da:'Premium', sv:'Premium', es:'Premium', fr:'Premium', de:'Premium' },
   revealTestTitle:{ en:'Reveal test', da:'Reveal test', sv:'Reveal test', es:'Prueba de revelaci\u00f3n', fr:'Test de r\u00e9v\u00e9lation', de:'Reveal-Test' },
   activeCallsTitle:{ en:'Active calls', da:'Aktive opkald', sv:'Aktiva samtal', es:'Llamadas activas', fr:'Appels actifs', de:'Aktive Anrufe' },
+  groupCallsTitle:{ en:'Group calls', da:'Gruppeopkald', sv:'Gruppsamtal', es:'Llamadas grupales', fr:'Appels de groupe', de:'Gruppenanrufe' },
   bugReportsTitle:{ en:'Bug reports', da:'Fejlmeldinger', sv:'Buggrapporter', es:'Informes de errores', fr:'Rapports de bugs', de:'Fehlermeldungen' },
   matchLogTitle:{ en:'Match log', da:'Matchlog', sv:'Matchlogg', es:'Registro de coincidencias', fr:'Journal des correspondances', de:'Matchprotokoll' },
   serverLogTitle:{ en:'Server log', da:'Server log', sv:'Serverlogg', es:'Registro del servidor', fr:'Journal du serveur', de:'Serverprotokoll' },


### PR DESCRIPTION
## Summary
- show group calls on admin page via new button
- list active Realetten sessions

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_688513fa2bb4832d94f5faa1b4b03bd4