### PR TITLE
Implement tiered subscription limits

### DIFF
--- a/src/components/DailyDiscovery.jsx
+++ b/src/components/DailyDiscovery.jsx
@@ -1,5 +1,5 @@
 import React, { useState, useEffect } from 'react';
-import { getAge, getTodayStr, getCurrentDate, getDailyProfileLimit } from '../utils.js';
+import { getAge, getTodayStr, getCurrentDate, getDailyProfileLimit, getSuperLikeLimit, getWeekId } from '../utils.js';
 import { User, PlayCircle, Star } from 'lucide-react';
 import VideoOverlay from './VideoOverlay.jsx';
 import { Card } from './ui/card.js';
@@ -208,9 +208,17 @@ export default function DailyDiscovery({ userId, onSelectProfile, ageRange, onOp
     }
   };
   const sendSuperLike = async profileId => {
+    const weekId = getWeekId();
+    const limit = getSuperLikeLimit(user);
+    const used = user.superLikeWeek === weekId ? (user.superLikesUsed || 0) : 0;
+    if(used >= limit){
+      alert('Ugentlig super like gr\u00e6nse n\u00e5et');
+      return;
+    }
     const likeId = `${userId}-${profileId}`;
     await setDoc(doc(db,'likes',likeId),{id:likeId,userId,profileId,super:true});
     await setDoc(doc(db,'episodeProgress', `${userId}-${profileId}`), { removed: true }, { merge: true });
+    await updateDoc(doc(db,'profiles',userId),{ superLikeWeek: weekId, superLikesUsed: used + 1 });
     triggerHaptic([200,50,200]);
     const otherLike = await getDoc(doc(db,'likes',`${profileId}-${userId}`));
     if(otherLike.exists()){

--- a/src/components/ProfileSettings.jsx
+++ b/src/components/ProfileSettings.jsx
@@ -17,7 +17,7 @@ import SnapVideoRecorder from "./SnapVideoRecorder.jsx";
 import MatchOverlay from './MatchOverlay.jsx';
 import { languages, useT } from '../i18n.js';
 import { getInterestCategory } from '../interests.js';
-import { getAge, getCurrentDate } from '../utils.js';
+import { getAge, getCurrentDate, getMaxVideoSeconds } from '../utils.js';
 import { triggerHaptic } from '../haptics.js';
 import { sendPushNotification } from '../notifications.js';
 import ProfileAnalytics from './ProfileAnalytics.jsx';
@@ -165,10 +165,6 @@ export default function ProfileSettings({ userId, ageRange, onChangeAgeRange, pu
     }
   };
 
-  const getMaxVideoSeconds = () => {
-    const tier = profile?.subscriptionTier;
-    return tier === 'Platinum' ? 25 : tier === 'Gold' ? 15 : 10;
-  };
 
   // Allow a small tolerance when validating clip length because the
   // MediaRecorder output can be slightly longer than the requested
@@ -219,7 +215,7 @@ export default function ProfileSettings({ userId, ageRange, onChangeAgeRange, pu
   const handleVideoChange = async e => {
     const file = e.target.files[0];
     if(!file) return;
-    const max = getMaxVideoSeconds();
+    const max = getMaxVideoSeconds(profile);
     if(!(await checkDuration(file, max))){
       alert(t('videoTooLong').replace('{seconds}', max));
       return;
@@ -233,7 +229,7 @@ export default function ProfileSettings({ userId, ageRange, onChangeAgeRange, pu
   };
 
   const handleVideoRecorded = async (file, music) => {
-    const max = getMaxVideoSeconds();
+    const max = getMaxVideoSeconds(profile);
     if(!(await checkDuration(file, max))){
       alert(t('videoTooLong').replace('{seconds}', max));
       return;
@@ -439,7 +435,7 @@ export default function ProfileSettings({ userId, ageRange, onChangeAgeRange, pu
       onChange: handleVideoChange,
       className: 'hidden'
     }),
-    !publicView && showSnapVideoRecorder && React.createElement(SnapVideoRecorder, { onCancel: () => setShowSnapVideoRecorder(false), onRecorded: handleVideoRecorded, maxDuration: getMaxVideoSeconds()*1000 })
+    !publicView && showSnapVideoRecorder && React.createElement(SnapVideoRecorder, { onCancel: () => setShowSnapVideoRecorder(false), onRecorded: handleVideoRecorded, maxDuration: getMaxVideoSeconds(profile)*1000 })
   );
 
 

--- a/src/utils.js
+++ b/src/utils.js
@@ -83,3 +83,24 @@ export function getDailyProfileLimit(user){
   const limits = { free:3, silver:5, gold:8, platinum:10 };
   return limits[tier] ?? limits.free;
 }
+
+export function getSuperLikeLimit(user){
+  const tier = user?.subscriptionTier || 'free';
+  const limits = { free:0, silver:1, gold:3, platinum:5 };
+  return limits[tier] ?? limits.free;
+}
+
+export function getMaxVideoSeconds(user){
+  const tier = user?.subscriptionTier || 'free';
+  const caps = { free:10, silver:15, gold:15, platinum:25 };
+  return caps[tier] ?? caps.free;
+}
+
+export function getWeekId(date = getCurrentDate()){
+  const d = new Date(Date.UTC(date.getFullYear(), date.getMonth(), date.getDate()));
+  const day = d.getUTCDay() || 7;
+  d.setUTCDate(d.getUTCDate() + 4 - day);
+  const yearStart = new Date(Date.UTC(d.getUTCFullYear(),0,1));
+  const weekNo = Math.ceil(((d - yearStart)/86400000 + 1)/7);
+  return `${d.getUTCFullYear()}-${weekNo}`;
+}


### PR DESCRIPTION
## Summary
- add utilities for tier-based super like and video limits
- enforce video length per subscription in profile settings
- cap weekly super likes by tier in daily discovery

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68923b990194832d9485a7b188cc808d