### PR TITLE
Update admin roles styling

### DIFF
--- a/src/components/AdminScreen.jsx
+++ b/src/components/AdminScreen.jsx
@@ -270,7 +270,7 @@ export default function AdminScreen({ onOpenStats, onOpenBugReports, onOpenMatch
     ),
 
   // Daily admin section
-  React.createElement('h3', { className: 'text-xl font-semibold mb-2 mt-4 text-blue-600' }, t('adminDaily')),
+  React.createElement('h3', { className: 'text-xl font-semibold mb-2 mt-4 text-pink-600' }, t('adminDaily')),
     React.createElement(Button, { className: 'mt-2 bg-blue-500 text-white px-4 py-2 rounded', onClick: onOpenReports }, 'Se anmeldt indhold'),
     React.createElement('div', { className: 'mt-2' },
       React.createElement(Button, {
@@ -287,12 +287,12 @@ export default function AdminScreen({ onOpenStats, onOpenBugReports, onOpenMatch
     ),
 
   // Business section
-  React.createElement('h3', { className: 'text-xl font-semibold mb-2 mt-4 text-blue-600' }, t('adminBusiness')),
+  React.createElement('h3', { className: 'text-xl font-semibold mb-2 mt-4 text-pink-600' }, t('adminBusiness')),
     React.createElement(Button, { className: 'mt-2 bg-blue-500 text-white px-4 py-2 rounded', onClick: onOpenStats }, 'Vis statistik'),
     React.createElement(Button, { className: 'mt-2 bg-blue-500 text-white px-4 py-2 rounded', onClick: onOpenRecentLogins }, 'Se seneste logins'),
 
   // Tester section
-  React.createElement('h3', { className: 'text-xl font-semibold mb-2 mt-4 text-blue-600' }, t('adminTesters')),
+  React.createElement('h3', { className: 'text-xl font-semibold mb-2 mt-4 text-pink-600' }, t('adminTesters')),
     React.createElement('p', { className: 'mb-2' }, 'Dagens dato: ' + getTodayStr()),
     React.createElement('div', { className: 'flex gap-2 mb-4' },
       React.createElement(Button, {
@@ -304,24 +304,24 @@ export default function AdminScreen({ onOpenStats, onOpenBugReports, onOpenMatch
         onClick: () => { resetDay(); location.reload(); }
       }, 'Reset dag')
     ),
-    React.createElement('h3', { className: 'text-xl font-semibold mb-2 text-blue-600' }, t('adminBugReports')),
+    React.createElement('h4', { className: 'text-lg font-semibold mb-2 text-blue-600' }, t('adminBugReports')),
     React.createElement(Button, { className: 'mt-2 bg-blue-500 text-white px-4 py-2 rounded', onClick: onOpenBugReports }, 'Se alle fejlmeldinger'),
     React.createElement(Button, { className: 'mt-2 bg-pink-500 text-white px-4 py-2 rounded', onClick: () => setShowBugReport(true) }, 'Fejlmeld'),
-    React.createElement('h3', { className: 'text-xl font-semibold mb-2 mt-4 text-blue-600' }, t('adminDatabase')),
+    React.createElement('h4', { className: 'text-lg font-semibold mb-2 mt-4 text-blue-600' }, t('adminDatabase')),
     React.createElement(Button, { className: 'mt-2 bg-red-500 text-white px-4 py-2 rounded', onClick: resetAllCandidates }, 'Reset all candidates'),
-    React.createElement('h3', { className: 'text-xl font-semibold mb-2 mt-4 text-blue-600' }, t('adminHaptics')),
+    React.createElement('h4', { className: 'text-lg font-semibold mb-2 mt-4 text-blue-600' }, t('adminHaptics')),
     React.createElement(Button, { className: 'mt-2 bg-blue-500 text-white px-4 py-2 rounded', onClick: testHaptic }, 'Test haptisk feedback'),
-    React.createElement('h3', { className: 'text-xl font-semibold mb-2 mt-4 text-blue-600' }, t('adminFunctionTest')),
+    React.createElement('h4', { className: 'text-lg font-semibold mb-2 mt-4 text-blue-600' }, t('adminFunctionTest')),
     React.createElement(Button, { className: 'mt-2 bg-blue-500 text-white px-4 py-2 rounded', onClick: onOpenFunctionTest }, 'Åbn funktionstest'),
-    React.createElement('h3', { className: 'text-xl font-semibold mb-2 mt-4 text-blue-600' }, t('adminRevealTest')),
+    React.createElement('h4', { className: 'text-lg font-semibold mb-2 mt-4 text-blue-600' }, t('adminRevealTest')),
     React.createElement(Button, { className: 'mt-2 bg-blue-500 text-white px-4 py-2 rounded', onClick: onOpenRevealTest }, 'Åbn reveal test'),
 
   // Developer section
-  React.createElement('h3', { className: 'text-xl font-semibold mb-2 mt-4 text-blue-600' }, t('adminDevelopers')),
+  React.createElement('h3', { className: 'text-xl font-semibold mb-2 mt-4 text-pink-600' }, t('adminDevelopers')),
     React.createElement('h4', { className: 'text-lg font-semibold mb-2 text-blue-600' }, t('adminDatabase')),
     React.createElement(Button, { className: 'mt-2 bg-blue-500 text-white px-4 py-2 rounded', onClick: () => seedData().then(() => alert('Databasen er nulstillet')) }, 'Reset database'),
     React.createElement(Button, { className: 'mt-2 bg-blue-500 text-white px-4 py-2 rounded', onClick: recoverMissing }, 'Hent mistet fra DB'),
-    React.createElement('h3', { className: 'text-xl font-semibold mb-2 text-blue-600' }, t('adminPush')),
+    React.createElement('h4', { className: 'text-lg font-semibold mb-2 text-blue-600' }, t('adminPush')),
     React.createElement(Button, { className: 'mt-2 bg-blue-500 text-white px-4 py-2 rounded mr-2', onClick: () => sendPush('Dagens klip er klar') }, 'Dagens klip er klar'),
     React.createElement(Button, { className: 'mt-2 bg-blue-500 text-white px-4 py-2 rounded mr-2', onClick: () => sendPush('Du har et match. Start samtalen') }, 'Du har et match. Start samtalen'),
     React.createElement(Button, { className: 'mt-2 bg-blue-500 text-white px-4 py-2 rounded', onClick: logClientToken }, 'Log client token'),
@@ -330,7 +330,7 @@ export default function AdminScreen({ onOpenStats, onOpenBugReports, onOpenMatch
     React.createElement(Button, { className: 'mt-2 bg-blue-500 text-white px-4 py-2 rounded', onClick: showPushInfo }, 'Show push info'),
     React.createElement(Button, { className: 'mt-2 bg-blue-500 text-white px-4 py-2 rounded', onClick: checkAuthAccess }, 'Check Firebase Auth'),
     React.createElement(Button, { className: 'mt-2 bg-blue-500 text-white px-4 py-2 rounded', onClick: onOpenServerLog }, 'Server log'),
-    React.createElement('h3', { className: 'text-xl font-semibold mb-2 mt-4 text-blue-600' }, t('adminLogging')),
+    React.createElement('h4', { className: 'text-lg font-semibold mb-2 mt-4 text-blue-600' }, t('adminLogging')),
     React.createElement('label', { className: 'flex items-center mb-2' },
       React.createElement('input', { type: 'checkbox', className: 'mr-2', checked: logEnabled, onChange: toggleLog }),
       'Udvidet logning'
@@ -362,7 +362,7 @@ export default function AdminScreen({ onOpenStats, onOpenBugReports, onOpenMatch
     React.createElement(Button, { className: 'mt-2 bg-blue-500 text-white px-4 py-2 rounded', onClick: onOpenScoreLog }, 'Se score log'),
     React.createElement(Button, { className: 'mt-2 bg-blue-500 text-white px-4 py-2 rounded', onClick: onOpenUserLog }, 'Følg bruger'),
     React.createElement(Button, { className: 'mt-2 bg-blue-500 text-white px-4 py-2 rounded', onClick: onOpenTextPieces }, 'Alle tekststykker'),
-    React.createElement('h3', { className: 'text-xl font-semibold mb-2 mt-4 text-blue-600' }, t('videoCallsTitle')),
+    React.createElement('h4', { className: 'text-lg font-semibold mb-2 mt-4 text-blue-600' }, t('videoCallsTitle')),
     React.createElement(Button, { className: 'mt-2 bg-blue-500 text-white px-4 py-2 rounded', onClick: onOpenCallLog }, 'Se aktive opkald'),
     React.createElement(Button, { className: 'mt-2 bg-blue-500 text-white px-4 py-2 rounded', onClick: onOpenGroupCallLog }, 'Se gruppeopkald')
   ),


### PR DESCRIPTION
## Summary
- make primary admin roles stand out with h3 in pink
- convert other admin subtitles to h4 and keep blue color

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6885a8323960832db6f7e30a4d06d093