### PR TITLE
Expand functional test chat conversation

### DIFF
--- a/src/VideotpushApp.jsx
+++ b/src/VideotpushApp.jsx
@@ -194,14 +194,27 @@ export default function VideotpushApp() {
         case 'matchPeter':
           matchWithPeter();
           break;
-        case 'chat101to105':
-          sendChat('101', '105', 'Hej');
+        case 'chat101to105a':
+          sendChat('101', '105', 'Hej Peter! Hvordan går det? Jeg tester den nye chat med længere beskeder.');
           setTab('chat');
           setViewProfile(null);
           break;
-        case 'chat105to101':
+        case 'chat105to101a':
           (async () => {
-            await sendChat('105', '101', 'Hej');
+            await sendChat('105', '101', 'Hej Maria, det går fint. Fedt at du tester. Lad os skrive længere beskeder for at se om alt virker.');
+            setUserId('101');
+            setTab('chat');
+            setViewProfile(null);
+          })();
+          break;
+        case 'chat101to105b':
+          sendChat('101', '105', 'Ja, jeg skriver lige en længere besked for at sikre, at alt vises korrekt og ruller ned som det skal.');
+          setTab('chat');
+          setViewProfile(null);
+          break;
+        case 'chat105to101b':
+          (async () => {
+            await sendChat('105', '101', 'Tak, det ser ud til at fungere. Lad os fortsætte for at være helt sikre.');
             setUserId('101');
             setTab('chat');
             setViewProfile(null);

--- a/src/functionTestModules.js
+++ b/src/functionTestModules.js
@@ -51,11 +51,11 @@ export const modules = [
       {
         title: 'Basic chat between matched profiles with option to unmatch',
         expected: [
-          'Send a message as one user',
-          'Log in as the matched user, reply, and confirm the first user sees it',
+          'Send multiple long messages as one user',
+          'Log in as the matched user, reply with long messages, and confirm the first user sees them',
           'Unmatching removes the chat for both'
         ],
-        action: { label: 'Run chat flow', events: ['loginMaria','matchPeter','chat101to105','chat105to101'] }
+        action: { label: 'Run chat flow', events: ['loginMaria','matchPeter','chat101to105a','chat105to101a','chat101to105b','chat105to101b'] }
       },
       {
         title: 'Improved chat layout with timestamps',


### PR DESCRIPTION
## Summary
- extend Chat & Reflections module to include multiple long messages between users 101 and 105
- handle new chat events so the test flow simulates a longer conversation

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_688f96186970832d8587e1e5ba4e3b8e