### PR TITLE
Add GUI tests for subscription tier behavior

### DIFF
--- a/src/components/AdBanner.test.jsx
+++ b/src/components/AdBanner.test.jsx
@@ -1,0 +1,51 @@
+import React from 'react';
+import ReactDOM from 'react-dom';
+import AdBanner from './AdBanner.jsx';
+
+jest.mock('../i18n.js', () => ({
+  useT: () => (key) => {
+    const map = {
+      adBannerText: 'Upgrade to {tier}',
+      adBannerButton: 'Upgrade',
+      tierSilver: 'Silver',
+      tierGold: 'Gold',
+      tierPlatinum: 'Platinum'
+    };
+    return map[key] || key;
+  }
+}));
+
+describe('AdBanner', () => {
+  let container;
+  beforeEach(() => {
+    container = document.createElement('div');
+    document.body.appendChild(container);
+  });
+
+  afterEach(() => {
+    ReactDOM.unmountComponentAtNode(container);
+    document.body.removeChild(container);
+    container = null;
+  });
+
+  test('shows upgrade to Silver for free tier', () => {
+    ReactDOM.render(<AdBanner user={{ subscriptionTier: 'free' }} />, container);
+    expect(container.textContent).toContain('Upgrade to Silver');
+  });
+
+  test('shows upgrade to Gold for silver tier', () => {
+    ReactDOM.render(<AdBanner user={{ subscriptionTier: 'silver' }} />, container);
+    expect(container.textContent).toContain('Upgrade to Gold');
+  });
+
+  test('shows upgrade to Platinum for gold tier', () => {
+    ReactDOM.render(<AdBanner user={{ subscriptionTier: 'gold' }} />, container);
+    expect(container.textContent).toContain('Upgrade to Platinum');
+  });
+
+  test('renders nothing for platinum tier', () => {
+    ReactDOM.render(<AdBanner user={{ subscriptionTier: 'platinum' }} />, container);
+    expect(container.innerHTML).toBe('');
+  });
+});
+


### PR DESCRIPTION
## Summary
- add AdBanner tests covering upgrade messages for all subscription tiers

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689257a19280832d992756acfb957e12