### PR TITLE
Integrate game into Realetten

### DIFF
--- a/src/components/RealettenCallScreen.jsx
+++ b/src/components/RealettenCallScreen.jsx
@@ -18,7 +18,7 @@ function sanitizeInterest(i){
   return encodeURIComponent(i || '').replace(/%20/g,'_');
 }
 
-export default function RealettenCallScreen({ interest, userId, onEnd }) {
+export default function RealettenCallScreen({ interest, userId, onEnd, onParticipantsChange }) {
   const [participants, setParticipants] = useState([]);
   const localRef = useRef(null);
   const localStreamRef = useRef(null);
@@ -74,7 +74,9 @@ export default function RealettenCallScreen({ interest, userId, onEnd }) {
     };
     const unsub = onSnapshot(ref, snap => {
       const data = snap.data();
-      setParticipants(data?.participants || []);
+      const list = data?.participants || [];
+      setParticipants(list);
+      if (onParticipantsChange) onParticipantsChange(list);
     });
     join();
     return () => {
@@ -89,6 +91,7 @@ export default function RealettenCallScreen({ interest, userId, onEnd }) {
         } catch {}
       })();
       unsub();
+      if (onParticipantsChange) onParticipantsChange([]);
     };
   }, [interest, userId]);
 

--- a/src/components/RealettenGameOverlay.jsx
+++ b/src/components/RealettenGameOverlay.jsx
@@ -1,0 +1,14 @@
+import React from 'react';
+import TurnGame from './TurnGame.jsx';
+import { X } from 'lucide-react';
+
+export default function RealettenGameOverlay({ players, onClose }) {
+  return React.createElement('div', { className:'fixed inset-0 z-50 bg-black/70 flex items-center justify-center' },
+    React.createElement('div', { className:'relative w-full max-w-md mx-4' },
+      React.createElement(TurnGame, { players, onExit:onClose }),
+      React.createElement('button', { className:'absolute top-2 right-2 text-white bg-black/40 rounded-full p-1', onClick:onClose },
+        React.createElement(X, { className:'w-6 h-6' })
+      )
+    )
+  );
+}

--- a/src/components/RealettenPage.jsx
+++ b/src/components/RealettenPage.jsx
@@ -1,16 +1,22 @@
-import React from 'react';
+import React, { useState } from 'react';
 import { ArrowLeft } from 'lucide-react';
 import { Card } from './ui/card.js';
 import { Button } from './ui/button.js';
 import SectionTitle from './SectionTitle.jsx';
 import RealettenCallScreen from './RealettenCallScreen.jsx';
+import RealettenGameOverlay from './RealettenGameOverlay.jsx';
 
 export default function RealettenPage({ interest, userId, onBack }) {
+  const [players, setPlayers] = useState([]);
+  const [showGame, setShowGame] = useState(false);
+  const action = React.createElement('div',{className:'flex gap-2'},
+    React.createElement(Button,{ className:'flex items-center gap-1', onClick:onBack },
+      React.createElement(ArrowLeft,{ className:'w-4 h-4' }), 'Tilbage'),
+    React.createElement(Button,{ className:'bg-pink-500 text-white', disabled:players.length!==4, onClick:()=>setShowGame(true) }, 'Start spil')
+  );
   return React.createElement(Card, { className:'p-6 m-4 shadow-xl bg-white/90 flex flex-col h-full flex-1 overflow-y-auto' },
-    React.createElement(SectionTitle,{ title:'Realetten',
-      action: React.createElement(Button,{ className:'flex items-center gap-1', onClick:onBack },
-        React.createElement(ArrowLeft,{ className:'w-4 h-4' }), 'Tilbage')
-    }),
-    React.createElement(RealettenCallScreen,{ interest, userId, onEnd:onBack })
+    React.createElement(SectionTitle,{ title:'Realetten', action }),
+    React.createElement(RealettenCallScreen,{ interest, userId, onEnd:onBack, onParticipantsChange:setPlayers }),
+    showGame && React.createElement(RealettenGameOverlay,{ players, onClose:()=>setShowGame(false) })
   );
 }

--- a/src/components/TurnGame.jsx
+++ b/src/components/TurnGame.jsx
@@ -26,15 +26,17 @@ const questions = [
   }
 ];
 
-export default function TurnGame() {
-  const [players, setPlayers] = useState([]);
+export default function TurnGame({ players: initialPlayers = [], onExit }) {
+  const [players, setPlayers] = useState(() => initialPlayers);
   const [nameInput, setNameInput] = useState('');
-  const [scores, setScores] = useState({});
+  const [scores, setScores] = useState(() =>
+    initialPlayers.length > 1 ?
+      Object.fromEntries(initialPlayers.map(p => [p, 0])) : {});
   const [current, setCurrent] = useState(0);
   const [qIdx, setQIdx] = useState(0);
   const [choice, setChoice] = useState(null);
   const [guesses, setGuesses] = useState({});
-  const [step, setStep] = useState('setup');
+  const [step, setStep] = useState(initialPlayers.length > 1 ? 'play' : 'setup');
   const [timeLeft, setTimeLeft] = useState(10);
 
   const addPlayer = () => {
@@ -101,10 +103,12 @@ export default function TurnGame() {
   };
 
   const q = questions[qIdx];
+  const closeBtn = onExit ?
+    React.createElement(Button, { className:'bg-gray-500 text-white', onClick:onExit }, 'Luk') : null;
 
   if (step === 'setup') {
     return React.createElement(Card, { className: 'p-6 m-4 shadow-xl bg-white/90' },
-      React.createElement(SectionTitle, { title: 'Gæt mit valg' }),
+      React.createElement(SectionTitle, { title: 'Gæt mit valg', action: closeBtn }),
       React.createElement('div', { className: 'flex mb-2' },
         React.createElement('input', {
           className: 'border flex-1 mr-2 p-1',
@@ -123,7 +127,7 @@ export default function TurnGame() {
 
   if (step === 'play') {
     return React.createElement(Card, { className: 'p-6 m-4 shadow-xl bg-white/90' },
-      React.createElement(SectionTitle, { title: `${players[current]}: ${q.text}` }),
+      React.createElement(SectionTitle, { title: `${players[current]}: ${q.text}`, action: closeBtn }),
       React.createElement('div', { className: 'space-y-2 mt-4' },
         q.options.map((o, i) =>
           React.createElement(Button, { key: i, className: 'bg-pink-500 text-white w-full', onClick: () => selectOption(i) }, o)
@@ -134,7 +138,7 @@ export default function TurnGame() {
 
   if (step === 'guess') {
     return React.createElement(Card, { className: 'p-6 m-4 shadow-xl bg-white/90' },
-      React.createElement(SectionTitle, { title: `Gæt ${players[current]}'s valg (${timeLeft})` }),
+      React.createElement(SectionTitle, { title: `Gæt ${players[current]}'s valg (${timeLeft})`, action: closeBtn }),
       players.filter((_, i) => i !== current).map(p =>
         React.createElement('div', { key: p, className: 'mb-4' },
           React.createElement('p', { className: 'font-medium mb-1' }, p),
@@ -155,7 +159,7 @@ export default function TurnGame() {
 
   if (step === 'reveal') {
     return React.createElement(Card, { className: 'p-6 m-4 shadow-xl bg-white/90' },
-      React.createElement(SectionTitle, { title: 'Resultat' }),
+      React.createElement(SectionTitle, { title: 'Resultat', action: closeBtn }),
       React.createElement('p', { className: 'mb-2' }, `Rigtigt svar: ${q.options[choice]}`),
       React.createElement('ul', { className: 'mb-4 list-disc list-inside' },
         players.map((p, i) => {


### PR DESCRIPTION
## Summary
- add RealettenGameOverlay component to show TurnGame as overlay
- allow RealettenCallScreen to notify participant list changes
- integrate game overlay in RealettenPage
- support preset players and exit button in TurnGame

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6885f835cb48832daf8b28f63968d542