### PR TITLE
Fix Realetten button state after sessions removed

### DIFF
--- a/src/components/InterestChatScreen.jsx
+++ b/src/components/InterestChatScreen.jsx
@@ -47,12 +47,21 @@ export default function InterestChatScreen({ userId }) {
 
   useEffect(() => {
     if(!interest) return;
+    let ignore = false;
+    // reset state immediately when switching interests so
+    // the button text doesn't momentarily show outdated info
+    setRealettenStarted(false);
     const ref = doc(db, 'turnGames', sanitizeInterest(interest));
-    getDoc(ref).then(snap => setRealettenStarted(snap.exists()));
-    const unsub = onSnapshot(ref, snap => {
-      setRealettenStarted(snap.exists());
+    getDoc(ref).then(snap => {
+      if(!ignore) setRealettenStarted(snap.exists());
     });
-    return () => unsub();
+    const unsub = onSnapshot(ref, snap => {
+      if(!ignore) setRealettenStarted(snap.exists());
+    });
+    return () => {
+      ignore = true;
+      unsub();
+    };
   }, [interest]);
 
   const sendMessage = async () => {


### PR DESCRIPTION
## Summary
- avoid stale `realettenStarted` state when switching interests
- ignore async `getDoc` results after cleanup to prevent outdated button text

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6887054550bc832d9433b53933ea843d