### PR TITLE
Remove stale web push tokens on re-authorization

### DIFF
--- a/src/firebase.js
+++ b/src/firebase.js
@@ -113,6 +113,15 @@ export async function subscribeToWebPush(userId, loginMethod = 'password') {
       browser: detectBrowser(),
       loginMethod
     });
+
+    const q = query(collection(db, 'webPushSubscriptions'), where('userId', '==', userId));
+    const snap = await getDocs(q);
+    const deletions = [];
+    snap.forEach(d => {
+      if (d.id !== safeId) deletions.push(deleteDoc(d.ref));
+    });
+    await Promise.all(deletions);
+
     logEvent('subscribeToWebPush success', { userId });
     return sub;
   } catch (err) {


### PR DESCRIPTION
## Summary
- clean up old web push tokens when subscribing again so only the current token remains

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6890f932ee04832da3c8f7c6f1b67b32