### PR TITLE
Add GUI component tests

### DIFF
--- a/src/components/SectionTitle.test.jsx
+++ b/src/components/SectionTitle.test.jsx
@@ -1,0 +1,36 @@
+import React from 'react';
+import ReactDOM from 'react-dom';
+import SectionTitle from './SectionTitle.jsx';
+
+describe('SectionTitle', () => {
+  let container;
+  beforeEach(() => {
+    container = document.createElement('div');
+    document.body.appendChild(container);
+  });
+
+  afterEach(() => {
+    ReactDOM.unmountComponentAtNode(container);
+    document.body.removeChild(container);
+    container = null;
+  });
+
+  test('renders provided title', () => {
+    ReactDOM.render(<SectionTitle title="Hello" />, container);
+    expect(container.textContent).toContain('Hello');
+  });
+
+  test('renders action element when provided', () => {
+    const action = React.createElement('button', null, 'Action');
+    ReactDOM.render(<SectionTitle title="Test" action={action} />, container);
+    const btn = container.querySelector('button');
+    expect(btn).not.toBeNull();
+    expect(btn.textContent).toBe('Action');
+  });
+
+  test('applies custom color class', () => {
+    ReactDOM.render(<SectionTitle title="Color" colorClass="text-blue-500" />, container);
+    const h2 = container.querySelector('h2');
+    expect(h2.className).toContain('text-blue-500');
+  });
+});

--- a/src/components/TaskButton.test.jsx
+++ b/src/components/TaskButton.test.jsx
@@ -1,0 +1,46 @@
+import React from 'react';
+import ReactDOM from 'react-dom';
+import TaskButton from './TaskButton.jsx';
+
+jest.mock('../tasks.js', () => ({
+  getNextTask: jest.fn()
+}));
+import { getNextTask } from '../tasks.js';
+
+describe('TaskButton', () => {
+  let container;
+  beforeEach(() => {
+    container = document.createElement('div');
+    document.body.appendChild(container);
+    getNextTask.mockReset();
+  });
+
+  afterEach(() => {
+    ReactDOM.unmountComponentAtNode(container);
+    document.body.removeChild(container);
+    container = null;
+  });
+
+  test('renders button with task label', () => {
+    getNextTask.mockReturnValue({ label: 'Do something' });
+    ReactDOM.render(<TaskButton profile={{}} onClick={() => {}} />, container);
+    const btn = container.querySelector('button');
+    expect(btn).not.toBeNull();
+    expect(btn.textContent).toBe('Do something');
+  });
+
+  test('calls onClick handler when clicked', () => {
+    getNextTask.mockReturnValue({ label: 'Action' });
+    const handleClick = jest.fn();
+    ReactDOM.render(<TaskButton profile={{}} onClick={handleClick} />, container);
+    const btn = container.querySelector('button');
+    btn.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+    expect(handleClick).toHaveBeenCalled();
+  });
+
+  test('renders nothing when no task returned', () => {
+    getNextTask.mockReturnValue(null);
+    ReactDOM.render(<TaskButton profile={{}} onClick={() => {}} />, container);
+    expect(container.innerHTML).toBe('');
+  });
+});


### PR DESCRIPTION
## Summary
- add test suite for SectionTitle to verify title, actions and custom colors
- add TaskButton tests validating task label rendering, click handling, and empty state

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689259c65878832d8fecdff84c343307