### PR TITLE
Fix Realetten user order

### DIFF
--- a/src/components/RealettenCallScreen.jsx
+++ b/src/components/RealettenCallScreen.jsx
@@ -121,8 +121,9 @@ export default function RealettenCallScreen({ interest, userId, botId, onEnd, on
         });
       }
       const activeList = list.filter(uid => !stale.includes(uid));
-      setParticipants(activeList);
-      if (onParticipantsChange) onParticipantsChange(activeList);
+      const ordered = [userId, ...activeList.filter(uid => uid !== userId)];
+      setParticipants(ordered);
+      if (onParticipantsChange) onParticipantsChange(ordered);
     });
     join();
     return () => {


### PR DESCRIPTION
## Summary
- keep the current user first in `RealettenCallScreen`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_688711a7cd98832da3a313d3e9e10893