### PR TITLE
Add extend area fallback for daily clips

### DIFF
--- a/src/components/DailyDiscovery.jsx
+++ b/src/components/DailyDiscovery.jsx
@@ -326,10 +326,8 @@ export default function DailyDiscovery({ userId, onSelectProfile, ageRange, onOp
     React.createElement(Button, {
       className: 'mt-4 w-full bg-yellow-500 text-white',
       onClick: () => {
-        const hasSub = hasActiveSub(user);
-        const extra = user.extraClipsDate === today ? 3 : 0;
-        const limit = (hasSub ? 6 : 3) + extra;
-        if (filtered.length < limit) {
+        const moreCandidates = scored.length > filtered.length;
+        if (!moreCandidates) {
           setShowExtend(true);
         } else if (user.extraClipsDate === today) {
           setShowInfo(true);


### PR DESCRIPTION
## Summary
- adjust `load more` logic to show **Extend Area** when no additional candidates are available

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6885c5b8c950832d8a73cd575e275f65