### PR TITLE
Fix participant order in group call

### DIFF
--- a/src/components/RealettenCallScreen.jsx
+++ b/src/components/RealettenCallScreen.jsx
@@ -121,9 +121,17 @@ export default function RealettenCallScreen({ interest, userId, botId, onEnd, on
         });
       }
       const activeList = list.filter(uid => !stale.includes(uid));
-      const ordered = [userId, ...activeList.filter(uid => uid !== userId)];
-      setParticipants(ordered);
-      if (onParticipantsChange) onParticipantsChange(ordered);
+      setParticipants(prev => {
+        const prevOthers = prev.filter(id => id !== userId);
+        const newOthers = activeList.filter(id => id !== userId);
+        const orderedOthers = prevOthers.filter(id => newOthers.includes(id));
+        newOthers.forEach(id => {
+          if (!orderedOthers.includes(id)) orderedOthers.push(id);
+        });
+        const ordered = [userId, ...orderedOthers];
+        if (onParticipantsChange) onParticipantsChange(ordered);
+        return ordered;
+      });
     });
     join();
     return () => {


### PR DESCRIPTION
## Summary
- keep the local user fixed in the first slot of Realetten group calls

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68871286a208832d9aa0029e585697b7