### PR TITLE
feat: allow reopening console log panel

### DIFF
--- a/src/components/AdminScreen.jsx
+++ b/src/components/AdminScreen.jsx
@@ -7,7 +7,7 @@ import { Button } from './ui/button.js';
 import SectionTitle from './SectionTitle.jsx';
 import seedData from '../seedData.js';
 import { db, collection, getDocs, deleteDoc, updateDoc, doc, getDoc, query, where, storage, listAll, ref, getDownloadURL, deleteObject, messaging, setExtendedLogging, isExtendedLogging, useDoc } from '../firebase.js';
-import { setConsoleCapture, isConsoleCapture } from '../consoleLogs.js';
+import { setConsoleCapture, isConsoleCapture, showConsolePanel } from '../consoleLogs.js';
 import { advanceDay, resetDay, getTodayStr } from '../utils.js';
 import { getToken } from 'firebase/messaging';
 import { fcmReg } from '../swRegistration.js';
@@ -36,6 +36,10 @@ export default function AdminScreen({ onOpenStats, onOpenBugReports, onOpenMatch
     const val = !consoleEnabled;
     setConsoleEnabled(val);
     setConsoleCapture(val);
+  };
+
+  const showConsoleLog = () => {
+    showConsolePanel();
   };
 
   const sendPush = async body => {
@@ -402,6 +406,7 @@ export default function AdminScreen({ onOpenStats, onOpenBugReports, onOpenMatch
       React.createElement('input', { type: 'checkbox', className: 'mr-2', checked: consoleEnabled, onChange: toggleConsole }),
       'Vis console log'
     ),
+    React.createElement(Button, { className: 'bg-blue-500 text-white px-4 py-2 rounded mb-2', onClick: showConsoleLog }, 'Åbn console vindue'),
     React.createElement('label', { className: 'flex items-center mb-2' },
       React.createElement('input', {
         type: 'checkbox',

--- a/src/components/ConsoleLogPanel.jsx
+++ b/src/components/ConsoleLogPanel.jsx
@@ -16,6 +16,18 @@ export default function ConsoleLogPanel() {
     return () => removeLogListener(handler);
   }, []);
 
+  useEffect(() => {
+    const handler = () => setVisible(true);
+    if (typeof window !== 'undefined') {
+      window.addEventListener('consolePanelShow', handler);
+    }
+    return () => {
+      if (typeof window !== 'undefined') {
+        window.removeEventListener('consolePanelShow', handler);
+      }
+    };
+  }, []);
+
   const copyLogs = async () => {
     try {
       const text = logs.map(l => `[${l.timestamp}] ${l.msg}`).join('\n');

--- a/src/consoleLogs.js
+++ b/src/consoleLogs.js
@@ -60,3 +60,10 @@ export function setConsoleCapture(val) {
 export function isConsoleCapture() {
   return capture;
 }
+
+export function showConsolePanel() {
+  if (typeof window !== 'undefined') {
+    localStorage.setItem('consolePanelVisible', 'true');
+    window.dispatchEvent(new Event('consolePanelShow'));
+  }
+}


### PR DESCRIPTION
## Summary
- add `showConsolePanel` helper to restore console log window
- let `ConsoleLogPanel` listen for panel reactivation events
- expose a button on admin screen to reopen the console logging panel

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_688c954ba878832da5c7894a19093657