### PR TITLE
Show user ID on Realetten videos

### DIFF
--- a/src/components/RealettenCallScreen.jsx
+++ b/src/components/RealettenCallScreen.jsx
@@ -326,7 +326,7 @@ export default function RealettenCallScreen({ interest, userId, botId, onEnd, on
         }),
         !uid && React.createElement('div',{className:'absolute inset-0 flex items-center justify-center text-white bg-black/60'},'Venter...'),
         uid === botId && React.createElement('div',{className:'absolute inset-0 flex items-center justify-center text-white bg-black/60 text-6xl'},'\u{1F916}'),
-        uid && !isSelf && React.createElement('div',{className:'absolute bottom-1 right-1 text-xs text-white bg-black/40 px-1 rounded'},uid)
+        uid && React.createElement('div',{className:'absolute bottom-1 right-1 text-xs text-white bg-black/60 px-1 rounded'},uid)
       );
     })
   );


### PR DESCRIPTION
## Summary
- Always display participant ID overlays on Realetten video tiles
- Increase overlay contrast for readability

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6890e51d0fb0832da3ee28dc3b93129a