### PR TITLE
Increase invite limit

### DIFF
--- a/docs/app-pages-da.md
+++ b/docs/app-pages-da.md
@@ -41,7 +41,7 @@
 
 ## Om RealDate
 - Fejlmelding med mulighed for vedhæftet skærmbillede.
-- Inviter op til fem venner og tilbyd gratis premium-abonnement. 
+- Inviter op til ti venner og tilbyd gratis premium-abonnement.
   Når en invitation er sendt, følges der med i, om brugeren opretter profil.
 
 ## Du er blevet liket

--- a/src/components/FunctionTestScreen.jsx
+++ b/src/components/FunctionTestScreen.jsx
@@ -265,7 +265,7 @@ const modules = [
         ]
       },
       {
-        title: 'Gift 3 months of premium with up to five invites',
+        title: 'Gift 3 months of premium with up to ten invites',
         expected: [
           'Premium gift enabled when invites are available',
           'Remaining gift count is displayed',

--- a/src/components/InviteOverlay.jsx
+++ b/src/components/InviteOverlay.jsx
@@ -12,7 +12,7 @@ export default function InviteOverlay({ userId, onClose }) {
   const invitesUsed = invites.filter(inv => inv.gift).length;
   const config = useDoc('config','app') || {};
   const invitesEnabled = config.premiumInvitesEnabled !== false;
-  const remaining = 5 - invitesUsed;
+  const remaining = 10 - invitesUsed;
   const [recipient, setRecipient] = useState('');
   const [link, setLink] = useState('');
   const [inviteId, setInviteId] = useState(null);

--- a/src/components/WelcomeScreen.jsx
+++ b/src/components/WelcomeScreen.jsx
@@ -149,7 +149,7 @@ export default function WelcomeScreen({ onLogin }) {
     if (giftFrom && inviteValid) {
       try {
         const inviterSnap = await getDoc(doc(db, 'profiles', giftFrom));
-        if (!inviterSnap.exists() || (inviterSnap.data().premiumInvitesUsed || 0) >= 5) {
+        if (!inviterSnap.exists() || (inviterSnap.data().premiumInvitesUsed || 0) >= 10) {
           giftFrom = null;
           inviteValid = false;
         }
@@ -242,7 +242,7 @@ export default function WelcomeScreen({ onLogin }) {
     if (giftFrom && inviteValid) {
       try {
         const inviterSnap = await getDoc(doc(db, 'profiles', giftFrom));
-        if (!inviterSnap.exists() || (inviterSnap.data().premiumInvitesUsed || 0) >= 5) {
+        if (!inviterSnap.exists() || (inviterSnap.data().premiumInvitesUsed || 0) >= 10) {
           giftFrom = null;
           inviteValid = false;
         }

--- a/src/i18n.js
+++ b/src/i18n.js
@@ -114,7 +114,7 @@ inviteAccepted:{ en:"Profile created", da:"Oprettet", sv:"Skapad", es:"Perfil cr
   helpTitle:{ en:'Help', da:'Hjælp', sv:'Hjälp', es:'Ayuda', fr:'Aide', de:'Hilfe' },
   helpLevels:{ en:'On the Daily Life page each profile has three levels. Watch clips to unlock more content.', da:'På siden Dagens liv har hver profil tre niveauer. Se klip for at låse mere op.' },
   helpSupport:{ en:'Need assistance? Choose "Report bug" on the About page to contact support.', da:'Brug for hjælp? Vælg \"Fejlmeld\" på Om RealDate-siden for at kontakte support.' },
-  helpInvites:{ en:'You can send up to five invitations. Follow each invitation until your friend has created a profile.', da:'Du kan sende op til fem invitationer. Følg hver invitation, indtil din ven har oprettet en profil.' },
+  helpInvites:{ en:'You can send up to ten invitations. Follow each invitation until your friend has created a profile.', da:'Du kan sende op til ti invitationer. Følg hver invitation, indtil din ven har oprettet en profil.' },
   dailyHelpLabel:{ en:'Need help?', da:'Need help?' },
   dailyHelpTitle:{ en:'Daily Clips Help', da:'Hjælp til Dagens klip' },
   dailyHelpText:{


### PR DESCRIPTION
## Summary
- allow 10 premium invites instead of 5
- update translations
- mention new limit in docs and testing screen

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6885b2cfe51c832da2389486444d72f4