### PR TITLE
feat: add chat flow actions

### DIFF
--- a/docs/function-test-modules.md
+++ b/docs/function-test-modules.md
@@ -25,7 +25,12 @@ Use the admin menu to open *Funktionstest* and choose a module to start testing.
 
 ### Chat & Reflections
 
-- Start a chat by sending a message as one user. Log in as the matched user, reply, and confirm the first user sees the response.
+- Start a chat between two matched users. Each action appears as a button that runs one at a time with a short pause between presses:
+  1. Log in as Maria (user 101).
+  2. Match with Peter (user 105).
+  3. Send the chat message "Hej" from Maria to Peter.
+  4. Log in as Peter and reply "Hej" to Maria.
+  5. Confirm Maria sees Peter's reply.
 - Trigger the match celebration overlay and make sure it can be dismissed.
 - Open the reflection calendar and verify ratings or notes appear on the correct dates.
 

--- a/src/components/WelcomeScreen.jsx
+++ b/src/components/WelcomeScreen.jsx
@@ -100,6 +100,9 @@ export default function WelcomeScreen({ onLogin }) {
         case 'submitLogin':
           handleLogin();
           break;
+        case 'loginMaria':
+          onLogin('101', 'admin');
+          break;
         default:
           break;
       }

--- a/src/functionTestModules.js
+++ b/src/functionTestModules.js
@@ -55,7 +55,7 @@ export const modules = [
           'Log in as the matched user, reply, and confirm the first user sees it',
           'Unmatching removes the chat for both'
         ],
-        action: { label: 'Open Chat', event: 'openChat' }
+        action: { label: 'Run chat flow', events: ['loginMaria','matchPeter','chat101to105','chat105to101'] }
       },
       {
         title: 'Improved chat layout with timestamps',


### PR DESCRIPTION
## Summary
- wire up login and chat events for functional test guide
- support automated match setup and 'Hej' message exchange between test users

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_688f7e2df4e4832da0591af1ef296238