### PR TITLE
Ensure push notifications include message text

### DIFF
--- a/src/components/AdminScreen.jsx
+++ b/src/components/AdminScreen.jsx
@@ -42,18 +42,18 @@ export default function AdminScreen({ onOpenStats, onOpenBugReports, onOpenMatch
     showConsolePanel();
   };
 
-  const sendPush = async body => {
+  const sendPush = async text => {
     const base = process.env.FUNCTIONS_BASE_URL || '';
 
     const send = async endpoint => {
       const resp = await fetch(`${base}/.netlify/functions/${endpoint}`, {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ body })
+        body: JSON.stringify({ title: text, body: text })
       });
       if (!resp.ok) {
-        const text = await resp.text();
-        throw new Error(text);
+        const message = await resp.text();
+        throw new Error(message);
       }
     };
 

--- a/src/firebase-messaging-sw.js
+++ b/src/firebase-messaging-sw.js
@@ -21,8 +21,8 @@ function handleBackgroundMessages() {
     console.log('Background message', payload);
     const n = payload.notification || {};
     const d = payload.data || {};
-    const title = n.title || 'RealDate';
-    const body = n.body || title;
+    const title = n.title || d.title || 'RealDate';
+    const body = n.body || d.body || title;
     self.registration.showNotification(title, {
       body,
       icon: 'icon-192.png',


### PR DESCRIPTION
## Summary
- Include both `title` and `body` when sending admin push notifications so text like "Dagens klip er klar" appears
- Use data fields as fallback in the Firebase service worker to show custom notification text

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6890e87e7024832daa8693afe494d82b