### PR TITLE
Add birthday validation

### DIFF
--- a/src/__tests__/WelcomeScreen.test.js
+++ b/src/__tests__/WelcomeScreen.test.js
@@ -70,6 +70,19 @@ test('shows age error when user is under 18', async () => {
   expect(await screen.findByText(/mindst 18 \u00e5r/)).toBeInTheDocument();
 });
 
+test('shows birthday format error when date is invalid', async () => {
+  renderWelcome();
+  await userEvent.click(screen.getByRole('button', { name: 'Create profile' }));
+  await userEvent.type(screen.getByPlaceholderText('Fornavn'), 'Alice');
+  await userEvent.type(screen.getByPlaceholderText('By'), 'City');
+  await userEvent.type(screen.getByPlaceholderText('you@example.com'), 'a@test.com');
+  await userEvent.type(screen.getByPlaceholderText('username'), 'alice');
+  await userEvent.type(screen.getByPlaceholderText('********'), 'pass123');
+  await userEvent.type(screen.getByPlaceholderText('dd.mm.yyyy'), '32.13.2020');
+  await userEvent.click(screen.getByRole('button', { name: 'Create profile' }));
+  expect(await screen.findByText(/Ugyldigt datoformat/)).toBeInTheDocument();
+});
+
 // Test that Google and Facebook signup buttons are shown
 test('shows provider signup buttons', async () => {
   renderWelcome();

--- a/src/__tests__/utils.test.js
+++ b/src/__tests__/utils.test.js
@@ -1,4 +1,4 @@
-import { getCurrentDate, getAge, getTodayStr, getDaysLeft } from '../utils.js';
+import { getCurrentDate, getAge, getTodayStr, getDaysLeft, parseBirthday } from '../utils.js';
 
 // Control time for deterministic tests
 beforeEach(() => {
@@ -39,4 +39,9 @@ test('getDaysLeft rounds down at midnight', () => {
   expect(getDaysLeft(expires)).toBe(5);
   jest.setSystemTime(new Date('2024-05-21T08:00:00Z'));
   expect(getDaysLeft(expires)).toBe(4);
+});
+
+test('parseBirthday validates and converts date string', () => {
+  expect(parseBirthday('01.02.2000')).toBe('2000-02-01');
+  expect(parseBirthday('32.13.2000')).toBe('');
 });

--- a/src/components/WelcomeScreen.jsx
+++ b/src/components/WelcomeScreen.jsx
@@ -7,7 +7,7 @@ import ForgotPasswordOverlay from './ForgotPasswordOverlay.jsx';
 import { UserPlus, LogIn } from 'lucide-react';
 import { useLang, useT } from '../i18n.js';
 import { auth, db, doc, setDoc, updateDoc, increment, getDoc, createUserWithEmailAndPassword, signInWithEmailAndPassword, signInWithGoogle, signInWithFacebook } from '../firebase.js';
-import { getAge, getCurrentDate } from '../utils.js';
+import { getAge, getCurrentDate, parseBirthday } from '../utils.js';
 
 export default function WelcomeScreen({ onLogin }) {
   const [showRegister, setShowRegister] = useState(false);
@@ -26,6 +26,7 @@ export default function WelcomeScreen({ onLogin }) {
   const [showMissingFields, setShowMissingFields] = useState(false);
   const [triedSubmit, setTriedSubmit] = useState(false);
   const [showAgeError, setShowAgeError] = useState(false);
+  const [showBirthdayError, setShowBirthdayError] = useState(false);
   const [showCreated, setShowCreated] = useState(false);
   const [createdMsg, setCreatedMsg] = useState('');
   const [createdId, setCreatedId] = useState('');
@@ -36,12 +37,6 @@ export default function WelcomeScreen({ onLogin }) {
 
   const handleSkip = () => {
     onLogin('101', 'admin');
-  };
-
-  const parseBirthday = str => {
-    const m = str.match(/^(\d{2})[.\/-](\d{2})[.\/-](\d{4})$/);
-    if (!m) return '';
-    return `${m[3]}-${m[2]}-${m[1]}`;
   };
 
   const handleBirthdayChange = e => {
@@ -106,12 +101,19 @@ export default function WelcomeScreen({ onLogin }) {
     const trimmedName = name.trim() || (provider.displayName || '');
     const trimmedCity = city.trim();
     const trimmedUser = username.trim();
-    if (!trimmedName || !trimmedCity || !birthday || !trimmedUser) {
+    const parsedBirthday = birthdayInput ? parseBirthday(birthdayInput) : '';
+    if (!trimmedName || !trimmedCity || !birthdayInput || !trimmedUser) {
       setTriedSubmit(true);
       setShowMissingFields(true);
       return;
     }
-    if (getAge(birthday) < 18) {
+    if (!parsedBirthday) {
+      setTriedSubmit(true);
+      setShowBirthdayError(true);
+      return;
+    }
+    setBirthday(parsedBirthday);
+    if (getAge(parsedBirthday) < 18) {
       setShowAgeError(true);
       return;
     }
@@ -168,8 +170,8 @@ export default function WelcomeScreen({ onLogin }) {
       email: trimmedEmail,
       gender,
       interest: gender === 'Kvinde' ? 'Mand' : 'Kvinde',
-      birthday,
-      age: birthday ? getAge(birthday) : 18,
+      birthday: parsedBirthday,
+      age: parsedBirthday ? getAge(parsedBirthday) : 18,
       language: lang,
       preferredLanguages: [lang],
       allowOtherLanguages: true,
@@ -205,13 +207,20 @@ export default function WelcomeScreen({ onLogin }) {
     const trimmedCity = city.trim();
     const trimmedEmail = email.trim();
     const trimmedUser = username.trim();
-    if (!trimmedName || !trimmedCity || !trimmedEmail || !birthday || !trimmedUser || !password) {
+    const parsedBirthday = birthdayInput ? parseBirthday(birthdayInput) : '';
+    if (!trimmedName || !trimmedCity || !trimmedEmail || !birthdayInput || !trimmedUser || !password) {
       setTriedSubmit(true);
       setShowMissingFields(true);
       return;
     }
+    if (!parsedBirthday) {
+      setTriedSubmit(true);
+      setShowBirthdayError(true);
+      return;
+    }
+    setBirthday(parsedBirthday);
     // Require a valid birthday confirming the user is at least 18
-    if (!birthday || getAge(birthday) < 18) {
+    if (getAge(parsedBirthday) < 18) {
       setShowAgeError(true);
       return;
     }
@@ -307,6 +316,12 @@ export default function WelcomeScreen({ onLogin }) {
       onClose: () => setShowAgeError(false)
     },
       React.createElement('p', { className:'text-center' }, 'Du skal v\u00e6re mindst 18 \u00e5r for at bruge appen')
+    ),
+    showBirthdayError && React.createElement(InfoOverlay, {
+      title: t('register'),
+      onClose: () => setShowBirthdayError(false)
+    },
+      React.createElement('p', { className:'text-center' }, 'Ugyldigt datoformat. Brug dd.mm.\u00e5\u00e5\u00e5\u00e5')
     ),
     showCreated && React.createElement(InfoOverlay, {
       title: t('register'),

--- a/src/utils.js
+++ b/src/utils.js
@@ -41,6 +41,21 @@ export function getAge(birthday){
   return age;
 }
 
+export function parseBirthday(str){
+  const m = str.match(/^(\d{2})[.\/-](\d{2})[.\/-](\d{4})$/);
+  if(!m) return '';
+  const day = parseInt(m[1], 10);
+  const month = parseInt(m[2], 10);
+  const year = parseInt(m[3], 10);
+  const date = new Date(Date.UTC(year, month - 1, day));
+  if(
+    date.getUTCFullYear() !== year ||
+    date.getUTCMonth() + 1 !== month ||
+    date.getUTCDate() !== day
+  ) return '';
+  return date.toISOString().split('T')[0];
+}
+
 export function detectOS(){
   if (typeof navigator === 'undefined') return '';
   const ua = navigator.userAgent || '';


### PR DESCRIPTION
## Summary
- add `parseBirthday` utility for date validation
- validate birthday input format and age in `WelcomeScreen`
- show error overlay when birthday format is invalid
- test new `parseBirthday` and invalid date handling

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6885b9fd6864832d8d4ab2d684eb288c