### PR TITLE
Fix admin removal of Realetten sessions

### DIFF
--- a/src/components/AdminScreen.jsx
+++ b/src/components/AdminScreen.jsx
@@ -271,6 +271,13 @@ export default function AdminScreen({ onOpenStats, onOpenBugReports, onOpenMatch
         await deleteDoc(docSnap.ref);
         await deleteDoc(doc(db, 'turnGames', docSnap.id)).catch(() => {});
       }
+
+      // Remove any stray turnGames documents that may remain
+      const games = await getDocs(collection(db, 'turnGames'));
+      for (const game of games.docs) {
+        await deleteDoc(game.ref).catch(() => {});
+      }
+
       alert('Alle Realetten sessions slettet');
     } catch (err) {
       alert('Failed: ' + err.message);


### PR DESCRIPTION
## Summary
- ensure "Kill Realetten sessions" also clears stray turnGames docs

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_688701ea42c4832d9a3d6572182fc617