### PR TITLE
Add developer option to reset invitations

### DIFF
--- a/src/components/AdminScreen.jsx
+++ b/src/components/AdminScreen.jsx
@@ -236,6 +236,20 @@ export default function AdminScreen({ onOpenStats, onOpenBugReports, onOpenMatch
     }
   };
 
+  const resetInvites = async () => {
+    if (!userId) return;
+    if (!window.confirm('Reset all invitations?')) return;
+    try {
+      const q = query(collection(db, 'invites'), where('inviterId', '==', userId));
+      const snap = await getDocs(q);
+      await Promise.all(snap.docs.map(d => deleteDoc(d.ref)));
+      await updateDoc(doc(db, 'profiles', userId), { premiumInvitesUsed: 0 });
+      alert('Invitations nulstillet');
+    } catch (err) {
+      alert('Failed: ' + err.message);
+    }
+  };
+
   const testHaptic = () => {
     triggerHaptic([100, 50, 100]);
   };
@@ -321,6 +335,7 @@ export default function AdminScreen({ onOpenStats, onOpenBugReports, onOpenMatch
     React.createElement('h4', { className: 'text-lg font-semibold mb-2 text-blue-600' }, t('adminDatabase')),
     React.createElement(Button, { className: 'mt-2 bg-blue-500 text-white px-4 py-2 rounded', onClick: () => seedData().then(() => alert('Databasen er nulstillet')) }, 'Reset database'),
     React.createElement(Button, { className: 'mt-2 bg-blue-500 text-white px-4 py-2 rounded', onClick: recoverMissing }, 'Hent mistet fra DB'),
+    React.createElement(Button, { className: 'mt-2 bg-red-500 text-white px-4 py-2 rounded', onClick: resetInvites }, 'Reset invitations'),
     React.createElement('h4', { className: 'text-lg font-semibold mb-2 text-blue-600' }, t('adminPush')),
     React.createElement(Button, { className: 'mt-2 bg-blue-500 text-white px-4 py-2 rounded mr-2', onClick: () => sendPush('Dagens klip er klar') }, 'Dagens klip er klar'),
     React.createElement(Button, { className: 'mt-2 bg-blue-500 text-white px-4 py-2 rounded mr-2', onClick: () => sendPush('Du har et match. Start samtalen') }, 'Du har et match. Start samtalen'),


### PR DESCRIPTION
## Summary
- add resetInvites helper to AdminScreen
- include a "Reset invitations" button under the developer admin section

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6885c0dc0a7c832db5284251e7ff527c