### PR TITLE
Add daily free profiles flow

### DIFF
--- a/src/components/MoreProfilesOverlay.jsx
+++ b/src/components/MoreProfilesOverlay.jsx
@@ -1,0 +1,26 @@
+import React from 'react';
+import { Card } from './ui/card.js';
+import { Button } from './ui/button.js';
+
+export default function MoreProfilesOverlay({ hasFree, canBuy, onClaimFree, onBuy, onClose }) {
+  return (
+    <div className="fixed inset-0 z-50 bg-black/50 flex items-center justify-center">
+      <Card className="bg-white p-6 rounded shadow-xl max-w-sm w-full">
+        <h2 className="text-xl font-semibold mb-4 text-pink-600 text-center">Flere klip</h2>
+        {hasFree && (
+          <Button className="w-full bg-green-500 text-white mb-2" onClick={onClaimFree}>
+            Få 3 gratis profiler
+          </Button>
+        )}
+        {canBuy && (
+          <Button className="w-full bg-yellow-500 text-white mb-2" onClick={onBuy}>
+            Køb 3 ekstra for 9 kr
+          </Button>
+        )}
+        <Button className="w-full bg-gray-200 text-black" onClick={onClose}>
+          Luk
+        </Button>
+      </Card>
+    </div>
+  );
+}

--- a/src/selectProfiles.js
+++ b/src/selectProfiles.js
@@ -1,6 +1,6 @@
 // Filtering helper kept separate so it can also run in a Netlify
 // Function. Netlify Functions support both JavaScript and TypeScript.
-import { getAge, getTodayStr, getCurrentDate } from './utils.js';
+import { getAge, getTodayStr } from './utils.js';
 import { getInterestCategory } from './interests.js';
 
 // Calculate a detailed match score for a single profile. Missing data is handled
@@ -129,11 +129,9 @@ export function scoreProfiles(user, profiles, ageRange) {
 }
 
 export default function selectProfiles(user, profiles, ageRange) {
-  const hasSubscription =
-    user.subscriptionExpires &&
-    new Date(user.subscriptionExpires) > getCurrentDate();
   const today = getTodayStr();
+  const free = user.freeClipsDate === today ? 3 : 0;
   const extra = user.extraClipsDate === today ? 3 : 0;
-  const limit = (hasSubscription ? 6 : 3) + extra;
+  const limit = 5 + free + extra;
   return scoreProfiles(user, profiles, ageRange).slice(0, limit);
 }


### PR DESCRIPTION
## Summary
- show five profiles initially in Daily Discovery
- allow claiming three free profiles and purchasing three more via overlay

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_688de39396ec832db2b296a59aab5f17