### PR TITLE
fix: correct service worker scope

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -13,7 +13,7 @@ if ('serviceWorker' in navigator) {
     // The service worker file lives in the public folder. Use a
     // relative path so Parcel can locate it during the build.
     const swUrl = new URL('../public/service-worker.js', import.meta.url);
-    const baseScope = new URL('../', swUrl).pathname;
+    const baseScope = new URL('.', swUrl).pathname;
     // Register the main service worker generated in the production build
     console.log('Attempting SW registration', swUrl.href, { scope: baseScope });
     let mainReg = null;


### PR DESCRIPTION
## Summary
- ensure service workers register with the site's base path

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_688f6d129c2c832d8b6537fcc4698ba9