### PR TITLE
Show invite link when overlay opens

### DIFF
--- a/src/components/InviteOverlay.jsx
+++ b/src/components/InviteOverlay.jsx
@@ -8,11 +8,12 @@ export default function InviteOverlay({ userId, onClose }) {
   const t = useT();
   const profiles = useCollection('profiles');
   const user = profiles.find(p => p.id === userId) || {};
-  const invites = useCollection('invites','inviterId', userId) || [];
+  const invites = useCollection('invites','inviterId', userId);
   const invitesUsed = invites.filter(inv => inv.gift).length;
   const config = useDoc('config','app') || {};
   const invitesEnabled = config.premiumInvitesEnabled !== false;
   const remaining = 10 - invitesUsed;
+  const noInvites = invitesEnabled && remaining <= 0;
   const [recipient, setRecipient] = useState('');
   const [link, setLink] = useState('');
   const [inviteId, setInviteId] = useState(null);
@@ -38,6 +39,12 @@ export default function InviteOverlay({ userId, onClose }) {
       return '';
     }
   };
+
+  useEffect(() => {
+    if (invites.loaded && !inviteId && !noInvites) {
+      createInvite(recipient);
+    }
+  }, [invites.loaded]);
 
 
   useEffect(() => {
@@ -83,7 +90,6 @@ export default function InviteOverlay({ userId, onClose }) {
     }
   };
 
-  const noInvites = invitesEnabled && remaining <= 0;
   const text = invitesEnabled
     ? (remaining > 0
         ? `Tilbyd 3 måneders gratis premium. Du har ${remaining} tilbage`


### PR DESCRIPTION
## Summary
- generate invite link automatically when InviteOverlay mounts
- keep loaded state from `useCollection`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68870c403e5c832da142353294fe3ffe