### PR TITLE
Integrate turn game into Realetten page

### DIFF
--- a/src/VideotpushApp.jsx
+++ b/src/VideotpushApp.jsx
@@ -1,7 +1,7 @@
 import React, { useState, useEffect } from 'react';
 import { LanguageProvider } from './i18n.js';
 import { User as UserIcon, Shield, HelpCircle } from 'lucide-react';
-import { VideoCameraIcon, HeartIcon, ChatBubbleOvalLeftIcon, CalendarDaysIcon, UserGroupIcon, PuzzlePieceIcon } from '@heroicons/react/24/solid';
+import { VideoCameraIcon, HeartIcon, ChatBubbleOvalLeftIcon, CalendarDaysIcon, UserGroupIcon } from '@heroicons/react/24/solid';
 import WelcomeScreen from './components/WelcomeScreen.jsx';
 import DailyDiscovery from './components/DailyDiscovery.jsx';
 import LikesScreen from './components/LikesScreen.jsx';
@@ -31,7 +31,6 @@ import HelpOverlay from './components/HelpOverlay.jsx';
 import ConsoleLogPanel from './components/ConsoleLogPanel.jsx';
 import TaskButton from './components/TaskButton.jsx';
 import GraphicsElementsScreen from './components/GraphicsElementsScreen.jsx';
-import TurnGame from './components/TurnGame.jsx';
 import { getNextTask } from './tasks.js';
 import { useCollection, requestNotificationPermission, subscribeToWebPush, db, doc, updateDoc, increment, logEvent, auth, isAdminUser, signOutUser } from './firebase.js';
 import { getCurrentDate } from './utils.js';
@@ -269,7 +268,6 @@ export default function VideotpushApp() {
           ),
           tab==='chat' && React.createElement(ChatScreen, { userId, onStartCall: id => setVideoCallId(id) }),
           tab==='interestchat' && React.createElement(InterestChatScreen, { userId }),
-          tab==='game' && React.createElement(TurnGame, null),
           tab==='checkin' && React.createElement(DailyCheckIn, { userId }),
           tab==='profile' && React.createElement(ProfileSettings, {
             userId,
@@ -312,7 +310,6 @@ export default function VideotpushApp() {
         hasUnread && React.createElement('span', { className: 'absolute -top-1 -right-2 bg-red-500 text-white text-xs rounded-full min-w-4 h-4 flex items-center justify-center px-1' }, unreadCount)
       ),
       React.createElement(UserGroupIcon, { className: 'w-8 h-8 text-pink-600', onClick: ()=>{setTab('interestchat'); setViewProfile(null);} }),
-      React.createElement(PuzzlePieceIcon, { className: 'w-8 h-8 text-pink-600', onClick: ()=>{setTab('game'); setViewProfile(null);} }),
       React.createElement(CalendarDaysIcon, { className: 'w-8 h-8 text-pink-600', onClick: ()=>{setTab('checkin'); setViewProfile(null);} })
       ),
     showHelp && React.createElement(HelpOverlay, { onClose: ()=>setShowHelp(false) }),

--- a/src/components/RealettenPage.jsx
+++ b/src/components/RealettenPage.jsx
@@ -5,10 +5,14 @@ import { Button } from './ui/button.js';
 import SectionTitle from './SectionTitle.jsx';
 import RealettenCallScreen from './RealettenCallScreen.jsx';
 import RealettenGameOverlay from './RealettenGameOverlay.jsx';
+import { useCollection } from '../firebase.js';
 
 export default function RealettenPage({ interest, userId, onBack }) {
   const [players, setPlayers] = useState([]);
+  const profiles = useCollection('profiles');
+  const profileMap = Object.fromEntries(profiles.map(p => [p.id, p]));
   const [showGame, setShowGame] = useState(false);
+  const playerNames = players.map(id => profileMap[id]?.name || id);
   const action = React.createElement('div',{className:'flex gap-2'},
     React.createElement(Button,{ className:'flex items-center gap-1', onClick:onBack },
       React.createElement(ArrowLeft,{ className:'w-4 h-4' }), 'Tilbage'),
@@ -17,6 +21,6 @@ export default function RealettenPage({ interest, userId, onBack }) {
   return React.createElement(Card, { className:'p-6 m-4 shadow-xl bg-white/90 flex flex-col h-full flex-1 overflow-y-auto' },
     React.createElement(SectionTitle,{ title:'Realetten', action }),
     React.createElement(RealettenCallScreen,{ interest, userId, onEnd:onBack, onParticipantsChange:setPlayers }),
-    showGame && React.createElement(RealettenGameOverlay,{ players, onClose:()=>setShowGame(false) })
+    showGame && React.createElement(RealettenGameOverlay,{ players: playerNames, onClose:()=>setShowGame(false) })
   );
 }


### PR DESCRIPTION
## Summary
- remove the dedicated game tab and icon
- pull profile names when starting a Realetten game
- pass those names to the game

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6886037e6c18832d83e433e52713ddf1