### PR TITLE
docs: update screen descriptions

### DIFF
--- a/docs/app-pages-da.md
+++ b/docs/app-pages-da.md
@@ -13,15 +13,24 @@
 - En hjælpefunktion i toppen guider brugeren gennem disse skridt.
 - Brugeren kan slette sin profil.
 - Videoklip kan maksimalt vare 10 sekunder, og en timer tæller ned under optagelsen.
+- **Indstillinger**
+  - Vælg aldersinterval for kandidater.
+  - Angiv foretrukne sprog og evt. tillad andre sprog.
+  - Markér op til fem interesser, der kan bruges i interessechatten.
+- **Statistik**
+  - Oversigt over hvor mange gange profilen er blevet vist.
 
 ## Dagens klip
 - Ved indgang vises listen med kandidatprofiler samt eventuelle ratede eller likede profiler.
 - Listen indeholder aktive profiler fra tidligere dage plus dagens nye (3 eller 6).
 - Hvis serveren returnerer for få nye profiler, kan brugeren udvide maks-afstanden.
+- Episodisk flow i tre trin: refleksion, reaktion og forbindelse.
+- Brugeren kan skrive en privat refleksion og give en rating på 1–4 stjerner.
+- Ratings og refleksioner gemmes separat og kan ses i refleksionskalenderen.
 - **Handlinger på kandidatlisten**
   - Åbn en profil for at se den offentlige kandidatprofil.
   - Vælg "Like" (kan blive til et match).
-  - Vælg "Remove" for at fjerne profilen helt, medmindre rating 3 eller 4 er givet 
+  - Vælg "Remove" for at fjerne profilen helt, medmindre rating 3 eller 4 er givet
     (så vises den under ratede eller likede profiler).
 - Brugeren kan én gang dagligt købe ekstra profiler.
 
@@ -33,11 +42,25 @@
 - Brugeren kan se tilgængeligt materiale og skrive en refleksion med rating 1–4
   samt give et like.
 
+## Daglig check-in
+- Kalender med oversigt over egne refleksioner.
+- Brugeren kan skrive en kort, privat tekst for hver dag.
+- Refleksioner kan knyttes til profiler og vises sammen med eventuelle ratings.
+
 ## Chat
 - Matchede profiler vises på en liste.
 - Chat med matchede brugere.
 - Start videokald.
 - Mulighed for at unmatche.
+
+## Interessechat og Realetten
+- Chat i grupper baseret på valgte interesser.
+- Mulighed for at starte Realetten – et turbaseret spil kombineret med fælles videokald.
+- Realetten kan spilles sammen med andre brugere eller mod en indbygget AI.
+
+## Notifikationer
+- Viser systembeskeder og invitationer sorteret efter dato.
+- Kort tilbageknap til forrige skærm.
 
 ## Om RealDate
 - Fejlmelding med mulighed for vedhæftet skærmbillede.


### PR DESCRIPTION
## Summary
- expand Danish documentation for profile settings, including age range, languages, interests and view statistics
- document episodic flow, daily check-in calendar and interest-based chat with Realetten game
- add notification screen description

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_688de4cc4cb4832d8b8fd9bb969d8dc2