### PR TITLE
Disable PiP and playback speed controls

### DIFF
--- a/src/components/ReportedContentScreen.jsx
+++ b/src/components/ReportedContentScreen.jsx
@@ -68,7 +68,14 @@ export default function ReportedContentScreen({ onBack }) {
     React.createElement('ul', { className:'space-y-4 overflow-y-auto max-h-[70vh]' },
       detailItems.map((item,i)=>
         React.createElement('li', { key:i, className:'border p-2 rounded' },
-          item.clipURL && React.createElement('video', { src:item.clipURL, controls:true, controlsList:'nodownload noplaybackrate', onRateChange:e=>{e.currentTarget.playbackRate=1;}, className:'w-full mb-2' }),
+          item.clipURL && React.createElement('video', {
+            src:item.clipURL,
+            controls:true,
+            controlsList:'nodownload noplaybackrate',
+            disablePictureInPicture:true,
+            onRateChange:e=>{e.currentTarget.playbackRate=1;},
+            className:'w-full mb-2'
+          }),
           item.text && React.createElement('p', { className:'mb-2' }, item.text),
           React.createElement('p', { className:'text-sm text-gray-600 mb-1' }, `Antal anmeldelser: ${item.reports.length}`),
           React.createElement('ul', { className:'mb-2 list-disc list-inside text-sm' },

--- a/src/components/VideoOverlay.jsx
+++ b/src/components/VideoOverlay.jsx
@@ -4,7 +4,14 @@ import { X } from 'lucide-react';
 export default function VideoOverlay({ src, onClose }) {
   return React.createElement('div', { className:'fixed inset-0 z-50 bg-black/70 flex items-center justify-center' },
     React.createElement('div', { className:'relative w-full max-w-md mx-4' },
-      React.createElement('video', { src, controls:true, controlsList:'nodownload noplaybackrate', onRateChange:e=>{e.currentTarget.playbackRate=1;}, className:'w-full rounded' }),
+      React.createElement('video', {
+        src,
+        controls:true,
+        controlsList:'nodownload noplaybackrate',
+        disablePictureInPicture:true,
+        onRateChange:e=>{e.currentTarget.playbackRate=1;},
+        className:'w-full rounded'
+      }),
       React.createElement('button', { onClick:onClose, className:'absolute top-2 right-2 text-white bg-black/40 rounded-full p-1' },
         React.createElement(X,{className:'w-6 h-6'})
       )

--- a/src/components/VideoPreview.jsx
+++ b/src/components/VideoPreview.jsx
@@ -5,6 +5,7 @@ export default function VideoPreview({ src, onEnded }) {
     src,
     controls: true,
     controlsList: 'nodownload noplaybackrate',
+    disablePictureInPicture: true,
     onRateChange: e => {
       e.currentTarget.playbackRate = 1;
     },


### PR DESCRIPTION
## Summary
- remove picture-in-picture option from all video players
- enforce normal playback speed

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6890e5fcf1ec832da27f918eb21cc5b0