### PR TITLE
Implement game round limit

### DIFF
--- a/src/components/RealettenPage.jsx
+++ b/src/components/RealettenPage.jsx
@@ -39,6 +39,7 @@ export default function RealettenPage({ interest, userId, onBack }) {
       scores: init,
       current: 0,
       qIdx: 0,
+      round: 1,
       step: 'play',
       choice: null,
       guesses: {},


### PR DESCRIPTION
## Summary
- initialize new games with `round: 1`
- track current round and stop after five rounds
- show round info and final results in the TurnGame UI

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68864a998ef4832d9ddcd77925eb24d0