### PR TITLE
Document Firebase auth setup for password reset

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,15 @@ Appen bruger generelt en rød/lyserød farveskala. Adminknapperne er blå, mens 
 4. Open the provided local URL (typically http://localhost:1234) in your browser.
 5. Sign up with your name to start swiping.
 
+## Password Reset Setup
+
+If you plan to use the "Forgot password?" link, make sure your Firebase project
+is configured for it:
+
+1. Under **Authentication → Sign-in method** enable **Email/Password**.
+2. Add your site domain to **Authentication → Settings → Authorized Domains**.
+   Without the domain entry, Firebase will silently fail to send reset emails.
+
 To create a production build run:
 ```bash
 npm run build

--- a/docs/production-checklist.md
+++ b/docs/production-checklist.md
@@ -30,8 +30,12 @@ This document tracks the remaining technical tasks required to deploy the RealDa
 ## 6. Domain and HTTPS
 - Choose a custom domain for the site and configure DNS records to point to GitHub Pages or another hosting provider.
 - Enable HTTPS and HSTS for secure communication.
+- Add your site domain under **Authentication → Settings → Authorized Domains** in Firebase so password reset emails work.
 
-## 7. Monitoring
+## 7. Authentication
+- Enable the **Email/Password** sign-in method in the Firebase console.
+
+## 8. Monitoring
 - Monitor Firebase and Netlify logs for errors after deployment.
 - Periodically review the client and server logs for unexpected issues.
 


### PR DESCRIPTION
## Summary
- note how to enable email/password sign-in and authorized domains
- clarify Firebase authentication tasks in production checklist

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_688a6d2643d0832dae80d6e0b42c43f5