### PR TITLE
Show recent activity on public profile

### DIFF
--- a/src/components/ProfileSettings.jsx
+++ b/src/components/ProfileSettings.jsx
@@ -54,6 +54,9 @@ export default function ProfileSettings({ userId, ageRange, onChangeAgeRange, pu
   const progressId = publicView && viewerId && viewerId !== userId ? `${viewerId}-${userId}` : null;
   const progress = useDoc('episodeProgress', progressId);
   const stage = isOwnProfile ? 3 : (progress?.stage || 1);
+  const activeNow = profile?.lastActive
+    ? (getCurrentDate().getTime() - new Date(profile.lastActive).getTime()) < 3 * 60 * 60 * 1000
+    : false;
 
   const handlePurchase = async () => {
     const now = getCurrentDate();
@@ -541,7 +544,10 @@ export default function ProfileSettings({ userId, ageRange, onChangeAgeRange, pu
           }, 'Gem ændringer')
         ) :
         React.createElement('div', { className:'flex items-center justify-between w-full' },
-          React.createElement(SectionTitle, { title: `${profile.name}, ${profile.birthday ? getAge(profile.birthday) : profile.age}${profile.city ? ', ' + profile.city : ''}` })
+          React.createElement(SectionTitle, {
+            title: `${profile.name}, ${profile.birthday ? getAge(profile.birthday) : profile.age}${profile.city ? ', ' + profile.city : ''}`,
+            action: publicView && activeNow ? React.createElement('span', { className: 'text-sm text-green-600 font-medium' }, t('activeNow')) : null
+          })
         ),
       isOwnProfile && !publicView && profile.email && React.createElement('p', { className:'text-center text-sm text-gray-600 mt-1' }, profile.email),
       !publicView && profile.subscriptionExpires && React.createElement('p', {

--- a/src/i18n.js
+++ b/src/i18n.js
@@ -185,6 +185,7 @@ inviteAccepted:{ en:"Profile created", da:"Oprettet", sv:"Skapad", es:"Perfil cr
   revealTestTitle:{ en:'Reveal test', da:'Reveal test', sv:'Reveal test', es:'Prueba de revelaci\u00f3n', fr:'Test de r\u00e9v\u00e9lation', de:'Reveal-Test' },
   videoCallsTitle:{ en:'Video calls', da:'Videoopkald', sv:'Videosamtal', es:'Llamadas de video', fr:'Appels vidéo', de:'Videoanrufe' },
   activeCallsTitle:{ en:'Active calls', da:'Aktive opkald', sv:'Aktiva samtal', es:'Llamadas activas', fr:'Appels actifs', de:'Aktive Anrufe' },
+  activeNow:{ en:'Active now', da:'Aktiv nu', sv:'Aktiv nu', es:'Activo ahora', fr:'Actif maintenant', de:'Jetzt aktiv' },
   groupCallsTitle:{ en:'Group calls', da:'Gruppeopkald', sv:'Gruppsamtal', es:'Llamadas grupales', fr:'Appels de groupe', de:'Gruppenanrufe' },
   bugReportsTitle:{ en:'Bug reports', da:'Fejlmeldinger', sv:'Buggrapporter', es:'Informes de errores', fr:'Rapports de bugs', de:'Fehlermeldungen' },
   matchLogTitle:{ en:'Match log', da:'Matchlog', sv:'Matchlogg', es:'Registro de coincidencias', fr:'Journal des correspondances', de:'Matchprotokoll' },


### PR DESCRIPTION
## Summary
- display "Aktiv nu" on public profiles when last login within 3 hours
- add translation for the new label

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_688de2efd4ac832d9a257667e8b53e11