### PR TITLE
Update Danish docs on archived profiles

### DIFF
--- a/docs/app-pages-da.md
+++ b/docs/app-pages-da.md
@@ -15,14 +15,14 @@
 - Videoklip kan maksimalt vare 10 sekunder, og en timer tæller ned under optagelsen.
 
 ## Dagens klip
-- Ved indgang vises listen med kandidatprofiler samt eventuelle arkiverede profiler.
+- Ved indgang vises listen med kandidatprofiler samt eventuelle ratede eller likede profiler.
 - Listen indeholder aktive profiler fra tidligere dage plus dagens nye (3 eller 6).
 - Hvis serveren returnerer for få nye profiler, kan brugeren udvide maks-afstanden.
 - **Handlinger på kandidatlisten**
   - Åbn en profil for at se den offentlige kandidatprofil.
   - Vælg "Like" (kan blive til et match).
   - Vælg "Remove" for at fjerne profilen helt, medmindre rating 3 eller 4 er givet 
-    (så vises den under arkiverede profiler).
+    (så vises den under ratede eller likede profiler).
 - Brugeren kan én gang dagligt købe ekstra profiler.
 
 ### Offentlig kandidatprofil

--- a/src/i18n.js
+++ b/src/i18n.js
@@ -147,8 +147,8 @@ inviteAccepted:{ en:"Profile created", da:"Oprettet", sv:"Skapad", es:"Perfil cr
   },
   max10Sec:{ en:'Max 10 sec', da:'Max 10 sek', sv:'Max 10 sek', es:'M\u00e1x 10 seg', fr:'Max 10 s', de:'Max 10 Sek' },
   remove:{ en:'Remove', da:'Fjern', sv:'Ta bort', es:'Eliminar', fr:'Supprimer', de:'Entfernen' },
-  showArchived:{ en:'Show archived profiles', da:'Vis gemte profiler', sv:'Visa arkiverade profiler', es:'Mostrar perfiles archivados', fr:'Afficher les profils archivés', de:'Archivierte Profile anzeigen' },
-  archivedProfiles:{ en:'Archived profiles', da:'Tidligere profiler', sv:'Tidigare profiler', es:'Perfiles archivados', fr:'Profils archivés', de:'Archivierte Profile' },
+  showArchived:{ en:'Show archived profiles', da:'Vis ratede eller likede profiler', sv:'Visa arkiverade profiler', es:'Mostrar perfiles archivados', fr:'Afficher les profils archivés', de:'Archivierte Profile anzeigen' },
+  archivedProfiles:{ en:'Archived profiles', da:'Ratede eller likede profiler', sv:'Tidigare profiler', es:'Perfiles archivados', fr:'Profils archivés', de:'Archivierte Profile' },
   qrOpen:{
     en:'Scan to open RealDate',
     da:'Scan for at \u00e5bne RealDate',


### PR DESCRIPTION
## Summary
- update terminology in Danish docs to replace `arkiverede profiler` with `ratede eller likede profiler`
- fix Danish button text to show `ratede eller likede profiler`

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_688b56bf9454832d8291317200496315