### PR TITLE
Implement automatic cleanup for empty realetten calls

### DIFF
--- a/src/components/RealettenCallScreen.jsx
+++ b/src/components/RealettenCallScreen.jsx
@@ -78,7 +78,16 @@ export default function RealettenCallScreen({ interest, userId, onEnd }) {
     });
     join();
     return () => {
-      updateDoc(ref, { participants: arrayRemove(userId) }).catch(()=>{});
+      (async () => {
+        try {
+          await updateDoc(ref, { participants: arrayRemove(userId) });
+          const snap = await getDoc(ref);
+          const data = snap.data() || {};
+          if (!snap.exists() || !(data.participants || []).length) {
+            await deleteDoc(ref);
+          }
+        } catch {}
+      })();
       unsub();
     };
   }, [interest, userId]);


### PR DESCRIPTION
## Summary
- delete the realetten group document when the participant list becomes empty

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6885194e94dc832db5efe66a2f248695