### PR TITLE
fix: hide active now on own profile view

### DIFF
--- a/src/components/ProfileSettings.jsx
+++ b/src/components/ProfileSettings.jsx
@@ -546,7 +546,7 @@ export default function ProfileSettings({ userId, ageRange, onChangeAgeRange, pu
         React.createElement('div', { className:'flex items-center justify-between w-full' },
           React.createElement(SectionTitle, {
             title: `${profile.name}, ${profile.birthday ? getAge(profile.birthday) : profile.age}${profile.city ? ', ' + profile.city : ''}`,
-            action: publicView && activeNow ? React.createElement('span', { className: 'text-sm text-green-600 font-medium' }, t('activeNow')) : null
+            action: publicView && !isOwnProfile && activeNow ? React.createElement('span', { className: 'text-sm text-green-600 font-medium' }, t('activeNow')) : null
           })
         ),
       isOwnProfile && !publicView && profile.email && React.createElement('p', { className:'text-center text-sm text-gray-600 mt-1' }, profile.email),


### PR DESCRIPTION
## Summary
- ensure public profile only shows "active now" when viewed by others

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6890e2579348832d8344d7d932a0df48