### PR TITLE
Implement Firestore-backed turn game

### DIFF
--- a/FEATURES.txt
+++ b/FEATURES.txt
@@ -26,3 +26,4 @@ Reset database from
 Show Firestore credentials status
 Reusable profile filtering helper for Netlify Functions
 Track logs for individual users from admin
+Turn-based Realetten game uses Firestore for shared state and scoring

--- a/src/components/RealettenPage.jsx
+++ b/src/components/RealettenPage.jsx
@@ -5,7 +5,11 @@ import { Button } from './ui/button.js';
 import SectionTitle from './SectionTitle.jsx';
 import RealettenCallScreen from './RealettenCallScreen.jsx';
 import TurnGame from './TurnGame.jsx';
-import { useCollection } from '../firebase.js';
+import { useCollection, db, doc, setDoc } from '../firebase.js';
+
+function sanitizeInterest(i){
+  return encodeURIComponent(i || '').replace(/%20/g,'_');
+}
 
 export default function RealettenPage({ interest, userId, onBack }) {
   const [players, setPlayers] = useState([]);
@@ -17,15 +21,30 @@ export default function RealettenPage({ interest, userId, onBack }) {
     React.createElement(Button,{ className:'flex items-center gap-1', onClick:onBack },
       React.createElement(ArrowLeft,{ className:'w-4 h-4' }), 'Tilbage')
   );
+  const startGame = async () => {
+    const gameId = sanitizeInterest(interest);
+    const init = Object.fromEntries(playerNames.map(p => [p, 0]));
+    await setDoc(doc(db, 'turnGames', gameId), {
+      players: playerNames,
+      scores: init,
+      current: 0,
+      qIdx: 0,
+      step: 'play',
+      choice: null,
+      guesses: {},
+      createdAt: new Date().toISOString()
+    });
+    setShowGame(true);
+  };
   const startButton = React.createElement(Button, {
     className: 'bg-pink-500 text-white mt-2 self-center',
     disabled: players.length === 0,
-    onClick: () => setShowGame(true)
+    onClick: startGame
   }, 'Start spil');
   return React.createElement(Card, { className:'p-6 m-4 shadow-xl bg-white/90 flex flex-col h-full flex-1 overflow-y-auto' },
     React.createElement(SectionTitle,{ title:'Realetten', action }),
     React.createElement(RealettenCallScreen,{ interest, userId, onEnd:onBack, onParticipantsChange:setPlayers }),
     !showGame && startButton,
-    showGame && React.createElement(TurnGame,{ players: playerNames, onExit:()=>setShowGame(false) })
+    showGame && React.createElement(TurnGame,{ sessionId: sanitizeInterest(interest), onExit:()=>setShowGame(false) })
   );
 }


### PR DESCRIPTION
## Summary
- persist Realetten turn game state in Firestore
- create game sessions from Realetten page
- list new feature in FEATURES.txt

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68863478d334832d8af63c37d617f746