### PR TITLE
Implement Firestore-backed turn game

### DIFF
--- a/FEATURES.txt
+++ b/FEATURES.txt
@@ -26,3 +26,4 @@ Reset database from
 Show Firestore credentials status
 Reusable profile filtering helper for Netlify Functions
 Track logs for individual users from admin
+Turn-based Realetten game uses Firestore for shared state and scoring

--- a/src/components/RealettenPage.jsx
+++ b/src/components/RealettenPage.jsx
@@ -1,31 +1,56 @@
-import React, { useState } from 'react';
+import React, { useState, useEffect } from 'react';
 import { ArrowLeft } from 'lucide-react';
 import { Card } from './ui/card.js';
 import { Button } from './ui/button.js';
 import SectionTitle from './SectionTitle.jsx';
 import RealettenCallScreen from './RealettenCallScreen.jsx';
 import TurnGame from './TurnGame.jsx';
-import { useCollection } from '../firebase.js';
+import { useCollection, useDoc, db, doc, setDoc } from '../firebase.js';
+
+function sanitizeInterest(i){
+  return encodeURIComponent(i || '').replace(/%20/g,'_');
+}
 
 export default function RealettenPage({ interest, userId, onBack }) {
   const [players, setPlayers] = useState([]);
   const profiles = useCollection('profiles');
   const profileMap = Object.fromEntries(profiles.map(p => [p.id, p]));
   const [showGame, setShowGame] = useState(false);
+  const sessionId = sanitizeInterest(interest);
+  const game = useDoc('turnGames', sessionId);
+  const myName = profileMap[userId]?.name || userId;
   const playerNames = players.map(id => profileMap[id]?.name || id);
+
+  useEffect(() => {
+    if (game) setShowGame(true);
+  }, [game]);
   const action = React.createElement('div',{className:'flex gap-2'},
     React.createElement(Button,{ className:'flex items-center gap-1', onClick:onBack },
       React.createElement(ArrowLeft,{ className:'w-4 h-4' }), 'Tilbage')
   );
+  const startGame = async () => {
+    const init = Object.fromEntries(playerNames.map(p => [p, 0]));
+    await setDoc(doc(db, 'turnGames', sessionId), {
+      players: playerNames,
+      scores: init,
+      current: 0,
+      qIdx: 0,
+      step: 'play',
+      choice: null,
+      guesses: {},
+      createdAt: new Date().toISOString()
+    });
+    setShowGame(true);
+  };
   const startButton = React.createElement(Button, {
     className: 'bg-pink-500 text-white mt-2 self-center',
     disabled: players.length === 0,
-    onClick: () => setShowGame(true)
+    onClick: startGame
   }, 'Start spil');
   return React.createElement(Card, { className:'p-6 m-4 shadow-xl bg-white/90 flex flex-col h-full flex-1 overflow-y-auto' },
     React.createElement(SectionTitle,{ title:'Realetten', action }),
     React.createElement(RealettenCallScreen,{ interest, userId, onEnd:onBack, onParticipantsChange:setPlayers }),
     !showGame && startButton,
-    showGame && React.createElement(TurnGame,{ players: playerNames, onExit:()=>setShowGame(false) })
+    showGame && React.createElement(TurnGame,{ sessionId, myName, onExit:()=>setShowGame(false) })
   );
 }

--- a/src/components/TurnGame.jsx
+++ b/src/components/TurnGame.jsx
@@ -2,6 +2,7 @@ import React, { useState, useEffect } from 'react';
 import { Card } from './ui/card.js';
 import { Button } from './ui/button.js';
 import SectionTitle from './SectionTitle.jsx';
+import { db, doc, setDoc, onSnapshot } from '../firebase.js';
 
 const questions = [
   {
@@ -26,48 +27,46 @@ const questions = [
   }
 ];
 
-export default function TurnGame({ players: propPlayers = [], onExit }) {
-  const [players, setPlayers] = useState(() => propPlayers);
+export default function TurnGame({ sessionId, myName = '', players: propPlayers = [], onExit }) {
   const [nameInput, setNameInput] = useState('');
-  const [scores, setScores] = useState(() =>
-    propPlayers.length > 1 ?
-      Object.fromEntries(propPlayers.map(p => [p, 0])) : {});
-  const [current, setCurrent] = useState(0);
-  const [qIdx, setQIdx] = useState(0);
-  const [choice, setChoice] = useState(null);
-  const [guesses, setGuesses] = useState({});
-  const [step, setStep] = useState(propPlayers.length > 1 ? 'play' : 'setup');
   const [timeLeft, setTimeLeft] = useState(10);
+  const [game, setGame] = useState(null);
 
   useEffect(() => {
-    setPlayers(prev => {
-      const set = new Set(prev);
-      let changed = false;
-      propPlayers.forEach(p => {
-        if (!set.has(p)) {
-          set.add(p);
-          changed = true;
-        }
-      });
-      return changed ? Array.from(set) : prev;
+    if (!sessionId) return;
+    const ref = doc(db, 'turnGames', sessionId);
+    const unsub = onSnapshot(ref, snap => {
+      setGame(snap.exists() ? snap.data() : null);
     });
-    setScores(prev => {
-      const next = { ...prev };
-      let changed = false;
-      propPlayers.forEach(p => {
-        if (!(p in next)) {
-          next[p] = 0;
-          changed = true;
-        }
-      });
-      return changed ? next : prev;
-    });
-  }, [propPlayers]);
+    return () => unsub();
+  }, [sessionId]);
+
+  const players = game?.players || propPlayers;
+  const scores = game?.scores ||
+    (propPlayers.length > 1 ? Object.fromEntries(propPlayers.map(p => [p, 0])) : {});
+  const current = game?.current || 0;
+  const qIdx = game?.qIdx || 0;
+  const choice = game?.choice ?? null;
+  const guesses = game?.guesses || {};
+  const step = game?.step || (players.length > 1 ? 'play' : 'setup');
+
+  const updateGame = data => {
+    if (!sessionId) return;
+    setDoc(doc(db, 'turnGames', sessionId), data, { merge: true }).catch(console.error);
+  };
+
+  useEffect(() => {
+    if (!sessionId || players.length) return;
+    if (propPlayers.length) {
+      const init = Object.fromEntries(propPlayers.map(p => [p, 0]));
+      updateGame({ players: propPlayers, scores: init, step: propPlayers.length > 1 ? 'play' : 'setup' });
+    }
+  }, [sessionId, propPlayers]);
 
   const addPlayer = () => {
     const trimmed = nameInput.trim();
     if (trimmed && !players.includes(trimmed)) {
-      setPlayers(p => [...p, trimmed]);
+      updateGame({ players: [...players, trimmed], scores: { ...scores, [trimmed]: 0 } });
       setNameInput('');
     }
   };
@@ -75,18 +74,16 @@ export default function TurnGame({ players: propPlayers = [], onExit }) {
   const startGame = () => {
     if (players.length > 1) {
       const init = Object.fromEntries(players.map(p => [p, 0]));
-      setScores(init);
-      setStep('play');
+      updateGame({ scores: init, step: 'play', current: 0, qIdx: 0, choice: null, guesses: {} });
     }
   };
 
   const selectOption = idx => {
-    setChoice(idx);
-    setStep('guess');
+    updateGame({ choice: idx, step: 'guess', guesses: {} });
   };
 
   const guess = (player, idx) => {
-    setGuesses(g => ({ ...g, [player]: idx }));
+    updateGame({ guesses: { ...guesses, [player]: idx } });
   };
 
   useEffect(() => {
@@ -107,27 +104,27 @@ export default function TurnGame({ players: propPlayers = [], onExit }) {
   }, [step]);
 
   const reveal = () => {
-    setStep('reveal');
-    setScores(s => {
-      const n = { ...s };
-      players.forEach((p, i) => {
-        if (i !== current && guesses[p] === choice) {
-          n[p] = (n[p] || 0) + 1;
-        }
-      });
-      return n;
+    const n = { ...scores };
+    players.forEach((p, i) => {
+      if (i !== current && guesses[p] === choice) {
+        n[p] = (n[p] || 0) + 1;
+      }
     });
+    updateGame({ scores: n, step: 'reveal' });
   };
 
   const nextRound = () => {
-    setGuesses({});
-    setChoice(null);
-    setCurrent((current + 1) % players.length);
-    setQIdx((qIdx + 1) % questions.length);
-    setStep('play');
+    updateGame({
+      guesses: {},
+      choice: null,
+      current: (current + 1) % players.length,
+      qIdx: (qIdx + 1) % questions.length,
+      step: 'play'
+    });
   };
 
   const q = questions[qIdx];
+  const isCurrent = players[current] === myName;
   const closeBtn = onExit ?
     React.createElement(Button, { className:'bg-gray-500 text-white', onClick:onExit }, 'Luk') : null;
 
@@ -153,32 +150,36 @@ export default function TurnGame({ players: propPlayers = [], onExit }) {
   if (step === 'play') {
     return React.createElement(Card, { className: 'p-6 m-4 shadow-xl bg-white/90' },
       React.createElement(SectionTitle, { title: `${players[current]}: ${q.text}`, action: closeBtn }),
-      React.createElement('div', { className: 'space-y-2 mt-4' },
-        q.options.map((o, i) =>
-          React.createElement(Button, { key: i, className: 'bg-pink-500 text-white w-full', onClick: () => selectOption(i) }, o)
-        )
-      )
+      isCurrent ?
+        React.createElement('div', { className: 'space-y-2 mt-4' },
+          q.options.map((o, i) =>
+            React.createElement(Button, { key: i, className: 'bg-pink-500 text-white w-full', onClick: () => selectOption(i) }, o)
+          )
+        ) :
+        React.createElement('p', { className: 'mt-4' }, `Venter på ${players[current]} ...`)
     );
   }
 
   if (step === 'guess') {
     return React.createElement(Card, { className: 'p-6 m-4 shadow-xl bg-white/90' },
       React.createElement(SectionTitle, { title: `Gæt ${players[current]}'s valg (${timeLeft})`, action: closeBtn }),
-      players.filter((_, i) => i !== current).map(p =>
-        React.createElement('div', { key: p, className: 'mb-4' },
-          React.createElement('p', { className: 'font-medium mb-1' }, p),
-          React.createElement('div', { className: 'space-y-1' },
-            q.options.map((o, i) =>
-              React.createElement(Button, {
-                key: i,
-                className: 'bg-blue-500 text-white w-full',
-                onClick: () => guess(p, i),
-                disabled: guesses[p] !== undefined
-              }, o)
+      isCurrent ?
+        React.createElement('p', { className: 'mt-4' }, 'Venter på gæt ...') :
+        players.filter((_, i) => i !== current).map(p =>
+          React.createElement('div', { key: p, className: 'mb-4' },
+            React.createElement('p', { className: 'font-medium mb-1' }, p),
+            React.createElement('div', { className: 'space-y-1' },
+              q.options.map((o, i) =>
+                React.createElement(Button, {
+                  key: i,
+                  className: 'bg-blue-500 text-white w-full',
+                  onClick: () => guess(p, i),
+                  disabled: guesses[p] !== undefined
+                }, o)
+              )
             )
           )
         )
-      )
     );
   }
 


### PR DESCRIPTION
## Summary
- persist Realetten turn game state in Firestore
- create game sessions from Realetten page
- list new feature in FEATURES.txt
- show started Realetten game to all connected profiles
- show waiting messages when it's not your turn

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68863478d334832d8af63c37d617f746