### PR TITLE
Fix turn indicator logic

### DIFF
--- a/src/components/ChatScreen.jsx
+++ b/src/components/ChatScreen.jsx
@@ -196,7 +196,12 @@ export default function ChatScreen({ userId, onStartCall }) {
           chats.map(m => {
             const p = profileMap[m.profileId] || {};
             const lastMessages = m.messages || [];
-            const last = lastMessages[lastMessages.length - 1];
+            const last = lastMessages.reduce((acc, cur) => {
+              if (!acc) return cur;
+              const aTs = acc.ts || 0;
+              const cTs = cur.ts || 0;
+              return cTs > aTs ? cur : acc;
+            }, null);
             const lastFromOther = last && last.from !== userId;
             return React.createElement('li', {
               key: m.id,


### PR DESCRIPTION
## Summary
- ensure chat 'Your turn' indicator is based on the most recent message

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68871910cbc8832db6d543c6e50f386b