### PR TITLE
Hide admin button for non-admin users

### DIFF
--- a/src/VideotpushApp.jsx
+++ b/src/VideotpushApp.jsx
@@ -323,7 +323,7 @@ export default function VideotpushApp() {
       userId && React.createElement('div', {
         className: 'absolute top-1/2 left-4 -translate-y-1/2 flex gap-4'
       },
-        React.createElement('div', { className: 'relative cursor-pointer', onClick: openAdmin },
+        isAdminUser(auth.currentUser) && React.createElement('div', { className: 'relative cursor-pointer', onClick: openAdmin },
           React.createElement(Shield, { className: 'w-6 h-6 text-white' })
         ),
         React.createElement('div', { className: 'relative cursor-pointer', onClick: openNotifications },


### PR DESCRIPTION
## Summary
- Show admin shortcut only when logged in user is authorized

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_688ddf80ba74832d8f0525c51a88ef20