### PR TITLE
Fix winner popup after AI removal

### DIFF
--- a/src/components/RealettenPage.jsx
+++ b/src/components/RealettenPage.jsx
@@ -26,7 +26,8 @@ export default function RealettenPage({ interest, userId, onBack }) {
     const gameId = sanitizeInterest(interest);
     const ref = doc(db, 'turnGames', gameId);
     const unsub = onSnapshot(ref, snap => {
-      setShowGame(snap.exists());
+      const data = snap.data() || {};
+      setShowGame(snap.exists() && data.step !== 'done');
     });
     return () => unsub();
   }, [interest]);


### PR DESCRIPTION
## Summary
- prevent `WinnerOverlay` from reappearing when removing the AI after a finished game

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6887143727d0832db0d9652640cfb058