### PR TITLE
fix: sign out before provider auth

### DIFF
--- a/src/firebase.js
+++ b/src/firebase.js
@@ -226,13 +226,15 @@ export function isAdminUser(user) {
   return !!user && ADMIN_EMAILS.includes(user.email || '');
 }
 
-export function signInWithGoogle() {
+export async function signInWithGoogle() {
   const provider = new GoogleAuthProvider();
+  if (auth.currentUser) await signOut(auth);
   return signInWithPopup(auth, provider);
 }
 
-export function signInWithFacebook() {
+export async function signInWithFacebook() {
   const provider = new FacebookAuthProvider();
+  if (auth.currentUser) await signOut(auth);
   return signInWithPopup(auth, provider);
 }
 


### PR DESCRIPTION
## Summary
- sign out any existing user before Google or Facebook login to avoid invalid action errors

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6890d2cac5e0832d93ab3f7d4e8eb6d4