### PR TITLE
Fix birthday picker overlay

### DIFF
--- a/src/components/ProfileSettings.jsx
+++ b/src/components/ProfileSettings.jsx
@@ -31,6 +31,7 @@ export default function ProfileSettings({ userId, ageRange, onChangeAgeRange, pu
   const videoSectionRef = useRef();
   const audioSectionRef = useRef();
   const aboutSectionRef = useRef();
+  const prevBirthdayRef = useRef('');
 
   const [showSnapRecorder, setShowSnapRecorder] = useState(false);
   const [showSnapVideoRecorder, setShowSnapVideoRecorder] = useState(false);
@@ -255,15 +256,24 @@ export default function ProfileSettings({ userId, ageRange, onChangeAgeRange, pu
     await updateDoc(doc(db,'profiles',userId), { name });
   };
 
-  const handleBirthdayChange = async e => {
+  const handleBirthdayChange = e => {
     const birthday = e.target.value;
-    if(birthday && getAge(birthday) < 18){
+    setProfile({ ...profile, birthday });
+  };
+
+  const handleBirthdayFocus = () => {
+    prevBirthdayRef.current = profile.birthday || '';
+  };
+
+  const handleBirthdayBlur = async e => {
+    const birthday = e.target.value;
+    if (birthday && getAge(birthday) < 18) {
       alert('Du skal v\u00e6re mindst 18 \u00e5r for at bruge appen');
+      setProfile({ ...profile, birthday: prevBirthdayRef.current });
       return;
     }
-    setProfile({ ...profile, birthday });
     const age = birthday ? getAge(birthday) : '';
-    await updateDoc(doc(db,'profiles',userId), { birthday, age });
+    await updateDoc(doc(db, 'profiles', userId), { birthday, age });
   };
 
   const updateNotificationPref = (field, value) => {
@@ -587,6 +597,8 @@ export default function ProfileSettings({ userId, ageRange, onChangeAgeRange, pu
             type:'date',
             value: profile.birthday || '',
             onChange: handleBirthdayChange,
+            onFocus: handleBirthdayFocus,
+            onBlur: handleBirthdayBlur,
             className:'border p-2 rounded w-full',
             placeholder: t('chooseBirthday')
           }),

--- a/src/components/WelcomeScreen.jsx
+++ b/src/components/WelcomeScreen.jsx
@@ -23,6 +23,7 @@ export default function WelcomeScreen({ onLogin }) {
   const [gender, setGender] = useState('Kvinde');
   const [birthday, setBirthday] = useState('');
   const [showBirthdayOverlay, setShowBirthdayOverlay] = useState(false);
+  const prevBirthdayRef = useRef('');
   const [showMissingFields, setShowMissingFields] = useState(false);
   const [triedSubmit, setTriedSubmit] = useState(false);
   const [showAgeError, setShowAgeError] = useState(false);
@@ -45,9 +46,19 @@ export default function WelcomeScreen({ onLogin }) {
     onLogin('101', 'admin');
   };
 
+  const handleBirthdayChange = e => {
+    setBirthday(e.target.value);
+  };
+
+  const handleBirthdayFocus = () => {
+    prevBirthdayRef.current = birthday || '';
+    setShowBirthdayOverlay(true);
+  };
+
   const handleBirthdayBlur = () => {
     setShowBirthdayOverlay(false);
     if (birthday && getAge(birthday) < 18) {
+      setBirthday(prevBirthdayRef.current);
       setShowAgeError(true);
     }
   };
@@ -308,7 +319,7 @@ export default function WelcomeScreen({ onLogin }) {
         className: 'border p-2',
         ref: birthdayInputRef,
         value: birthday,
-        onChange: e => setBirthday(e.target.value),
+        onChange: handleBirthdayChange,
         autoFocus: true
       }),
       React.createElement(Button, {
@@ -372,8 +383,8 @@ export default function WelcomeScreen({ onLogin }) {
           type: 'date',
           className: `border p-2 mb-2 w-full ${triedSubmit && !birthday ? 'border-red-500' : ''}`,
           value: birthday,
-          onFocus: () => setShowBirthdayOverlay(true),
-          onChange: e => setBirthday(e.target.value),
+          onFocus: handleBirthdayFocus,
+          onChange: handleBirthdayChange,
           placeholder: 'F\u00f8dselsdag',
           required: true
         }),


### PR DESCRIPTION
## Summary
- prevent premature closing of the birthday picker in profile settings
- validate age only when the date input loses focus
- apply the same birthday picker logic when creating a user

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6884bb4cf92c832d9c4762a2a04cc99a