### PR TITLE
Add basic AI bot for Realetten testing

### DIFF
--- a/src/components/RealettenCallScreen.jsx
+++ b/src/components/RealettenCallScreen.jsx
@@ -18,7 +18,7 @@ function sanitizeInterest(i){
   return encodeURIComponent(i || '').replace(/%20/g,'_');
 }
 
-export default function RealettenCallScreen({ interest, userId, onEnd, onParticipantsChange }) {
+export default function RealettenCallScreen({ interest, userId, botId, onEnd, onParticipantsChange }) {
   const [participants, setParticipants] = useState([]);
   const localRef = useRef(null);
   const localStreamRef = useRef(null);
@@ -101,6 +101,7 @@ export default function RealettenCallScreen({ interest, userId, onEnd, onPartici
     const id = sanitizeInterest(interest);
 
     const connect = async uid => {
+      if (botId && uid === botId) return;
       if (pcsRef.current[uid]) return;
       const pairId = [userId, uid].sort().join('_');
       const callDoc = doc(db, 'realetten', id, 'calls', pairId);
@@ -232,6 +233,7 @@ export default function RealettenCallScreen({ interest, userId, onEnd, onPartici
           playsInline:true
         }),
         !uid && React.createElement('div',{className:'absolute inset-0 flex items-center justify-center text-white bg-black/60'},'Venter...'),
+        uid === botId && React.createElement('div',{className:'absolute inset-0 flex items-center justify-center text-white bg-black/60'},'\u{1F916}'),
         uid && !isSelf && React.createElement('div',{className:'absolute bottom-1 right-1 text-xs text-white bg-black/40 px-1 rounded'},uid)
       );
     })

--- a/src/components/TurnGame.jsx
+++ b/src/components/TurnGame.jsx
@@ -28,7 +28,7 @@ const questions = [
   }
 ];
 
-export default function TurnGame({ sessionId, players: propPlayers = [], myName, onExit }) {
+export default function TurnGame({ sessionId, players: propPlayers = [], myName, botName, onExit }) {
   const [nameInput, setNameInput] = useState('');
   const [timeLeft, setTimeLeft] = useState(10);
   const [game, setGame] = useState(null);
@@ -128,6 +128,28 @@ export default function TurnGame({ sessionId, players: propPlayers = [], myName,
       return () => clearInterval(id);
     }
   }, [step]);
+
+  useEffect(() => {
+    if (!botName) return;
+    if (step === 'play' && players[current] === botName && choice === null) {
+      const id = setTimeout(() => {
+        const idx = Math.floor(Math.random() * questions[qIdx].options.length);
+        selectOption(idx);
+      }, 800);
+      return () => clearTimeout(id);
+    }
+  }, [botName, step, current, choice, qIdx, players]);
+
+  useEffect(() => {
+    if (!botName) return;
+    if (step === 'guess' && players[current] !== botName && guesses[botName] === undefined) {
+      const id = setTimeout(() => {
+        const idx = Math.floor(Math.random() * questions[qIdx].options.length);
+        guess(botName, idx);
+      }, 800);
+      return () => clearTimeout(id);
+    }
+  }, [botName, step, guesses, current, qIdx, players]);
 
   const reveal = () => {
     const n = { ...scores };


### PR DESCRIPTION
## Summary
- add support for optional AI bot in Realetten video calls and game
- auto join bot and allow kicking it from Realetten page
- make TurnGame handle bot moves with random choices

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68864eee34f8832db9332e0b70412453