### PR TITLE
Fix 'Your turn' placement

### DIFF
--- a/src/components/ChatScreen.jsx
+++ b/src/components/ChatScreen.jsx
@@ -206,11 +206,11 @@ export default function ChatScreen({ userId, onStartCall }) {
                 p.photoURL ?
                   React.createElement('img', { src: p.photoURL, className: 'w-10 h-10 rounded object-cover' }) :
                   React.createElement(UserIcon, { className: 'w-10 h-10 text-pink-500' }),
-                p.verified && React.createElement('span', { className:'text-green-600 text-xs' }, 'Verified')
+                p.verified && React.createElement('span', { className:'text-green-600 text-xs' }, 'Verified'),
+                lastFromOther && React.createElement('span', { className: 'text-sm text-blue-600 font-semibold' }, 'Your turn!')
               ),
               React.createElement('div', { className: 'flex flex-col' },
                 React.createElement('span', { className: 'font-medium' }, `${p.name || ''}, ${p.birthday ? getAge(p.birthday) : p.age || ''}, ${p.city || ''}`),
-                lastFromOther && React.createElement('span', { className: 'text-sm text-blue-600 font-semibold' }, 'Your turn!'),
                 m.lastMessage && React.createElement('span', { className: 'text-sm text-gray-500' }, m.lastMessage)
               )
             );


### PR DESCRIPTION
## Summary
- move the "Your turn" indicator beneath the profile image in chat list items

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68862d233288832d9e8ea5ff6ddd3bb5