### PR TITLE
feat: show message when no interests in chat

### DIFF
--- a/src/components/InterestChatScreen.jsx
+++ b/src/components/InterestChatScreen.jsx
@@ -24,6 +24,7 @@ export default function InterestChatScreen({ userId, onSelectProfile = null }) {
   const messagesRef = useRef(null);
   const textareaRef = useRef(null);
   const t = useT();
+  const hasInterests = (profile?.interests || []).length > 0;
 
   useEffect(() => {
     if(!interest && profile?.interests?.length){
@@ -95,6 +96,7 @@ export default function InterestChatScreen({ userId, onSelectProfile = null }) {
         }, i)
       )
     ),
+    !hasInterests && React.createElement('div', { className:'text-gray-600 text-center py-4' }, t('noInterestsSelected')),
     interest && React.createElement(React.Fragment, null,
       React.createElement('div', { ref:messagesRef, className:'flex-1 bg-gray-100 p-4 rounded space-y-3 flex flex-col overflow-y-auto' },
         (chat?.messages || []).map((m,i)=>{

--- a/src/i18n.js
+++ b/src/i18n.js
@@ -209,6 +209,14 @@ inviteAccepted:{ en:"Profile created", da:"Oprettet", sv:"Skapad", es:"Perfil cr
     fr:'Discussion par intérêt',
     de:'Interessenchat'
   },
+  noInterestsSelected:{
+    en:'No interests selected. Add interests on your profile page.',
+    da:'Ingen interesser valgt. Tilføj interesser på din profilside.',
+    sv:'Inga intressen valda. Lägg till intressen på din profilsida.',
+    es:'No has seleccionado intereses. Añade intereses en tu página de perfil.',
+    fr:"Aucun centre d'intérêt sélectionné. Ajoutez des centres d'intérêt sur votre page de profil.",
+    de:'Keine Interessen ausgewählt. Füge Interessen auf deiner Profilseite hinzu.'
+  },
   gameTitle:{ en:'Guess My Choice', da:'Gæt mit valg' },
 };
 


### PR DESCRIPTION
## Summary
- Show message directing users to add interests when none selected in Interest Chat
- Add i18n key for no-interests message

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6890e3d32fbc832da2edc11bf0ae1190