### PR TITLE
Add profile links in group chat

### DIFF
--- a/src/VideotpushApp.jsx
+++ b/src/VideotpushApp.jsx
@@ -267,7 +267,7 @@ export default function VideotpushApp() {
               })
           ),
           tab==='chat' && React.createElement(ChatScreen, { userId, onStartCall: id => setVideoCallId(id) }),
-          tab==='interestchat' && React.createElement(InterestChatScreen, { userId }),
+          tab==='interestchat' && React.createElement(InterestChatScreen, { userId, onSelectProfile: selectProfile }),
           tab==='checkin' && React.createElement(DailyCheckIn, { userId }),
           tab==='profile' && React.createElement(ProfileSettings, {
             userId,

--- a/src/components/InterestChatScreen.jsx
+++ b/src/components/InterestChatScreen.jsx
@@ -12,7 +12,7 @@ function sanitizeInterest(i){
   return encodeURIComponent(i || '').replace(/%20/g,'_');
 }
 
-export default function InterestChatScreen({ userId }) {
+export default function InterestChatScreen({ userId, onSelectProfile = null }) {
   const profile = useDoc('profiles', userId);
   const profiles = useCollection('profiles');
   const profileMap = Object.fromEntries(profiles.map(p => [p.id, p]));
@@ -104,7 +104,14 @@ export default function InterestChatScreen({ userId }) {
           const nameAge = p.name ? `${p.name}, ${p.birthday?getAge(p.birthday):p.age||''}` : '';
           return React.createElement('div',{key:i,className:`flex ${fromSelf?'justify-end':'justify-start'}`},
             React.createElement('div',{className:'space-y-1 max-w-[75%]'},
-              React.createElement('div',{className:'text-xs text-gray-500'}, nameAge?`${nameAge} \u2013 ${time}`:time),
+              React.createElement('div',{className:'text-xs text-gray-500'},
+                nameAge ?
+                  React.createElement('span', {
+                    className: onSelectProfile ? 'text-blue-600 underline cursor-pointer' : undefined,
+                    onClick: onSelectProfile ? ()=>onSelectProfile(m.from) : undefined
+                  }, `${nameAge} \u2013 ${time}`) :
+                  time
+              ),
               React.createElement('div',{className:`inline-block px-3 py-2 rounded-lg ${fromSelf?'bg-pink-500 text-white':'bg-gray-200 text-black'}`}, m.text)
             )
           );


### PR DESCRIPTION
## Summary
- allow `InterestChatScreen` to receive `onSelectProfile`
- pass `selectProfile` handler from `VideotpushApp`
- make names in group chat clickable to open public profile

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68870b5c2e5c832da82e1f07d7a234cb