### PR TITLE
Fix participant reordering

### DIFF
--- a/src/components/RealettenCallScreen.jsx
+++ b/src/components/RealettenCallScreen.jsx
@@ -117,8 +117,14 @@ export default function RealettenCallScreen({ interest, userId, botId, onEnd, on
         });
       }
       const activeList = list.filter(uid => !stale.includes(uid));
-      setParticipants(activeList);
-      if (onParticipantsChange) onParticipantsChange(activeList);
+      const sortedList = activeList.slice();
+      const selfIndex = sortedList.indexOf(userId);
+      if (selfIndex > 0) {
+        sortedList.splice(selfIndex, 1);
+        sortedList.unshift(userId);
+      }
+      setParticipants(sortedList);
+      if (onParticipantsChange) onParticipantsChange(sortedList);
     });
     join();
     return () => {


### PR DESCRIPTION
## Summary
- keep the current user first when ordering participants in Realetten calls

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68870dbdc830832d931b0e14377ea7f2