### PR TITLE
Fix FCM service worker registration timing

### DIFF
--- a/src/firebase.js
+++ b/src/firebase.js
@@ -43,7 +43,7 @@ import {
   GoogleAuthProvider,
   FacebookAuthProvider
 } from 'firebase/auth';
-import { fcmReg } from './swRegistration.js';
+import { fcmReg, fcmRegReady } from './swRegistration.js';
 import { detectOS, detectBrowser } from './utils.js';
 
 let extendedLogging = false;
@@ -175,9 +175,10 @@ export async function requestNotificationPermission(userId, loginMethod = 'passw
 
   try {
     logEvent('requestNotificationPermission start', { userId });
+    const reg = fcmReg || await fcmRegReady;
     const token = await getToken(messaging, {
       vapidKey: process.env.FCM_VAPID_KEY,
-      serviceWorkerRegistration: fcmReg
+      serviceWorkerRegistration: reg
     });
     if (token) {
       await setDoc(doc(db, 'pushTokens', token), {

--- a/src/swRegistration.js
+++ b/src/swRegistration.js
@@ -1,5 +1,11 @@
 export let fcmReg = null;
 
+let resolveReg;
+export const fcmRegReady = new Promise(resolve => {
+  resolveReg = resolve;
+});
+
 export function setFcmReg(reg) {
   fcmReg = reg;
+  resolveReg?.(reg);
 }


### PR DESCRIPTION
## Summary
- Expose a promise from `swRegistration` that resolves when the Firebase messaging service worker is registered
- Wait for this registration before requesting an FCM token to avoid fallback to a missing root service worker

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_688f702e678c832d872c538459dfb9bd