### PR TITLE
Add help overlay for admin page

### DIFF
--- a/src/components/AdminHelpOverlay.jsx
+++ b/src/components/AdminHelpOverlay.jsx
@@ -1,0 +1,52 @@
+import React from 'react';
+import InfoOverlay from './InfoOverlay.jsx';
+import { useT } from '../i18n.js';
+
+const descriptions = [
+  'Choose language: Set the admin interface language.',
+  'Select user: Switch between profiles.',
+  'Save & Logout: Save user changes and sign out.',
+  'Se anmeldt indhold: View reported content.',
+  'Verificer profil/Fjern verificering: Toggle verification for the selected profile.',
+  'Delete user: Permanently remove the selected user.',
+  'Vis statistik: View statistics charts.',
+  'Se seneste logins: Show recent login methods.',
+  'N\u00e6ste dag: Advance local date for testing.',
+  'Reset dag: Reset the local date to today.',
+  'Se alle fejlmeldinger: Open list of bug reports.',
+  'Fejlmeld: Submit a bug report.',
+  'Reset all candidates: Delete likes, matches and episode progress.',
+  'Test haptisk feedback: Trigger vibration on the device.',
+  'A\u00e5bn funktionstest: Open the manual function test module.',
+  'A\u00e5bn reveal test: Open the reveal test module.',
+  'Reset database: Recreate test data.',
+  'Hent mistet fra DB: Restore missing profile files from storage.',
+  'Dagens klip er klar: Send push notification for daily clips.',
+  'Du har et match. Start samtalen: Send match notification.',
+  'Log client token: Display this device push token.',
+  'Show VAPID keys: Show local VAPID key pair.',
+  'Compare VAPID keys: Compare local keys with the server.',
+  'Show push info: Show push configuration values.',
+  'Check Firebase Auth: Verify server authentication access.',
+  'Server log: View recent server logs.',
+  'Udvidet logning: Toggle extra logging.',
+  'Vis console log: Capture browser console output.',
+  'Premium invites: Enable or disable premium invites.',
+  'View levels: Toggle display of user levels.',
+  'Se log: View general text log.',
+  'Se matchlog: View match log.',
+  'Se score log: View scoring log.',
+  'F\u00f8lg bruger: Monitor activity of a user.',
+  'Alle tekststykker: View all text pieces.',
+  'Se aktive opkald: Show current video calls.',
+  'Se gruppeopkald: Show group video calls.'
+];
+
+export default function AdminHelpOverlay({ onClose }) {
+  const t = useT();
+  return React.createElement(InfoOverlay, { title: t('helpTitle'), onClose },
+    React.createElement('ul', { className: 'list-disc ml-5 space-y-1 text-sm text-left' },
+      descriptions.map((d, i) => React.createElement('li', { key: i }, d))
+    )
+  );
+}

--- a/src/components/AdminScreen.jsx
+++ b/src/components/AdminScreen.jsx
@@ -1,5 +1,6 @@
 import React, { useState } from 'react';
 import BugReportOverlay from './BugReportOverlay.jsx';
+import AdminHelpOverlay from './AdminHelpOverlay.jsx';
 import { languages, useLang, useT } from '../i18n.js';
 import { Card } from './ui/card.js';
 import { Button } from './ui/button.js';
@@ -18,6 +19,7 @@ export default function AdminScreen({ onOpenStats, onOpenBugReports, onOpenMatch
   const { lang, setLang } = useLang();
   const t = useT();
   const [showBugReport, setShowBugReport] = useState(false);
+  const [showHelp, setShowHelp] = useState(false);
   const [logEnabled, setLogEnabled] = useState(isExtendedLogging());
   const [consoleEnabled, setConsoleEnabled] = useState(isConsoleCapture());
   const config = useDoc('config', 'app') || {};
@@ -243,7 +245,14 @@ export default function AdminScreen({ onOpenStats, onOpenBugReports, onOpenMatch
 
   return React.createElement(React.Fragment, null,
     React.createElement(Card, { className: 'p-6 m-4 shadow-xl bg-white/90' },
-    React.createElement(SectionTitle, { title: t('adminTitle'), colorClass: 'text-blue-600' }),
+    React.createElement(SectionTitle, {
+      title: t('adminTitle'),
+      colorClass: 'text-blue-600',
+      action: React.createElement(Button, {
+        onClick: () => setShowHelp(true),
+        className: 'bg-blue-500 text-white px-2 py-1 rounded text-sm'
+      }, t('helpTitle'))
+    }),
     React.createElement('label', { className: 'block mb-1' }, t('chooseLanguage')),
     React.createElement('select', {
       className: 'border p-2 mb-4 w-full',
@@ -366,6 +375,7 @@ export default function AdminScreen({ onOpenStats, onOpenBugReports, onOpenMatch
     React.createElement(Button, { className: 'mt-2 bg-blue-500 text-white px-4 py-2 rounded', onClick: onOpenCallLog }, 'Se aktive opkald'),
     React.createElement(Button, { className: 'mt-2 bg-blue-500 text-white px-4 py-2 rounded', onClick: onOpenGroupCallLog }, 'Se gruppeopkald')
   ),
-    showBugReport && React.createElement(BugReportOverlay, { onClose: () => setShowBugReport(false) })
+    showBugReport && React.createElement(BugReportOverlay, { onClose: () => setShowBugReport(false) }),
+    showHelp && React.createElement(AdminHelpOverlay, { onClose: () => setShowHelp(false) })
   );
 }

--- a/src/components/InfoOverlay.jsx
+++ b/src/components/InfoOverlay.jsx
@@ -4,7 +4,7 @@ import { Button } from './ui/button.js';
 
 export default function InfoOverlay({ title, children, onClose }) {
   return React.createElement('div', { className: 'fixed inset-0 z-50 bg-black/50 flex items-center justify-center' },
-    React.createElement(Card, { className: 'bg-white p-6 rounded shadow-xl max-w-sm w-full' },
+    React.createElement(Card, { className: 'bg-white p-6 rounded shadow-xl max-w-sm w-full max-h-[90vh] overflow-y-auto' },
       React.createElement('h2', { className: 'text-xl font-semibold mb-4 text-pink-600 text-center' }, title),
       children,
       React.createElement(Button, { className: 'w-full bg-pink-500 text-white mt-4', onClick: onClose }, 'Luk')


### PR DESCRIPTION
## Summary
- add `AdminHelpOverlay` component with descriptions of all admin controls
- include help button in `AdminScreen` and display the overlay
- limit `InfoOverlay` height and make content scrollable so long help text fits on screen

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6885c19394a4832dae3f0afb98c99038