### PR TITLE
Remove old push tokens on re-subscribe

### DIFF
--- a/src/firebase.js
+++ b/src/firebase.js
@@ -172,6 +172,14 @@ export async function requestNotificationPermission(userId, loginMethod = 'passw
         browser: detectBrowser(),
         loginMethod
       }, { merge: true });
+
+      const q = query(collection(db, 'pushTokens'), where('userId', '==', userId));
+      const snap = await getDocs(q);
+      const deletions = [];
+      snap.forEach(d => {
+        if (d.id !== token) deletions.push(deleteDoc(d.ref));
+      });
+      await Promise.all(deletions);
     }
     logEvent('requestNotificationPermission success', { userId });
     return token;


### PR DESCRIPTION
## Summary
- clean up stale push tokens when user re-authorizes notifications

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6890e79719dc832d813a44bae695a6f5