### PR TITLE
Adjust Danish market business case pricing

### DIFF
--- a/docs/denmark-market-business-case.md
+++ b/docs/denmark-market-business-case.md
@@ -10,11 +10,11 @@
 ## Revenue Projection
 Assumptions:
 - Expected market penetration for VideoTinder: **10%** of dating app users -> **94,500 users**
-- Premium subscription price: **100 DKK/month**
+- Premium subscription price: **49 DKK/month**
 - Conversion to premium: **10%** of VideoTinder users -> **9,450 paying subscribers**
 
 Annual revenue:
-- 9,450 subscribers × 100 DKK × 12 months = **11,340,000 DKK** (≈1.7M USD)
+- 9,450 subscribers × 49 DKK × 12 months = **5,556,600 DKK** (≈0.8M USD)
 
 ## Cost Estimate
 - Infrastructure and support: **20 DKK** per user per year -> 94,500 × 20 = **1,890,000 DKK**
@@ -24,9 +24,9 @@ Annual revenue:
 Total estimated annual cost: **6,890,000 DKK**
 
 ## Break-even Analysis
-- Estimated annual profit: 11,340,000 − 6,890,000 = **4,450,000 DKK**
-- Break-even premium users: 6,890,000 ÷ (100 × 12) ≈ **5,742 paying users**
-- Break-even total users (at 10% premium conversion): **57,420 users**
+- Estimated annual loss: 5,556,600 − 6,890,000 = **−1,333,400 DKK**
+- Break-even premium users: 6,890,000 ÷ (49 × 12) ≈ **11,718 paying users**
+- Break-even total users (at 10% premium conversion): **117,180 users**
 
 ## First Three Years Outlook
 To reach the full penetration and conversion assumptions above, the first few years are expected to ramp up gradually.
@@ -34,23 +34,23 @@ To reach the full penetration and conversion assumptions above, the first few ye
 ### Year 1: Establish the product and gather feedback
 - **Penetration:** 2% of dating app users → **19,000 total users**
 - **Premium conversion:** 5% → **950 paying subscribers**
-- **Annual revenue:** 950 × 100 DKK × 12 = **1,140,000 DKK**
+- **Annual revenue:** 950 × 49 DKK × 12 = **558,600 DKK**
 - **Estimated costs:** infrastructure (380,000 DKK), marketing (1,000,000 DKK), overhead (1,500,000 DKK)
-- **Net result:** **−1,740,000 DKK** while investing in product-market fit
+- **Net result:** **−2,321,400 DKK** while investing in product-market fit
 
 ### Year 2: Refine features and begin scaling
 - **Penetration:** 5% → **47,500 total users**
 - **Premium conversion:** 8% → **3,800 paying subscribers**
-- **Annual revenue:** 3,800 × 100 DKK × 12 = **4,560,000 DKK**
+- **Annual revenue:** 3,800 × 49 DKK × 12 = **2,234,400 DKK**
 - **Estimated costs:** infrastructure (950,000 DKK), marketing (2,000,000 DKK), overhead (1,800,000 DKK)
-- **Net result:** **−190,000 DKK**, moving toward break-even
+- **Net result:** **−2,515,600 DKK**, moving toward break-even
 
 ### Year 3: Expand reach and solidify monetization
 - **Penetration:** 8% → **76,000 total users**
 - **Premium conversion:** 9% → **6,840 paying subscribers**
-- **Annual revenue:** 6,840 × 100 DKK × 12 = **8,208,000 DKK**
+- **Annual revenue:** 6,840 × 49 DKK × 12 = **4,021,920 DKK**
 - **Estimated costs:** infrastructure (1,520,000 DKK), marketing (2,500,000 DKK), overhead (1,900,000 DKK)
-- **Net result:** **2,288,000 DKK** profit as adoption strengthens
+- **Net result:** **−1,898,080 DKK** as pricing limits profitability
 
 ## Strategic Considerations
 - High smartphone usage and a large single population support market entry


### PR DESCRIPTION
## Summary
- revise Denmark market business case to target 49 DKK/month subscription price
- recalculate revenue projection, break-even point, and three-year outlook

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6890df024534832d9a2ba2af70fd4a10