### PR TITLE
test: add chat action button to function test guide

### DIFF
--- a/docs/function-test-modules.md
+++ b/docs/function-test-modules.md
@@ -25,7 +25,7 @@ Use the admin menu to open *Funktionstest* and choose a module to start testing.
 
 ### Chat & Reflections
 
-- Send a chat message to a match and confirm it appears on both devices.
+- Start a chat by sending a message as one user. Log in as the matched user, reply, and confirm the first user sees the response.
 - Trigger the match celebration overlay and make sure it can be dismissed.
 - Open the reflection calendar and verify ratings or notes appear on the correct dates.
 

--- a/src/VideotpushApp.jsx
+++ b/src/VideotpushApp.jsx
@@ -128,6 +128,10 @@ export default function VideotpushApp() {
         case 'openBugReports':
           openBugReports();
           break;
+        case 'openChat':
+          setTab('chat');
+          setViewProfile(null);
+          break;
         case 'logout':
           logout();
           break;

--- a/src/functionTestModules.js
+++ b/src/functionTestModules.js
@@ -51,10 +51,11 @@ export const modules = [
       {
         title: 'Basic chat between matched profiles with option to unmatch',
         expected: [
-          'Matched users can exchange messages',
-          'Unmatching removes the chat for both',
-          'Messages update in real time'
-        ]
+          'Send a message as one user',
+          'Log in as the matched user, reply, and confirm the first user sees it',
+          'Unmatching removes the chat for both'
+        ],
+        action: { label: 'Open Chat', event: 'openChat' }
       },
       {
         title: 'Improved chat layout with timestamps',


### PR DESCRIPTION
## Summary
- connect chat scenario to function test guide with an action button
- handle `openChat` test event to navigate directly to chat

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_688c9853f020832d94ea029b06005d9b