### PR TITLE
Fix invite limit enforcement

### DIFF
--- a/src/components/InviteOverlay.jsx
+++ b/src/components/InviteOverlay.jsx
@@ -37,8 +37,10 @@ export default function InviteOverlay({ userId, onClose }) {
   };
 
   useEffect(() => {
+    if (inviteId) return;
+    if (invitesEnabled && remaining <= 0) return;
     createInvite();
-  }, []);
+  }, [inviteId, invitesEnabled, remaining]);
 
   useEffect(() => {
     if (!inviteId) return;
@@ -89,6 +91,7 @@ export default function InviteOverlay({ userId, onClose }) {
     }
   };
 
+  const noInvites = invitesEnabled && remaining <= 0;
   const text = invitesEnabled
     ? (remaining > 0
         ? `Tilbyd 3 måneders gratis premium. Du har ${remaining} tilbage`
@@ -104,9 +107,10 @@ export default function InviteOverlay({ userId, onClose }) {
         placeholder: t('firstName'),
         className: 'border p-2 rounded w-full mb-2',
         value: recipient,
-        onChange: e => setRecipient(e.target.value)
+        onChange: e => setRecipient(e.target.value),
+        disabled: noInvites
       }),
-      React.createElement('input', { type: 'text', readOnly: true, className: 'border p-2 rounded w-full mb-2', value: link }),
+      React.createElement('input', { type: 'text', readOnly: true, className: 'border p-2 rounded w-full mb-2', value: link, disabled: noInvites }),
       invites.length > 0 && React.createElement('div', { className:'mb-4' },
         React.createElement('h3', { className:'font-semibold text-sm mb-1' }, t('inviteList')),
         React.createElement('ul', { className:'text-sm space-y-1' },
@@ -116,8 +120,8 @@ export default function InviteOverlay({ userId, onClose }) {
           ))
         )
       ),
-      React.createElement(Button, { className: 'w-full bg-pink-500 text-white mb-2', onClick: share }, t('share')),
-      React.createElement(Button, { className: 'w-full', onClick: copy }, t('copyLink')),
+      React.createElement(Button, { className: 'w-full bg-pink-500 text-white mb-2', onClick: share, disabled: noInvites }, t('share')),
+      React.createElement(Button, { className: 'w-full', onClick: copy, disabled: noInvites }, t('copyLink')),
       React.createElement(Button, { className: 'w-full mt-2', onClick: onClose }, t('cancel'))
     )
   );


### PR DESCRIPTION
## Summary
- stop creating new premium invites after reaching the limit
- hide sharing options when no premium invitations remain

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68845b31cb10832db32703d545273009