### PR TITLE
feat: add subscription tier selection

### DIFF
--- a/src/components/LikesScreen.jsx
+++ b/src/components/LikesScreen.jsx
@@ -4,7 +4,7 @@ import { User as UserIcon, PlayCircle, Heart } from 'lucide-react';
 import VideoOverlay from './VideoOverlay.jsx';
 import MatchOverlay from './MatchOverlay.jsx';
 import { Card } from './ui/card.js';
-import PurchaseOverlay from './PurchaseOverlay.jsx';
+import SubscriptionOverlay from './SubscriptionOverlay.jsx';
 import { Button } from './ui/button.js';
 import SectionTitle from './SectionTitle.jsx';
 import { useCollection, db, doc, setDoc, deleteDoc, getDoc } from '../firebase.js';
@@ -63,7 +63,7 @@ export default function LikesScreen({ userId, onSelectProfile }) {
   };
 
   const [showPurchase, setShowPurchase] = useState(false);
-  const handlePurchase = async () => {
+  const handlePurchase = async (tier) => {
     const now = getCurrentDate();
     const current = currentUser.subscriptionExpires ? new Date(currentUser.subscriptionExpires) : now;
     const base = current > now ? current : now;
@@ -73,7 +73,7 @@ export default function LikesScreen({ userId, onSelectProfile }) {
       subscriptionActive:true,
       subscriptionPurchased: now.toISOString(),
       subscriptionExpires: expiry.toISOString(),
-      subscriptionTier: 'silver'
+      subscriptionTier: tier
     },{ merge:true });
     setShowPurchase(false);
   };
@@ -122,13 +122,7 @@ export default function LikesScreen({ userId, onSelectProfile }) {
     ),
     !hasSubscription && React.createElement('span',{className:'absolute inset-0 m-auto text-yellow-500 text-sm font-semibold pointer-events-none flex items-center justify-center text-center px-2'},'Kr\u00e6ver premium abonnement'),
     !hasSubscription && React.createElement(Button,{className:'mt-4 w-full bg-yellow-500 text-white',onClick:()=>setShowPurchase(true)},'Køb premium'),
-    showPurchase && React.createElement(PurchaseOverlay,{title:'Månedligt abonnement', price:'59 kr/md', onClose:()=>setShowPurchase(false), onBuy:handlePurchase},
-      React.createElement('ul',{className:'list-disc list-inside text-sm space-y-1'},
-        React.createElement('li',null,'🎞️ Få adgang til at se flere nye klip hver dag (+3 profiler)'),
-        React.createElement('li',null,'🧠 Få indsigt i hvem der har liket dig (ubegrænset)'),
-        React.createElement('li',null,'⏳ Bliv på set i længere tid på listen af profiler (+5 dage)')
-      )
-    ),
+    showPurchase && React.createElement(SubscriptionOverlay,{onClose:()=>setShowPurchase(false), onBuy:handlePurchase}),
     storyProfile && React.createElement(StoryLineOverlay,{profile:storyProfile, progress: progresses.find(pr=>pr.profileId===storyProfile.id), onClose:()=>setStoryProfile(null), onMatch:id=>{toggleLike(id); setStoryProfile(null);}}),
     matchedProfile && React.createElement(MatchOverlay,{name:matchedProfile.name,onClose:()=>setMatchedProfile(null)}),
     activeVideo && React.createElement(VideoOverlay,{src:activeVideo,onClose:()=>setActiveVideo(null)})

--- a/src/components/ProfileSettings.jsx
+++ b/src/components/ProfileSettings.jsx
@@ -11,7 +11,7 @@ import VideoPreview from './VideoPreview.jsx';
 import ReportOverlay from './ReportOverlay.jsx';
 import DeleteAccountOverlay from './DeleteAccountOverlay.jsx';
 import { useCollection, useDoc, db, storage, getDoc, doc, updateDoc, setDoc, deleteDoc, ref, uploadBytes, getDownloadURL, listAll, deleteObject, deleteAccount } from '../firebase.js';
-import PurchaseOverlay from './PurchaseOverlay.jsx';
+import SubscriptionOverlay from './SubscriptionOverlay.jsx';
 import InterestsOverlay from './InterestsOverlay.jsx';
 import SnapVideoRecorder from "./SnapVideoRecorder.jsx";
 import MatchOverlay from './MatchOverlay.jsx';
@@ -59,7 +59,7 @@ export default function ProfileSettings({ userId, ageRange, onChangeAgeRange, pu
     ? (getCurrentDate().getTime() - new Date(profile.lastActive).getTime()) < 3 * 60 * 60 * 1000
     : false;
 
-  const handlePurchase = async () => {
+  const handlePurchase = async (tier) => {
     const now = getCurrentDate();
     const current = profile.subscriptionExpires ? new Date(profile.subscriptionExpires) : now;
     const base = current > now ? current : now;
@@ -69,9 +69,9 @@ export default function ProfileSettings({ userId, ageRange, onChangeAgeRange, pu
       subscriptionActive: true,
       subscriptionPurchased: now.toISOString(),
       subscriptionExpires: expiry.toISOString(),
-      subscriptionTier: 'silver'
+      subscriptionTier: tier
     });
-    setProfile({ ...profile, subscriptionActive: true, subscriptionPurchased: now.toISOString(), subscriptionExpires: expiry.toISOString(), subscriptionTier: 'silver' });
+    setProfile({ ...profile, subscriptionActive: true, subscriptionPurchased: now.toISOString(), subscriptionExpires: expiry.toISOString(), subscriptionTier: tier });
     setShowSub(false);
   };
 
@@ -710,18 +710,10 @@ export default function ProfileSettings({ userId, ageRange, onChangeAgeRange, pu
         className: 'mt-6 w-full bg-red-500 text-white',
         onClick: () => setShowDelete(true)
       }, t('deleteAccount')),
-    showSub && React.createElement(PurchaseOverlay, {
-        title: 'Månedligt abonnement',
-        price: '59 kr/md',
+    showSub && React.createElement(SubscriptionOverlay, {
         onClose: () => setShowSub(false),
         onBuy: handlePurchase
-      },
-        React.createElement('ul', { className: 'list-disc list-inside text-sm space-y-1' },
-          React.createElement('li', null, '🎞️ Få adgang til at se flere nye klip hver dag (+3 profiler)'),
-          React.createElement('li', null, '🧠 Få indsigt i hvem der har liket dig (ubegrænset)'),
-          React.createElement('li', null, '⏳ Bliv på set i længere tid på listen af profiler (+5 dage)')
-        )
-      ),
+      }),
     showInterests && React.createElement(InterestsOverlay, {
         current: profile.interests || [],
         onSave: handleSaveInterests,

--- a/src/components/SubscriptionOverlay.jsx
+++ b/src/components/SubscriptionOverlay.jsx
@@ -1,0 +1,32 @@
+import React, { useState } from 'react';
+import { Card } from './ui/card.js';
+import { Button } from './ui/button.js';
+
+export default function SubscriptionOverlay({ onClose, onBuy }) {
+  const plans = [
+    { tier: 'silver', title: 'Sølv', price: '59 kr/md', benefit: '+2 profiler' },
+    { tier: 'gold', title: 'Guld', price: '99 kr/md', benefit: '+5 profiler' },
+    { tier: 'platinum', title: 'Platin', price: '149 kr/md', benefit: '+7 profiler' }
+  ];
+  const [selected, setSelected] = useState('silver');
+  return React.createElement('div', { className: 'fixed inset-0 z-50 bg-black/50 flex items-center justify-center' },
+    React.createElement(Card, { className: 'bg-white p-6 rounded shadow-xl max-w-sm w-full' },
+      React.createElement('h2', { className: 'text-xl font-semibold mb-4 text-yellow-600 text-center' }, 'Vælg abonnement'),
+      React.createElement('ul', { className: 'space-y-2 mb-4' },
+        plans.map(p => (
+          React.createElement('li', { key: p.tier },
+            React.createElement(Button, {
+              className: `w-full flex flex-col items-start ${selected === p.tier ? 'bg-yellow-500 text-white' : 'bg-gray-100 text-black'}`,
+              onClick: () => setSelected(p.tier)
+            },
+              React.createElement('span', { className: 'font-medium' }, `${p.title} – ${p.price}`),
+              React.createElement('span', { className: 'text-sm' }, `Dagligt kliplimit ${p.benefit}`)
+            )
+          )
+        ))
+      ),
+      React.createElement(Button, { className: 'w-full bg-yellow-500 text-white mb-2', onClick: () => onBuy(selected) }, 'Køb'),
+      React.createElement(Button, { className: 'w-full bg-gray-200 text-black', onClick: onClose }, 'Luk')
+    )
+  );
+}


### PR DESCRIPTION
## Summary
- add overlay to pick between silver, gold, and platinum subscriptions
- store selected tier when purchasing premium from likes or settings

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68921c24e120832db1a83f7108e197dd