### PR TITLE
Bump version

### DIFF
--- a/README.md
+++ b/README.md
@@ -182,7 +182,7 @@ To ensure users receive new versions, update the `CACHE_NAME` constant near the 
 ```javascript
 // Bump the cache name whenever cached files change to ensure
 // clients receive the latest versions.
-const CACHE_NAME = 'videotpush-v1';
+const CACHE_NAME = 'videotpush-v2';
 ```
 
 Change the value (for example to `videotpush-v2`) when deploying a new build. During activation the service worker deletes caches that do not match this name:

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "videotpush",
-  "version": "1.0.53",
+  "version": "1.0.55",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "videotpush",
-      "version": "1.0.53",
+      "version": "1.0.55",
       "dependencies": {
         "@heroicons/react": "^2.0.18",
         "firebase": "^9.23.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "videotpush",
-  "version": "1.0.53",
+  "version": "1.0.55",
   "description": "A minimal React PWA for swiping short videos and speed dating.",
   "scripts": {
     "start": "npx serve .",

--- a/public/service-worker.js
+++ b/public/service-worker.js
@@ -1,6 +1,6 @@
 // Bump the cache name whenever cached files change to ensure
 // clients receive the latest versions.
-const CACHE_NAME = 'videotpush-v1';
+const CACHE_NAME = 'videotpush-v2';
 // Cache for images, audio and video so large media files work offline
 const MEDIA_CACHE = 'media-cache-v1';
 const URLS_TO_CACHE = [

--- a/src/version.js
+++ b/src/version.js
@@ -1,1 +1,1 @@
-export default '1.0.53';
+export default '1.0.55';


### PR DESCRIPTION
## Summary
- update version to 1.0.55 in package manifests
- update src/version.js
- update cache name to `videotpush-v2` in service worker and README

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_688723488dbc832dbee35409a399dc0f