### PR TITLE
Swap call and unmatch buttons

### DIFF
--- a/src/components/ChatScreen.jsx
+++ b/src/components/ChatScreen.jsx
@@ -145,9 +145,9 @@ export default function ChatScreen({ userId, onStartCall }) {
           ),
           React.createElement('p', { className: 'flex-1 font-medium' }, `${activeProfile.name || ''}, ${activeProfile.birthday ? getAge(activeProfile.birthday) : activeProfile.age || ''}, ${activeProfile.city || ''}`),
           React.createElement(Button, {
-            className: 'bg-pink-500 text-white',
-            onClick: () => onStartCall && onStartCall([userId, active.profileId].sort().join('-'))
-          }, incomingCall ? 'Deltag i opkald' : 'Foretag opkald')
+            className: 'bg-red-500 text-white',
+            onClick: unmatch
+          }, 'Unmatch')
         ),
         React.createElement('div', { ref: messagesRef, className: 'flex-1 bg-gray-100 p-4 rounded space-y-3 flex flex-col overflow-y-auto' },
           (active.messages || []).map((m,i) => {
@@ -185,9 +185,9 @@ export default function ChatScreen({ userId, onStartCall }) {
             )
           ),
           React.createElement(Button, {
-            className: 'bg-red-500 text-white',
-            onClick: unmatch
-          }, 'Unmatch')
+            className: 'bg-pink-500 text-white',
+            onClick: () => onStartCall && onStartCall([userId, active.profileId].sort().join('-'))
+          }, incomingCall ? 'Deltag i opkald' : 'Foretag opkald')
         )
       )
     ) : (


### PR DESCRIPTION
## Summary
- move the Unmatch button to the user header
- move the call button to the bottom of the chat

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6885ccd9716c832da6fde9934d1c221c