### PR TITLE
feat: differentiate premium video lengths

### DIFF
--- a/src/components/SubscriptionOverlay.jsx
+++ b/src/components/SubscriptionOverlay.jsx
@@ -4,9 +4,9 @@ import { Button } from './ui/button.js';
 
 export default function SubscriptionOverlay({ onClose, onBuy }) {
   const plans = [
-    { tier: 'silver', title: 'Sølv', price: '39 kr/md', daily: 5 },
-    { tier: 'gold', title: 'Guld', price: '79 kr/md', daily: 8 },
-    { tier: 'platinum', title: 'Platin', price: '139 kr/md', daily: 10 }
+    { tier: 'silver', title: 'Sølv', price: '39 kr/md', daily: 5, seconds: 10 },
+    { tier: 'gold', title: 'Guld', price: '79 kr/md', daily: 8, seconds: 15 },
+    { tier: 'platinum', title: 'Platin', price: '139 kr/md', daily: 10, seconds: 25 }
   ];
   const [selected, setSelected] = useState('silver');
   return React.createElement('div', { className: 'fixed inset-0 z-50 bg-black/50 flex items-center justify-center' },
@@ -20,7 +20,7 @@ export default function SubscriptionOverlay({ onClose, onBuy }) {
               onClick: () => setSelected(p.tier)
             },
               React.createElement('span', { className: 'font-medium' }, `${p.title} – ${p.price}`),
-              React.createElement('span', { className: 'text-sm' }, `Dagligt kliplimit ${p.daily}`)
+              React.createElement('span', { className: 'text-sm' }, `Dagligt kliplimit ${p.daily}, video op til ${p.seconds} sek`)
             )
           )
         ))

--- a/src/utils.js
+++ b/src/utils.js
@@ -92,7 +92,7 @@ export function getSuperLikeLimit(user){
 
 export function getMaxVideoSeconds(user){
   const tier = user?.subscriptionTier || 'free';
-  const caps = { free:10, silver:15, gold:15, platinum:25 };
+  const caps = { free:10, silver:10, gold:15, platinum:25 };
   return caps[tier] ?? caps.free;
 }
 


### PR DESCRIPTION
## Summary
- Align video length caps with subscription tiers
- Show video duration details in subscription picker

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68924f1265c4832dbec85130f8e138dd