### PR TITLE
Fix test guide overlay start

### DIFF
--- a/src/components/FunctionTestGuide.jsx
+++ b/src/components/FunctionTestGuide.jsx
@@ -10,22 +10,34 @@ export default function FunctionTestGuide() {
   const startX = useRef(0);
 
   useEffect(() => {
-    const stored = localStorage.getItem('functionTestGuide');
-    if (stored) {
-      try {
-        const data = JSON.parse(stored);
-        setModuleIndex(data.module);
-        setStepIndex(data.step || 0);
-      } catch {}
-    }
+    const read = () => {
+      const stored = localStorage.getItem('functionTestGuide');
+      if (stored) {
+        try {
+          const data = JSON.parse(stored);
+          setModuleIndex(data.module);
+          setStepIndex(data.step || 0);
+          return;
+        } catch {}
+      }
+      setModuleIndex(null);
+    };
+    read();
+    window.addEventListener('storage', read);
+    window.addEventListener('functionTestGuideChange', read);
+    return () => {
+      window.removeEventListener('storage', read);
+      window.removeEventListener('functionTestGuideChange', read);
+    };
   }, []);
 
   useEffect(() => {
     if (moduleIndex === null) {
       localStorage.removeItem('functionTestGuide');
-      return;
+    } else {
+      localStorage.setItem('functionTestGuide', JSON.stringify({ module: moduleIndex, step: stepIndex }));
     }
-    localStorage.setItem('functionTestGuide', JSON.stringify({ module: moduleIndex, step: stepIndex }));
+    window.dispatchEvent(new Event('functionTestGuideChange'));
   }, [moduleIndex, stepIndex]);
 
   if (moduleIndex === null) return null;

--- a/src/components/FunctionTestScreen.jsx
+++ b/src/components/FunctionTestScreen.jsx
@@ -113,8 +113,9 @@ export default function FunctionTestScreen({ onBack }) {
 
   const module = modules[activeModule];
   const startGuide = () => {
-    localStorage.setItem("functionTestGuide", JSON.stringify({ module: activeModule, step: 0 }));
-    alert("Test guide started");
+    localStorage.setItem('functionTestGuide', JSON.stringify({ module: activeModule, step: 0 }));
+    window.dispatchEvent(new Event('functionTestGuideChange'));
+    alert('Test guide started');
   };
   return React.createElement(Card, { className:'p-6 m-4 shadow-xl bg-white/90' },
     React.createElement(SectionTitle, { title:module.name, colorClass:'text-blue-600', action: React.createElement("div", { className:"flex gap-2" }, React.createElement(Button, { className:"bg-green-500 text-white px-2 py-1 rounded", onClick: startGuide }, "Run"), React.createElement(Button, { onClick: () => setActiveModule(-1) }, t("back"))) }),


### PR DESCRIPTION
## Summary
- listen for guide activation events in `FunctionTestGuide`
- fire a `functionTestGuideChange` event when starting the guide

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_688b1288fe70832d826f9b0b2a97e76c