### PR TITLE
Extend FunctionTest actions

### DIFF
--- a/src/VideotpushApp.jsx
+++ b/src/VideotpushApp.jsx
@@ -85,9 +85,22 @@ export default function VideotpushApp() {
 
   useEffect(() => {
     const handler = e => {
-      if (e.detail === 'dailyClips') {
-        setTab('discovery');
-        setViewProfile(null);
+      switch (e.detail) {
+        case 'dailyClips':
+          setTab('discovery');
+          setViewProfile(null);
+          break;
+        case 'openAdmin':
+          openAdmin();
+          break;
+        case 'openProfileSettings':
+          openProfileSettings();
+          break;
+        case 'logout':
+          logout();
+          break;
+        default:
+          break;
       }
     };
     window.addEventListener('functionTestAction', handler);

--- a/src/components/FunctionTestGuide.jsx
+++ b/src/components/FunctionTestGuide.jsx
@@ -60,6 +60,14 @@ export default function FunctionTestGuide() {
     }
   };
 
+  const runActions = async events => {
+    setVisible(false);
+    for (const ev of events) {
+      window.dispatchEvent(new CustomEvent('functionTestAction', { detail: ev }));
+      await new Promise(r => setTimeout(r, 600));
+    }
+  };
+
   const onTouchStart = e => { startX.current = e.touches[0].clientX; };
   const onTouchEnd = e => {
     const dx = e.changedTouches[0].clientX - startX.current;
@@ -85,13 +93,25 @@ export default function FunctionTestGuide() {
           ),
           feature.action && React.createElement(Button, {
             className: 'bg-pink-600 text-white w-full mb-2',
-            onClick: () => {
-              window.dispatchEvent(new CustomEvent('functionTestAction', { detail: feature.action.event }));
-              setVisible(false);
+            onClick: async () => {
+              const events = Array.isArray(feature.action.events)
+                ? feature.action.events
+                : [feature.action.event].filter(Boolean);
+              if (events.length) {
+                await runActions(events);
+              }
             }
           }, feature.action.label),
           React.createElement('div', { className: 'text-center text-xs text-gray-500 mb-2' }, 'Swipe right to hide ▶'),
-          React.createElement(Button, { className: 'bg-blue-500 text-white w-full', onClick: next }, stepIndex + 1 < mod.features.length ? 'Next' : 'Finish')
+          React.createElement(Button, { className: 'bg-blue-500 text-white w-full', onClick: async () => {
+            const events = feature.action ? (Array.isArray(feature.action.events) ? feature.action.events : [feature.action.event].filter(Boolean)) : [];
+            if (events.length) {
+              await runActions(events);
+            }
+            const more = stepIndex + 1 < mod.features.length;
+            next();
+            if (more) setVisible(true);
+          } }, stepIndex + 1 < mod.features.length ? 'Next' : 'Finish')
         )
       )
     )

--- a/src/components/WelcomeScreen.jsx
+++ b/src/components/WelcomeScreen.jsx
@@ -85,6 +85,29 @@ export default function WelcomeScreen({ onLogin }) {
     }
   };
 
+  React.useEffect(() => {
+    const handler = e => {
+      switch (e.detail) {
+        case 'showLogin':
+          setShowLoginForm(true);
+          break;
+        case 'fillLoginUser':
+          setLoginUser('test@example.com');
+          break;
+        case 'fillLoginPass':
+          setLoginPass('password');
+          break;
+        case 'submitLogin':
+          handleLogin();
+          break;
+        default:
+          break;
+      }
+    };
+    window.addEventListener('functionTestAction', handler);
+    return () => window.removeEventListener('functionTestAction', handler);
+  }, []);
+
   const finalizeRegistration = async (id, profile, uid, inviteId, inviteValid, giftFrom) => {
     await setDoc(doc(db, 'profiles', id), { ...profile, uid });
     await setDoc(doc(db, 'users', uid), { profileId: id });

--- a/src/functionTestModules.js
+++ b/src/functionTestModules.js
@@ -91,7 +91,8 @@ export const modules = [
           'Settings screen allows editing basic info',
           'Admin mode adds extra controls',
           'Only admins can access the admin menu'
-        ]
+        ],
+        action: { label: 'Open Profile', event: 'openProfileSettings' }
       },
       {
         title: 'Preferred languages with option to allow other languages',
@@ -181,7 +182,8 @@ export const modules = [
           'Admin screen lists available test profiles',
           'Selecting a profile switches the current user',
           'Switching back restores admin access'
-        ]
+        ],
+        action: { label: 'Open Admin', event: 'openAdmin' }
       },
       {
         title: 'Daily stats saved automatically and shown as graphs in admin',
@@ -234,7 +236,8 @@ export const modules = [
           'Existing user can log in with correct credentials',
           'Invalid credentials show an error message',
           'Successful login opens discovery'
-        ]
+        ],
+        action: { label: 'Auto Login', events: ['showLogin','fillLoginUser','fillLoginPass','submitLogin'] }
       },
       {
         title: 'Reset password with "Forgot Password"',


### PR DESCRIPTION
## Summary
- allow FunctionTestGuide to run multiple actions sequentially
- add event handling for more actions in the main app and welcome screen
- define new actions in the function test modules

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_688b1f285188832da35867a1e311fcb4