### PR TITLE
Add actions and hint to function test overlay

### DIFF
--- a/src/VideotpushApp.jsx
+++ b/src/VideotpushApp.jsx
@@ -83,6 +83,17 @@ export default function VideotpushApp() {
     setViewProfile(null);
   };
 
+  useEffect(() => {
+    const handler = e => {
+      if (e.detail === 'dailyClips') {
+        setTab('discovery');
+        setViewProfile(null);
+      }
+    };
+    window.addEventListener('functionTestAction', handler);
+    return () => window.removeEventListener('functionTestAction', handler);
+  }, []);
+
   const handleTaskClick = () => {
     const task = getNextTask(currentUser);
     if (!task) return;

--- a/src/components/FunctionTestGuide.jsx
+++ b/src/components/FunctionTestGuide.jsx
@@ -69,21 +69,29 @@ export default function FunctionTestGuide() {
   return (
     React.createElement(React.Fragment, null,
       !visible && React.createElement('div', {
-        className:'fixed top-1/2 right-0 -translate-y-1/2 bg-pink-600 text-white px-2 py-1 rounded-l cursor-pointer z-40',
+        className: 'fixed top-1/2 right-0 -translate-y-1/2 bg-pink-600 text-white px-2 py-1 rounded-l cursor-pointer z-40',
         onClick: () => setVisible(true)
       }, '▶'),
       visible && React.createElement('div', {
-        className:'fixed inset-0 z-40 bg-black/50 flex items-center justify-center',
+        className: 'fixed inset-0 z-40 bg-black/50 flex items-center justify-center',
         onTouchStart,
         onTouchEnd
       },
-        React.createElement(Card, { className:'bg-white p-4 rounded shadow-xl max-w-xs w-full' },
-          React.createElement('h3', { className:'font-bold mb-2 text-pink-600 text-center' }, mod.name),
-          React.createElement('div', { className:'font-medium mb-1' }, feature.title),
-          React.createElement('ul', { className:'list-disc ml-5 text-sm mb-2' },
-            feature.expected.map((ex, i) => React.createElement('li', { key:i }, ex))
+        React.createElement(Card, { className: 'bg-white p-4 rounded shadow-xl max-w-xs w-full' },
+          React.createElement('h3', { className: 'font-bold mb-2 text-pink-600 text-center' }, mod.name),
+          React.createElement('div', { className: 'font-medium mb-1' }, feature.title),
+          React.createElement('ul', { className: 'list-disc ml-5 text-sm mb-2' },
+            feature.expected.map((ex, i) => React.createElement('li', { key: i }, ex))
           ),
-          React.createElement(Button, { className:'bg-blue-500 text-white w-full', onClick: next }, stepIndex + 1 < mod.features.length ? 'Next' : 'Finish')
+          feature.action && React.createElement(Button, {
+            className: 'bg-pink-600 text-white w-full mb-2',
+            onClick: () => {
+              window.dispatchEvent(new CustomEvent('functionTestAction', { detail: feature.action.event }));
+              setVisible(false);
+            }
+          }, feature.action.label),
+          React.createElement('div', { className: 'text-center text-xs text-gray-500 mb-2' }, 'Swipe right to hide ▶'),
+          React.createElement(Button, { className: 'bg-blue-500 text-white w-full', onClick: next }, stepIndex + 1 < mod.features.length ? 'Next' : 'Finish')
         )
       )
     )

--- a/src/functionTestModules.js
+++ b/src/functionTestModules.js
@@ -8,7 +8,8 @@ export const modules = [
           'New clips become available every day',
           'Free users see up to 3 clips, subscribers see 6',
           'The list resets the next day'
-        ]
+        ],
+        action: { label: 'Go to Daily Clips', event: 'dailyClips' }
       },
       {
         title: 'Option to buy 3 extra clips for the day',


### PR DESCRIPTION
## Summary
- allow function test modules to include an `action`
- show hint to swipe right to hide overlay
- enable navigation actions from the test guide

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_688b16e2891c832dbdf168c6cb97de9b