### PR TITLE
Fix Realetten turn game missing options

### DIFF
--- a/src/components/RealettenPage.jsx
+++ b/src/components/RealettenPage.jsx
@@ -55,6 +55,6 @@ export default function RealettenPage({ interest, userId, onBack }) {
     React.createElement(SectionTitle,{ title:'Realetten', action }),
     React.createElement(RealettenCallScreen,{ interest, userId, onEnd:onBack, onParticipantsChange:setPlayers }),
     !showGame && startButton,
-    showGame && React.createElement(TurnGame,{ sessionId: sanitizeInterest(interest), myName, onExit:()=>setShowGame(false) })
+    showGame && React.createElement(TurnGame,{ sessionId: sanitizeInterest(interest), players: playerNames, myName, onExit:()=>setShowGame(false) })
   );
 }

--- a/src/components/TurnGame.jsx
+++ b/src/components/TurnGame.jsx
@@ -56,12 +56,21 @@ export default function TurnGame({ sessionId, players: propPlayers = [], myName,
   };
 
   useEffect(() => {
-    if (!sessionId || players.length) return;
-    if (propPlayers.length) {
+    if (!sessionId || !propPlayers.length) return;
+    // If the game document is empty, initialize it with all players
+    if (!players.length) {
       const init = Object.fromEntries(propPlayers.map(p => [p, 0]));
       updateGame({ players: propPlayers, scores: init, step: propPlayers.length > 1 ? 'play' : 'setup' });
+      return;
     }
-  }, [sessionId, propPlayers]);
+    // Add any missing players that joined after the game started
+    const missing = propPlayers.filter(p => !players.includes(p));
+    if (missing.length) {
+      const updatedScores = { ...scores };
+      missing.forEach(p => { updatedScores[p] = 0; });
+      updateGame({ players: [...players, ...missing], scores: updatedScores });
+    }
+  }, [sessionId, propPlayers.toString(), players.toString(), scores]);
 
   const addPlayer = () => {
     const trimmed = nameInput.trim();


### PR DESCRIPTION
## Summary
- add Realetten participants to turn game state
- supply player names to TurnGame from `RealettenPage`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_688641ae1e9c832dbcd053d1dac1ff2b