### PR TITLE
Restrict interest chat to paid tiers

### DIFF
--- a/src/components/InterestChatScreen.jsx
+++ b/src/components/InterestChatScreen.jsx
@@ -1,5 +1,5 @@
 import React, { useState, useEffect, useRef } from 'react';
-import { getAge } from '../utils.js';
+import { getAge, getCurrentDate, hasInterestChat } from '../utils.js';
 import { Card } from './ui/card.js';
 import { Button } from './ui/button.js';
 import { Textarea } from './ui/textarea.js';
@@ -25,6 +25,10 @@ export default function InterestChatScreen({ userId, onSelectProfile = null }) {
   const textareaRef = useRef(null);
   const t = useT();
   const hasInterests = (profile?.interests || []).length > 0;
+  const hasActiveSubscription =
+    profile?.subscriptionExpires &&
+    new Date(profile.subscriptionExpires) > getCurrentDate();
+  const canUseInterestChat = hasActiveSubscription && hasInterestChat(profile);
 
   useEffect(() => {
     if(!interest && profile?.interests?.length){
@@ -81,6 +85,13 @@ export default function InterestChatScreen({ userId, onSelectProfile = null }) {
   };
 
   if(!profile) return null;
+  if(!canUseInterestChat){
+    return React.createElement(Card, { className:'p-6 m-4 shadow-xl bg-white/90 flex flex-col items-center text-center' },
+      React.createElement(SectionTitle, { title: t('interestChatsTitle') }),
+      React.createElement('p', { className:'text-gray-600 mb-4' }, 'Kræver Sølv, Guld eller Platin'),
+      React.createElement(Button, { className:'bg-pink-500 text-white', onClick:()=>window.dispatchEvent(new CustomEvent('showSubscription')) }, 'Køb abonnement')
+    );
+  }
   if(showRealetten && interest){
     return React.createElement(RealettenPage, { interest, userId, onBack:()=>setShowRealetten(false) });
   }

--- a/src/utils.js
+++ b/src/utils.js
@@ -96,6 +96,11 @@ export function getMaxVideoSeconds(user){
   return caps[tier] ?? caps.free;
 }
 
+export function hasInterestChat(user){
+  const tier = user?.subscriptionTier || 'free';
+  return ['silver','gold','platinum'].includes(tier);
+}
+
 export function getWeekId(date = getCurrentDate()){
   const d = new Date(Date.UTC(date.getFullYear(), date.getMonth(), date.getDate()));
   const day = d.getUTCDay() || 7;

--- a/src/utils.test.js
+++ b/src/utils.test.js
@@ -11,6 +11,7 @@ import {
   getDailyProfileLimit,
   getSuperLikeLimit,
   getMaxVideoSeconds,
+  hasInterestChat,
   getWeekId
 } from './utils';
 
@@ -95,6 +96,11 @@ describe('utils', () => {
   test('getMaxVideoSeconds respects tier', () => {
     expect(getMaxVideoSeconds({ subscriptionTier: 'gold' })).toBe(15);
     expect(getMaxVideoSeconds({})).toBe(10);
+  });
+
+  test('hasInterestChat requires paid tier', () => {
+    expect(hasInterestChat({ subscriptionTier: 'silver' })).toBe(true);
+    expect(hasInterestChat({ subscriptionTier: 'free' })).toBe(false);
   });
 
   test('getWeekId returns ISO week id', () => {


### PR DESCRIPTION
## Summary
- add `hasInterestChat` helper to detect tiers that include group chat
- gate `InterestChatScreen` behind active subscription and show upgrade CTA
- cover interest chat eligibility with unit test

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6892ed7131a8832d9e92cf8063dc9009