### PR TITLE
feat: add chat flow actions

### DIFF
--- a/docs/function-test-modules.md
+++ b/docs/function-test-modules.md
@@ -25,7 +25,14 @@ Use the admin menu to open *Funktionstest* and choose a module to start testing.
 
 ### Chat & Reflections
 
-- Start a chat by sending a message as one user. Log in as the matched user, reply, and confirm the first user sees the response.
+ - Start a chat between two matched users. Each action appears as a button that runs one at a time with a short pause between presses:
+  1. Log in as Maria (user 101).
+  2. Match with Peter (user 105).
+  3. Send the chat message "Hej" from Maria to Peter.
+  4. Send a longer message "Hej Peter, hvordan går det? Dette er en testbesked." from Maria to Peter.
+  5. Log in as Peter and reply "Hej" to Maria.
+  6. Send a longer reply "Hej Maria! Alt er fint her. Skal vi mødes senere?" from Peter to Maria.
+  7. Confirm Maria sees Peter's replies.
 - Trigger the match celebration overlay and make sure it can be dismissed.
 - Open the reflection calendar and verify ratings or notes appear on the correct dates.
 

--- a/src/VideotpushApp.jsx
+++ b/src/VideotpushApp.jsx
@@ -33,7 +33,7 @@ import FunctionTestGuide from './components/FunctionTestGuide.jsx';
 import TaskButton from './components/TaskButton.jsx';
 import GraphicsElementsScreen from './components/GraphicsElementsScreen.jsx';
 import { getNextTask } from './tasks.js';
-import { useCollection, requestNotificationPermission, subscribeToWebPush, db, doc, getDoc, updateDoc, increment, logEvent, auth, isAdminUser, signOutUser } from './firebase.js';
+import { useCollection, requestNotificationPermission, subscribeToWebPush, db, doc, setDoc, updateDoc, arrayUnion, getDoc, increment, logEvent, auth, isAdminUser, signOutUser } from './firebase.js';
 import { getCurrentDate } from './utils.js';
 import { cacheMediaIfNewer } from './cacheMedia.js';
 import version from './version.js';
@@ -123,6 +123,45 @@ export default function VideotpushApp() {
     markNotificationsRead();
   };
 
+  const matchWithPeter = async () => {
+    const m1 = { id: '101-105', userId: '101', profileId: '105', lastMessage: '', unreadByUser: false, unreadByProfile: false, newMatch: false };
+    const m2 = { id: '105-101', userId: '105', profileId: '101', lastMessage: '', unreadByUser: false, unreadByProfile: false, newMatch: true };
+    try {
+      await Promise.all([
+        setDoc(doc(db, 'matches', m1.id), m1),
+        setDoc(doc(db, 'matches', m2.id), m2)
+      ]);
+    } catch (err) {
+      console.error('Failed to create match', err);
+    }
+  };
+
+  const sendChat = async (from, to, text) => {
+    const id1 = `${from}-${to}`;
+    const id2 = `${to}-${from}`;
+    const message = { from, text, ts: Date.now() };
+    try {
+      await Promise.all([
+        updateDoc(doc(db, 'matches', id1), {
+          lastMessage: text,
+          unreadByProfile: true,
+          unreadByUser: false,
+          messages: arrayUnion(message),
+          newMatch: false
+        }),
+        updateDoc(doc(db, 'matches', id2), {
+          lastMessage: text,
+          unreadByProfile: false,
+          unreadByUser: true,
+          messages: arrayUnion(message),
+          newMatch: false
+        })
+      ]);
+    } catch (err) {
+      console.error('Failed to send message', err);
+    }
+  };
+
   useEffect(() => {
     const handler = e => {
       switch (e.detail) {
@@ -145,6 +184,47 @@ export default function VideotpushApp() {
         case 'openChat':
           setTab('chat');
           setViewProfile(null);
+          break;
+        case 'loginMaria':
+          setLoggedIn(true);
+          setUserId('101');
+          setTab('chat');
+          setViewProfile(null);
+          break;
+        case 'matchPeter':
+          matchWithPeter();
+          break;
+        case 'chat101to105':
+          sendChat('101', '105', 'Hej');
+          setTab('chat');
+          setViewProfile(null);
+          break;
+        case 'chat101to105Long':
+          sendChat('101', '105', 'Hej Peter, hvordan går det? Dette er en testbesked.');
+          setTab('chat');
+          setViewProfile(null);
+          break;
+        case 'chat105to101':
+          (async () => {
+            setUserId('105');
+            setTab('chat');
+            setViewProfile(null);
+            await sendChat('105', '101', 'Hej');
+            setUserId('101');
+            setTab('chat');
+            setViewProfile(null);
+          })();
+          break;
+        case 'chat105to101Long':
+          (async () => {
+            setUserId('105');
+            setTab('chat');
+            setViewProfile(null);
+            await sendChat('105', '101', 'Hej Maria! Alt er fint her. Skal vi mødes senere?');
+            setUserId('101');
+            setTab('chat');
+            setViewProfile(null);
+          })();
           break;
         case 'logout':
           logout();

--- a/src/components/WelcomeScreen.jsx
+++ b/src/components/WelcomeScreen.jsx
@@ -100,6 +100,9 @@ export default function WelcomeScreen({ onLogin }) {
         case 'submitLogin':
           handleLogin();
           break;
+        case 'loginMaria':
+          onLogin('101', 'admin');
+          break;
         default:
           break;
       }

--- a/src/functionTestModules.js
+++ b/src/functionTestModules.js
@@ -55,7 +55,7 @@ export const modules = [
           'Log in as the matched user, reply, and confirm the first user sees it',
           'Unmatching removes the chat for both'
         ],
-        action: { label: 'Open Chat', event: 'openChat' }
+        action: { label: 'Run chat flow', events: ['loginMaria','matchPeter','chat101to105','chat101to105Long','chat105to101','chat105to101Long'] }
       },
       {
         title: 'Improved chat layout with timestamps',


### PR DESCRIPTION
## Summary
- wire up login and chat events for functional test guide
- support automated match setup and 'Hej' message exchange between test users
- extend chat flow with additional longer messages for thorough testing

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_688f7e2df4e4832da0591af1ef296238