### PR TITLE
Add automation and improvements to function tests

### DIFF
--- a/src/VideotpushApp.jsx
+++ b/src/VideotpushApp.jsx
@@ -96,6 +96,9 @@ export default function VideotpushApp() {
         case 'openProfileSettings':
           openProfileSettings();
           break;
+        case 'openBugReports':
+          openBugReports();
+          break;
         case 'logout':
           logout();
           break;
@@ -124,6 +127,11 @@ export default function VideotpushApp() {
       return;
     }
     setTab('admin');
+    setViewProfile(null);
+  };
+
+  const openBugReports = () => {
+    setTab('bugs');
     setViewProfile(null);
   };
 


### PR DESCRIPTION
## Summary
- extend automation hook in the app to open bug reports from tests
- add screenshot capture, N/A status, comment history and auto-run
- show progress summary and link to bugs

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_688b2923db84832d9359093b14a902da