### PR TITLE
Show game for all participants

### DIFF
--- a/src/components/RealettenGameOverlay.jsx
+++ b/src/components/RealettenGameOverlay.jsx
@@ -2,10 +2,10 @@ import React from 'react';
 import TurnGame from './TurnGame.jsx';
 import { X } from 'lucide-react';
 
-export default function RealettenGameOverlay({ players, onClose }) {
+export default function RealettenGameOverlay({ players, myName, onClose }) {
   return React.createElement('div', { className:'fixed inset-0 z-50 bg-black/70 flex items-center justify-center' },
     React.createElement('div', { className:'relative w-full max-w-2xl mx-4' },
-      React.createElement(TurnGame, { players, onExit:onClose }),
+      React.createElement(TurnGame, { players, myName, onExit:onClose }),
       React.createElement('button', { className:'absolute top-2 right-2 text-white bg-black/40 rounded-full p-1', onClick:onClose },
         React.createElement(X, { className:'w-6 h-6' })
       )

--- a/src/components/TurnGame.jsx
+++ b/src/components/TurnGame.jsx
@@ -27,7 +27,7 @@ const questions = [
   }
 ];
 
-export default function TurnGame({ sessionId, players: propPlayers = [], onExit }) {
+export default function TurnGame({ sessionId, players: propPlayers = [], myName, onExit }) {
   const [nameInput, setNameInput] = useState('');
   const [timeLeft, setTimeLeft] = useState(10);
   const [game, setGame] = useState(null);
@@ -147,6 +147,12 @@ export default function TurnGame({ sessionId, players: propPlayers = [], onExit 
   }
 
   if (step === 'play') {
+    if (myName && players[current] !== myName) {
+      return React.createElement(Card, { className: 'p-6 m-4 shadow-xl bg-white/90' },
+        React.createElement(SectionTitle, { title: `${players[current]}: ${q.text}`, action: closeBtn }),
+        React.createElement('p', { className:'mt-4 text-center' }, `Venter på ${players[current]}...`)
+      );
+    }
     return React.createElement(Card, { className: 'p-6 m-4 shadow-xl bg-white/90' },
       React.createElement(SectionTitle, { title: `${players[current]}: ${q.text}`, action: closeBtn }),
       React.createElement('div', { className: 'space-y-2 mt-4' },


### PR DESCRIPTION
## Summary
- update RealettenPage to open TurnGame when a game exists in Firestore
- pass the local player's name to TurnGame
- display a "waiting" message when it's not the local player's turn
- update RealettenGameOverlay to forward new prop

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68863da28900832d9122ce35ed8123e2