### PR TITLE
Simplify birthday input

### DIFF
--- a/src/__tests__/WelcomeScreen.test.js
+++ b/src/__tests__/WelcomeScreen.test.js
@@ -65,7 +65,7 @@ test('shows age error when user is under 18', async () => {
   await userEvent.type(screen.getByPlaceholderText('you@example.com'), 'a@test.com');
   await userEvent.type(screen.getByPlaceholderText('username'), 'alice');
   await userEvent.type(screen.getByPlaceholderText('********'), 'pass123');
-  await userEvent.type(screen.getByPlaceholderText('F\u00f8dselsdag'), '2010-01-01');
+  await userEvent.type(screen.getByPlaceholderText('dd.mm.yyyy'), '01.01.2010');
   await userEvent.click(screen.getByRole('button', { name: 'Create profile' }));
   expect(await screen.findByText(/mindst 18 \u00e5r/)).toBeInTheDocument();
 });
@@ -86,9 +86,7 @@ test('calls Firebase and onLogin when registration succeeds', async () => {
   await userEvent.click(screen.getByRole('button', { name: 'Create profile' }));
   await userEvent.type(screen.getByPlaceholderText('Fornavn'), 'Bob');
   await userEvent.type(screen.getByPlaceholderText('By'), 'Town');
-  await userEvent.type(screen.getByPlaceholderText('F\u00f8dselsdag'), '1990-01-01');
-  // Close birthday selector overlay
-  await userEvent.click(screen.getByText('Luk'));
+  await userEvent.type(screen.getByPlaceholderText('dd.mm.yyyy'), '01.01.1990');
   await userEvent.type(screen.getByPlaceholderText('you@example.com'), 'bob@test.com');
   await userEvent.type(screen.getByPlaceholderText('username'), 'bob');
   await userEvent.type(screen.getByPlaceholderText('********'), 'secret');

--- a/src/components/WelcomeScreen.jsx
+++ b/src/components/WelcomeScreen.jsx
@@ -1,4 +1,4 @@
-import React, { useState, useRef, useEffect } from 'react';
+import React, { useState } from 'react';
 import { Card } from './ui/card.js';
 import { Button } from './ui/button.js';
 import { Input } from './ui/input.js';
@@ -21,9 +21,8 @@ export default function WelcomeScreen({ onLogin }) {
   const [loginPass, setLoginPass] = useState('');
   const [loginError, setLoginError] = useState(false);
   const [gender, setGender] = useState('Kvinde');
+  const [birthdayInput, setBirthdayInput] = useState('');
   const [birthday, setBirthday] = useState('');
-  const [showBirthdayOverlay, setShowBirthdayOverlay] = useState(false);
-  const prevBirthdayRef = useRef('');
   const [showMissingFields, setShowMissingFields] = useState(false);
   const [triedSubmit, setTriedSubmit] = useState(false);
   const [showAgeError, setShowAgeError] = useState(false);
@@ -31,36 +30,25 @@ export default function WelcomeScreen({ onLogin }) {
   const [createdMsg, setCreatedMsg] = useState('');
   const [createdId, setCreatedId] = useState('');
   const [showForgot, setShowForgot] = useState(false);
-  const birthdayInputRef = useRef(null);
   const { lang } = useLang();
   const t = useT();
 
-  useEffect(() => {
-    if (showBirthdayOverlay) {
-      const input = birthdayInputRef.current;
-      if (input && input.showPicker) input.showPicker();
-    }
-  }, [showBirthdayOverlay]);
 
   const handleSkip = () => {
     onLogin('101', 'admin');
   };
 
+  const parseBirthday = str => {
+    const m = str.match(/^(\d{2})[.\/-](\d{2})[.\/-](\d{4})$/);
+    if (!m) return '';
+    return `${m[3]}-${m[2]}-${m[1]}`;
+  };
+
   const handleBirthdayChange = e => {
-    setBirthday(e.target.value);
-  };
-
-  const handleBirthdayFocus = () => {
-    prevBirthdayRef.current = birthday || '';
-    setShowBirthdayOverlay(true);
-  };
-
-  const handleBirthdayBlur = () => {
-    setShowBirthdayOverlay(false);
-    if (birthday && getAge(birthday) < 18) {
-      setBirthday(prevBirthdayRef.current);
-      setShowAgeError(true);
-    }
+    const val = e.target.value;
+    setBirthdayInput(val);
+    const iso = parseBirthday(val);
+    setBirthday(iso);
   };
 
   const handleLogin = async () => {
@@ -308,25 +296,6 @@ export default function WelcomeScreen({ onLogin }) {
   return React.createElement(
     React.Fragment,
     null,
-    showBirthdayOverlay && React.createElement('div', {
-      className: 'fixed inset-0 flex flex-col items-center justify-center bg-black/80 z-50'
-    },
-      React.createElement('h1', {
-        className: 'text-3xl font-bold text-pink-600 text-center mb-4 mt-10'
-      }, t('chooseBirthday')),
-      React.createElement(Input, {
-        type: 'date',
-        className: 'border p-2',
-        ref: birthdayInputRef,
-        value: birthday,
-        onChange: handleBirthdayChange,
-        autoFocus: true
-      }),
-      React.createElement(Button, {
-        className: 'mt-4 bg-pink-500 text-white px-4 py-2 rounded',
-        onClick: handleBirthdayBlur
-      }, 'Luk')
-    ),
     showMissingFields && React.createElement(InfoOverlay, {
       title: t('missingFieldsTitle'),
       onClose: () => setShowMissingFields(false)
@@ -380,12 +349,11 @@ export default function WelcomeScreen({ onLogin }) {
         }),
         React.createElement('label', { className:'block mb-1' }, t('birthday')),
         React.createElement(Input, {
-          type: 'date',
+          type: 'text',
           className: `border p-2 mb-2 w-full ${triedSubmit && !birthday ? 'border-red-500' : ''}`,
-          value: birthday,
-          onFocus: handleBirthdayFocus,
+          value: birthdayInput,
           onChange: handleBirthdayChange,
-          placeholder: 'F\u00f8dselsdag',
+          placeholder: 'dd.mm.yyyy',
           required: true
         }),
         React.createElement('label', { className:'block mb-1' }, t('email')),


### PR DESCRIPTION
## Summary
- remove birthday date picker overlay
- replace birthday picker with text input in `dd.mm.yyyy` format
- adjust tests for new input behavior

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6885a8c411f0832d820b42dd9dd85f11