### PR TITLE
Change admin section headings to H2

### DIFF
--- a/src/components/AdminScreen.jsx
+++ b/src/components/AdminScreen.jsx
@@ -293,7 +293,7 @@ export default function AdminScreen({ onOpenStats, onOpenBugReports, onOpenMatch
     ),
 
   // Daily admin section
-  React.createElement('h3', { className: 'text-xl font-semibold mb-2 mt-4 text-pink-600' }, t('adminDaily')),
+  React.createElement('h2', { className: 'text-xl font-semibold mb-2 mt-4 text-pink-600' }, t('adminDaily')),
     React.createElement(Button, { className: 'mt-2 bg-blue-500 text-white px-4 py-2 rounded', onClick: onOpenReports }, 'Se anmeldt indhold'),
     React.createElement('div', { className: 'mt-2' },
       React.createElement(Button, {
@@ -310,12 +310,12 @@ export default function AdminScreen({ onOpenStats, onOpenBugReports, onOpenMatch
     ),
 
   // Business section
-  React.createElement('h3', { className: 'text-xl font-semibold mb-2 mt-4 text-pink-600' }, t('adminBusiness')),
+  React.createElement('h2', { className: 'text-xl font-semibold mb-2 mt-4 text-pink-600' }, t('adminBusiness')),
     React.createElement(Button, { className: 'mt-2 bg-blue-500 text-white px-4 py-2 rounded', onClick: onOpenStats }, 'Vis statistik'),
     React.createElement(Button, { className: 'mt-2 bg-blue-500 text-white px-4 py-2 rounded', onClick: onOpenRecentLogins }, 'Se seneste logins'),
 
   // Tester section
-  React.createElement('h3', { className: 'text-xl font-semibold mb-2 mt-4 text-pink-600' }, t('adminTesters')),
+  React.createElement('h2', { className: 'text-xl font-semibold mb-2 mt-4 text-pink-600' }, t('adminTesters')),
     React.createElement('p', { className: 'mb-2' }, 'Dagens dato: ' + getTodayStr()),
     React.createElement('div', { className: 'flex gap-2 mb-4' },
       React.createElement(Button, {
@@ -340,7 +340,7 @@ export default function AdminScreen({ onOpenStats, onOpenBugReports, onOpenMatch
     React.createElement(Button, { className: 'mt-2 bg-blue-500 text-white px-4 py-2 rounded', onClick: onOpenRevealTest }, 'Åbn reveal test'),
 
   // Developer section
-  React.createElement('h3', { className: 'text-xl font-semibold mb-2 mt-4 text-pink-600' }, t('adminDevelopers')),
+  React.createElement('h2', { className: 'text-xl font-semibold mb-2 mt-4 text-pink-600' }, t('adminDevelopers')),
     React.createElement('h4', { className: 'text-lg font-semibold mb-2 text-blue-600' }, t('adminDatabase')),
     React.createElement(Button, { className: 'mt-2 bg-blue-500 text-white px-4 py-2 rounded', onClick: () => seedData().then(() => alert('Databasen er nulstillet')) }, 'Reset database'),
     React.createElement(Button, { className: 'mt-2 bg-blue-500 text-white px-4 py-2 rounded', onClick: recoverMissing }, 'Hent mistet fra DB'),


### PR DESCRIPTION
## Summary
- make each admin section heading use `<h2>` for better hierarchy

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6885c6386240832d9928c11134e38204