### PR TITLE
Improve navigation for premium likes page

### DIFF
--- a/src/VideotpushApp.jsx
+++ b/src/VideotpushApp.jsx
@@ -491,8 +491,8 @@ export default function VideotpushApp() {
     },
       React.createElement(VideoCameraIcon, { className: 'w-8 h-8 text-pink-600', onClick: ()=>{setTab('discovery'); setViewProfile(null);} }),
       React.createElement('div', { className: 'relative', onClick: ()=>{setTab('likes'); setViewProfile(null);} },
-        React.createElement(HeartIcon, { className: 'w-8 h-8 text-pink-600' }),
-        hasUnseenLikes && React.createElement('span', { className: 'absolute -top-1 -right-2 bg-red-500 text-white text-xs rounded-full min-w-4 h-4 flex items-center justify-center px-1' }, '1')
+        React.createElement(HeartIcon, { className: 'w-8 h-8 text-yellow-500' }),
+        hasUnseenLikes && React.createElement('span', { className: 'absolute -top-1 -right-2 bg-red-500 text-white text-xs rounded-full min-w-4 h-4 flex items-center justify-center px-1' }, unseenLikesCount > 9 ? '9+' : unseenLikesCount)
       ),
       React.createElement('div', { className: 'relative', onClick: ()=>{setTab('chat'); setViewProfile(null);} },
         React.createElement(ChatBubbleOvalLeftIcon, { className: 'w-8 h-8 text-pink-600' }),

--- a/src/components/LikesScreen.jsx
+++ b/src/components/LikesScreen.jsx
@@ -13,7 +13,7 @@ import StoryLineOverlay from './StoryLineOverlay.jsx';
 import { triggerHaptic } from '../haptics.js';
 import { sendPushNotification } from '../notifications.js';
 
-export default function LikesScreen({ userId, onSelectProfile }) {
+export default function LikesScreen({ userId, onSelectProfile, onBack }) {
   const profiles = useCollection('profiles');
   const likes = useCollection('likes', 'profileId', userId);
   const matches = useCollection('matches', 'userId', userId);
@@ -79,7 +79,7 @@ export default function LikesScreen({ userId, onSelectProfile }) {
   };
 
   return React.createElement(Card,{className:'relative p-6 m-4 shadow-xl bg-white/90 flex flex-col'},
-    React.createElement(SectionTitle,{title:t('likesTitle'), colorClass:'text-yellow-600'}),
+    React.createElement(SectionTitle,{title:t('likesTitle'), colorClass:'text-yellow-600', action: React.createElement(Button,{onClick:onBack, className:'bg-yellow-500 text-white'}, t('back'))}),
     React.createElement('p',{className:'mb-4 text-gray-500'},`${likedProfiles.length} profiler`),
     hasSubscription && currentUser.subscriptionExpires &&
       React.createElement('p', {


### PR DESCRIPTION
## Summary
- Add back button to likes screen for clearer navigation
- Highlight likes tab in premium yellow and show number of unseen likes

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68921fba62c0832d9956abd39711b961