### PR TITLE
Add admin function to kill Realetten sessions

### DIFF
--- a/FEATURES.txt
+++ b/FEATURES.txt
@@ -28,3 +28,4 @@ Reusable profile filtering helper for Netlify Functions
 Track logs for individual users from admin
 Turn-based Realetten game uses Firestore for shared state and scoring
 Winner celebration overlay highlights top score
+Kill all Realetten sessions from admin

--- a/src/components/AdminScreen.jsx
+++ b/src/components/AdminScreen.jsx
@@ -252,6 +252,31 @@ export default function AdminScreen({ onOpenStats, onOpenBugReports, onOpenMatch
     }
   };
 
+  const killRealettenSessions = async () => {
+    if (!window.confirm('Delete all Realetten sessions?')) return;
+    try {
+      const list = await getDocs(collection(db, 'realetten'));
+      for (const docSnap of list.docs) {
+        const callsCol = collection(db, 'realetten', docSnap.id, 'calls');
+        const calls = await getDocs(callsCol);
+        for (const call of calls.docs) {
+          const offers = await getDocs(collection(callsCol, call.id, 'offerCandidates'));
+          const answers = await getDocs(collection(callsCol, call.id, 'answerCandidates'));
+          await Promise.all([
+            ...offers.docs.map(d => deleteDoc(d.ref)),
+            ...answers.docs.map(d => deleteDoc(d.ref))
+          ]);
+          await deleteDoc(call.ref);
+        }
+        await deleteDoc(docSnap.ref);
+        await deleteDoc(doc(db, 'turnGames', docSnap.id)).catch(() => {});
+      }
+      alert('Alle Realetten sessions slettet');
+    } catch (err) {
+      alert('Failed: ' + err.message);
+    }
+  };
+
   const testHaptic = () => {
     triggerHaptic([100, 50, 100]);
   };
@@ -349,6 +374,7 @@ export default function AdminScreen({ onOpenStats, onOpenBugReports, onOpenMatch
     React.createElement(Button, { className: 'mt-2 bg-blue-500 text-white px-4 py-2 rounded', onClick: () => seedData().then(() => alert('Databasen er nulstillet')) }, 'Reset database'),
     React.createElement(Button, { className: 'mt-2 bg-blue-500 text-white px-4 py-2 rounded', onClick: recoverMissing }, 'Hent mistet fra DB'),
     React.createElement(Button, { className: 'mt-2 bg-red-500 text-white px-4 py-2 rounded', onClick: resetInvites }, 'Reset invitations'),
+    React.createElement(Button, { className: 'mt-2 bg-red-500 text-white px-4 py-2 rounded', onClick: killRealettenSessions }, 'Kill Realetten sessions'),
     React.createElement('h4', { className: 'text-lg font-semibold mb-2 text-blue-600' }, t('adminPush')),
     React.createElement('div', { className: 'mt-2 flex flex-wrap gap-2' },
       React.createElement(Button, { className: 'bg-blue-500 text-white px-4 py-2 rounded', onClick: () => sendPush('Dagens klip er klar') }, 'Dagens klip er klar'),


### PR DESCRIPTION
## Summary
- add button in AdminScreen for developers to kill all Realetten sessions
- document the new capability in FEATURES.txt

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6886966ebe10832dbeccbb2bc4436649