### PR TITLE
Add Danish market business case doc

### DIFF
--- a/docs/denmark-market-business-case.md
+++ b/docs/denmark-market-business-case.md
@@ -1,0 +1,36 @@
+# Denmark Market Business Case for VideoTinder
+
+## Market Overview
+- **Population (2023):** ~5.9 million people
+- **Adults aged 18-65:** ~3.5 million
+- **Single adults (\~50% of adults):** ~1.75 million
+- **Smartphone penetration (\~90%):** ~1.58 million potential mobile users
+- **Dating app adoption among singles (\~60%):** ~0.95 million users familiar with dating apps
+
+## Revenue Projection
+Assumptions:
+- Expected market penetration for VideoTinder: **10%** of dating app users -> **94,500 users**
+- Premium subscription price: **100 DKK/month**
+- Conversion to premium: **10%** of VideoTinder users -> **9,450 paying subscribers**
+
+Annual revenue:
+- 9,450 subscribers × 100 DKK × 12 months = **11,340,000 DKK** (≈1.7M USD)
+
+## Cost Estimate
+- Infrastructure and support: **20 DKK** per user per year -> 94,500 × 20 = **1,890,000 DKK**
+- Marketing and user acquisition: **3,000,000 DKK**
+- Operational overhead (staff, legal, admin): **2,000,000 DKK**
+
+Total estimated annual cost: **6,890,000 DKK**
+
+## Break-even Analysis
+- Estimated annual profit: 11,340,000 − 6,890,000 = **4,450,000 DKK**
+- Break-even premium users: 6,890,000 ÷ (100 × 12) ≈ **5,742 paying users**
+- Break-even total users (at 10% premium conversion): **57,420 users**
+
+## Strategic Considerations
+- High smartphone usage and a large single population support market entry
+- Localized Danish-language experience can differentiate VideoTinder from global competitors
+- Successful adoption in Denmark can serve as a springboard to other Nordic countries
+
+*All figures are estimates based on publicly available demographic data and standard SaaS cost assumptions.*


### PR DESCRIPTION
## Summary
- add Danish market business case outlining population, revenue, cost and break-even estimates

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6890d32d8ef0832d8cbf447f940c9d36