### PR TITLE
Avoid redundant profile fetch on daily discovery page

### DIFF
--- a/src/VideotpushApp.jsx
+++ b/src/VideotpushApp.jsx
@@ -459,7 +459,7 @@ export default function VideotpushApp() {
         React.createElement(React.Fragment, null,
           React.createElement(TaskButton, { profile: currentUser, onClick: handleTaskClick }),
           tab==='discovery' && !viewProfile && (
-            React.createElement(DailyDiscovery, { userId, onSelectProfile: selectProfile, ageRange, onOpenProfile: openProfileSettings })
+            React.createElement(DailyDiscovery, { userId, profiles, onSelectProfile: selectProfile, ageRange, onOpenProfile: openProfileSettings })
           ),
           viewProfile && (
             viewProfile === userId ?

--- a/src/components/DailyDiscovery.jsx
+++ b/src/components/DailyDiscovery.jsx
@@ -20,8 +20,7 @@ import { triggerHaptic } from '../haptics.js';
 import useDayOffset from '../useDayOffset.js';
 import { sendPushNotification } from '../notifications.js';
 
-export default function DailyDiscovery({ userId, onSelectProfile, ageRange, onOpenProfile }) {
-  const profiles = useCollection('profiles');
+export default function DailyDiscovery({ userId, profiles = [], onSelectProfile, ageRange, onOpenProfile }) {
   const t = useT();
   const config = useDoc('config', 'app') || {};
   const showLevels = config.showLevels !== false;


### PR DESCRIPTION
## Summary
- Use preloaded profiles from parent component instead of refetching on the Daily Discovery page
- Pass profile list into DailyDiscovery from VideotpushApp to reuse existing data

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689255922ae0832dbcd8b648c48c3b58