### PR TITLE
Remove 'no invites left' popup

### DIFF
--- a/src/components/InviteOverlay.jsx
+++ b/src/components/InviteOverlay.jsx
@@ -98,15 +98,6 @@ export default function InviteOverlay({ userId, onClose }) {
         : 'Du har ikke flere premium invitationer')
     : t('inviteDesc');
 
-  if (invitesEnabled && remaining <= 0) {
-    return React.createElement('div', { className: 'fixed inset-0 z-50 bg-black/50 flex items-center justify-center' },
-      React.createElement(Card, { className: 'bg-white p-6 rounded shadow-xl max-w-sm w-full' },
-        React.createElement('h2', { className: 'text-xl font-semibold mb-4 text-pink-600 text-center' }, t('inviteFriend')),
-        React.createElement('p', { className: 'text-center text-sm mb-4' }, text),
-        React.createElement(Button, { className: 'w-full mt-2', onClick: onClose }, t('cancel'))
-      )
-    );
-  }
 
   return React.createElement('div', { className: 'fixed inset-0 z-50 bg-black/50 flex items-center justify-center' },
     React.createElement(Card, { className: 'bg-white p-6 rounded shadow-xl max-w-sm w-full' },


### PR DESCRIPTION
## Summary
- remove popup card displayed when no premium invites remain

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6885ab5bde98832d9ae788a0c191c189