### PR TITLE
Fix back navigation from group chat profile view

### DIFF
--- a/src/VideotpushApp.jsx
+++ b/src/VideotpushApp.jsx
@@ -52,6 +52,7 @@ export default function VideotpushApp() {
   const [ageRange,setAgeRange]=useState([35,55]);
   const [tab,setTab]=useState('admin');
   const [viewProfile,setViewProfile]=useState(null);
+  const [returnTab,setReturnTab]=useState('discovery');
   const [videoCallId,setVideoCallId]=useState(null);
   const [showHelp,setShowHelp]=useState(false);
   const [activeTask, setActiveTask] = useState(null);
@@ -69,8 +70,9 @@ export default function VideotpushApp() {
   }, [currentUser, activeTask]);
 
   const openDailyClips = () => {
-    setTab('discovery');
+    setTab(returnTab);
     setViewProfile(null);
+    setReturnTab('discovery');
   };
 
   const openProfileSettings = () => {
@@ -119,6 +121,7 @@ export default function VideotpushApp() {
   };
 
   const viewOwnPublicProfile = () => {
+    setReturnTab('profile');
     setViewProfile(userId);
     setTab('discovery');
   };
@@ -201,6 +204,7 @@ export default function VideotpushApp() {
     } })
   );
   const selectProfile = async id => {
+    setReturnTab(tab);
     setViewProfile(id);
     setTab('discovery');
     try {


### PR DESCRIPTION
## Summary
- preserve previous tab before opening a profile
- return to the originating tab when leaving a public profile
- ensure viewing own profile returns to profile settings

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_688711ec4b60832db3ddc408e3f36e81