### PR TITLE
Add video calls title in AdminScreen

### DIFF
--- a/src/components/AdminScreen.jsx
+++ b/src/components/AdminScreen.jsx
@@ -362,6 +362,7 @@ export default function AdminScreen({ onOpenStats, onOpenBugReports, onOpenMatch
     React.createElement(Button, { className: 'mt-2 bg-blue-500 text-white px-4 py-2 rounded', onClick: showPushInfo }, 'Show push info'),
     React.createElement(Button, { className: 'mt-2 bg-blue-500 text-white px-4 py-2 rounded', onClick: checkAuthAccess }, 'Check Firebase Auth'),
     React.createElement(Button, { className: 'mt-2 bg-blue-500 text-white px-4 py-2 rounded', onClick: onOpenServerLog }, 'Server log'),
+    React.createElement('h3', { className: 'text-xl font-semibold mb-2 mt-4 text-blue-600' }, t('videoCallsTitle')),
     React.createElement(Button, { className: 'mt-2 bg-blue-500 text-white px-4 py-2 rounded', onClick: onOpenCallLog }, 'Se aktive opkald'),
     React.createElement(Button, { className: 'mt-2 bg-blue-500 text-white px-4 py-2 rounded', onClick: onOpenGroupCallLog }, 'Se gruppeopkald')
   ),

--- a/src/i18n.js
+++ b/src/i18n.js
@@ -168,6 +168,7 @@ inviteAccepted:{ en:"Profile created", da:"Oprettet", sv:"Skapad", es:"Perfil cr
   adminPush:{ en:'Push notifications', da:'Push notifications', sv:'Pushnotiser', es:'Notificaciones push', fr:'Notifications push', de:'Push-Benachrichtigungen' },
   premiumTitle:{ en:'Premium', da:'Premium', sv:'Premium', es:'Premium', fr:'Premium', de:'Premium' },
   revealTestTitle:{ en:'Reveal test', da:'Reveal test', sv:'Reveal test', es:'Prueba de revelaci\u00f3n', fr:'Test de r\u00e9v\u00e9lation', de:'Reveal-Test' },
+  videoCallsTitle:{ en:'Video calls', da:'Videoopkald', sv:'Videosamtal', es:'Llamadas de video', fr:'Appels vidéo', de:'Videoanrufe' },
   activeCallsTitle:{ en:'Active calls', da:'Aktive opkald', sv:'Aktiva samtal', es:'Llamadas activas', fr:'Appels actifs', de:'Aktive Anrufe' },
   groupCallsTitle:{ en:'Group calls', da:'Gruppeopkald', sv:'Gruppsamtal', es:'Llamadas grupales', fr:'Appels de groupe', de:'Gruppenanrufe' },
   bugReportsTitle:{ en:'Bug reports', da:'Fejlmeldinger', sv:'Buggrapporter', es:'Informes de errores', fr:'Rapports de bugs', de:'Fehlermeldungen' },


### PR DESCRIPTION
## Summary
- translate common title for video call logs
- show "Video calls" heading above Active/Group call buttons in AdminScreen

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68853881131c832dafa3878784150380