### PR TITLE
Add winner celebration overlay

### DIFF
--- a/FEATURES.txt
+++ b/FEATURES.txt
@@ -27,3 +27,4 @@ Show Firestore credentials status
 Reusable profile filtering helper for Netlify Functions
 Track logs for individual users from admin
 Turn-based Realetten game uses Firestore for shared state and scoring
+Winner celebration overlay highlights top score

--- a/src/components/TurnGame.jsx
+++ b/src/components/TurnGame.jsx
@@ -1,4 +1,5 @@
 import React, { useState, useEffect } from 'react';
+import WinnerOverlay from './WinnerOverlay.jsx';
 import { Card } from './ui/card.js';
 import { Button } from './ui/button.js';
 import SectionTitle from './SectionTitle.jsx';
@@ -31,6 +32,7 @@ export default function TurnGame({ sessionId, players: propPlayers = [], myName,
   const [nameInput, setNameInput] = useState('');
   const [timeLeft, setTimeLeft] = useState(10);
   const [game, setGame] = useState(null);
+  const [showWinner, setShowWinner] = useState(false);
 
   useEffect(() => {
     if (!sessionId) return;
@@ -51,6 +53,10 @@ export default function TurnGame({ sessionId, players: propPlayers = [], myName,
   const choice = game?.choice ?? null;
   const guesses = game?.guesses || {};
   const step = game?.step || (players.length > 1 ? 'play' : 'setup');
+
+  useEffect(() => {
+    if (step === 'done') setShowWinner(true);
+  }, [step]);
 
   const updateGame = data => {
     if (!sessionId) return;
@@ -247,18 +253,24 @@ export default function TurnGame({ sessionId, players: propPlayers = [], myName,
   }
 
   if (step === 'done') {
-    return React.createElement(Card, { className: 'p-6 m-4 shadow-xl bg-white/90' },
-      React.createElement(SectionTitle, { title: 'Resultat', action: closeBtn }),
-      React.createElement('h3', { className: 'font-semibold mb-1' }, 'Slutstilling'),
-      React.createElement('ul', { className: 'mb-4 list-disc list-inside' },
-        players.map(p =>
-          React.createElement('li', { key: p }, `${p}: ${scores[p] || 0}`)
-        )
+    const maxScore = Math.max(...players.map(p => scores[p] || 0));
+    const winners = players.filter(p => (scores[p] || 0) === maxScore);
+    const overlay = showWinner ? React.createElement(WinnerOverlay, { winners, onClose: () => setShowWinner(false) }) : null;
+    return React.createElement(React.Fragment, null,
+      React.createElement(Card, { className: 'p-6 m-4 shadow-xl bg-white/90' },
+        React.createElement(SectionTitle, { title: 'Resultat', action: closeBtn }),
+        React.createElement('h3', { className: 'font-semibold mb-1' }, 'Slutstilling'),
+        React.createElement('ul', { className: 'mb-4 list-disc list-inside' },
+          players.map(p =>
+            React.createElement('li', { key: p }, `${p}: ${scores[p] || 0}`)
+          )
+        ),
+        closeBtn || !onExit ? null : React.createElement(Button, {
+          className: 'bg-pink-500 text-white w-full',
+          onClick: onExit
+        }, 'Luk')
       ),
-      closeBtn || !onExit ? null : React.createElement(Button, {
-        className: 'bg-pink-500 text-white w-full',
-        onClick: onExit
-      }, 'Luk')
+      overlay
     );
   }
 

--- a/src/components/WinnerOverlay.jsx
+++ b/src/components/WinnerOverlay.jsx
@@ -1,0 +1,22 @@
+import React, { useEffect } from 'react';
+import { Card } from './ui/card.js';
+import { Button } from './ui/button.js';
+import { triggerHaptic } from '../haptics.js';
+
+export default function WinnerOverlay({ winners = [], onClose }) {
+  useEffect(() => {
+    triggerHaptic([100, 50, 100]);
+  }, []);
+  const multiple = winners.length > 1;
+  const title = multiple ? 'Vinderne er:' : 'Vinderen er:';
+  const names = winners.join(' og ');
+  return React.createElement('div', { className:'fixed inset-0 z-50 bg-black/50 flex items-center justify-center' },
+    React.createElement(Card, { className:'bg-white p-6 rounded shadow-xl max-w-sm w-full text-center' },
+      React.createElement('h2', { className:'text-2xl font-bold text-pink-600 mb-4' }, 'Spillet er slut!'),
+      React.createElement('p', { className:'mb-2 font-semibold' }, title),
+      React.createElement('p', { className:'mb-4 text-xl' }, names),
+      React.createElement('div', { className:'text-4xl mb-4' }, '🎉'),
+      React.createElement(Button, { className:'w-full bg-pink-500 text-white', onClick:onClose }, 'Fedt')
+    )
+  );
+}


### PR DESCRIPTION
## Summary
- highlight the top scorer when the Realetten game ends
- display a winner overlay when the final results show
- document the new celebration feature

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68864bdd5a18832da9b0ed4788f93c9b