### PR TITLE
Add premium subscription icon and integrate

### DIFF
--- a/src/components/PremiumFeatures.jsx
+++ b/src/components/PremiumFeatures.jsx
@@ -15,7 +15,7 @@ export default function PremiumFeatures({ userId, onBack, onSelectProfile }) {
   const t = useT();
 
   return React.createElement(Card, { className: 'p-6 m-4 shadow-xl bg-white/90' },
-    React.createElement(SectionTitle, { title: t('premiumTitle'), colorClass: 'text-yellow-600' }),
+    React.createElement(SectionTitle, { title: t('premiumTitle'), colorClass: 'text-yellow-600', premium: true }),
     React.createElement(Button, { className: 'mb-4 bg-yellow-500 text-white', onClick: onBack }, t('back')),
     React.createElement('p', { className: 'mb-4 text-sm text-gray-700' }, 'Her er profiler der har liket dig:'),
     React.createElement('ul', { className: 'space-y-4' },

--- a/src/components/PremiumIcon.jsx
+++ b/src/components/PremiumIcon.jsx
@@ -1,0 +1,6 @@
+import React from 'react';
+import { Crown } from 'lucide-react';
+
+export default function PremiumIcon({ className = 'w-5 h-5 text-yellow-500' }) {
+  return React.createElement(Crown, { className });
+}

--- a/src/components/ProfileSettings.jsx
+++ b/src/components/ProfileSettings.jsx
@@ -18,6 +18,7 @@ import MatchOverlay from './MatchOverlay.jsx';
 import { languages, useT } from '../i18n.js';
 import { getInterestCategory } from '../interests.js';
 import { getAge, getCurrentDate, getMaxVideoSeconds } from '../utils.js';
+import PremiumIcon from './PremiumIcon.jsx';
 import { triggerHaptic } from '../haptics.js';
 import { sendPushNotification } from '../notifications.js';
 import ProfileAnalytics from './ProfileAnalytics.jsx';
@@ -565,10 +566,13 @@ export default function ProfileSettings({ userId, ageRange, onChangeAgeRange, pu
         ),
       isOwnProfile && !publicView && profile.email && React.createElement('p', { className:'text-center text-sm text-gray-600 mt-1' }, profile.email),
       !publicView && profile.subscriptionExpires && React.createElement('p', {
-        className: 'text-center text-sm mt-2 ' + (subscriptionActive ? 'text-green-600' : 'text-red-500')
-      }, subscriptionActive
-        ? `Premium abonnement aktivt til ${new Date(profile.subscriptionExpires).toLocaleDateString('da-DK')}`
-        : `Premium abonnement udløb ${new Date(profile.subscriptionExpires).toLocaleDateString('da-DK')}`),
+        className: 'text-center text-sm mt-2 flex items-center justify-center gap-1 ' + (subscriptionActive ? 'text-green-600' : 'text-red-500')
+      },
+        !subscriptionActive && React.createElement(PremiumIcon, null),
+        subscriptionActive
+          ? `Premium abonnement aktivt til ${new Date(profile.subscriptionExpires).toLocaleDateString('da-DK')}`
+          : `Premium abonnement udløb ${new Date(profile.subscriptionExpires).toLocaleDateString('da-DK')}`
+      ),
         !publicView && profile.subscriptionPurchased && React.createElement('p', {
           className: 'text-center text-sm text-gray-500'
         }, `Købt ${new Date(profile.subscriptionPurchased).toLocaleDateString('da-DK')}`)

--- a/src/components/SectionTitle.jsx
+++ b/src/components/SectionTitle.jsx
@@ -1,8 +1,12 @@
 import React from 'react';
+import PremiumIcon from './PremiumIcon.jsx';
 
-export default function SectionTitle({ title, action, colorClass = 'text-pink-600' }) {
+export default function SectionTitle({ title, action, colorClass = 'text-pink-600', premium = false }) {
   return React.createElement('div', { className: 'flex items-center justify-between mb-2' },
-    React.createElement('h2', { className: `text-2xl font-semibold ${colorClass}` }, title),
+    React.createElement('h2', { className: `text-2xl font-semibold flex items-center gap-2 ${colorClass}` },
+      premium && React.createElement(PremiumIcon, null),
+      title
+    ),
     action || null
   );
 }


### PR DESCRIPTION
## Summary
- introduce reusable PremiumIcon component using lucide crown
- allow SectionTitle to display premium icon and mark premium features
- indicate expired subscriptions with icon in profile settings

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6892d9081b74832daf13cfb3cc87a09c