### PR TITLE
Fix FunctionTestGuide handle reappearance

### DIFF
--- a/src/components/FunctionTestGuide.jsx
+++ b/src/components/FunctionTestGuide.jsx
@@ -40,6 +40,13 @@ export default function FunctionTestGuide() {
     window.dispatchEvent(new Event('functionTestGuideChange'));
   }, [moduleIndex, stepIndex]);
 
+  // Ensure the handle is visible whenever a new test starts
+  useEffect(() => {
+    if (moduleIndex !== null) {
+      setVisible(false);
+    }
+  }, [moduleIndex]);
+
   if (moduleIndex === null) return null;
   const mod = modules[moduleIndex];
   if (!mod) return null;


### PR DESCRIPTION
## Summary
- ensure FunctionTestGuide handle is reset when starting a new test

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_688b140a2550832db0e89038755519c7