### PR TITLE
Add monthly boost allocation for premium plans

### DIFF
--- a/FEATURES.txt
+++ b/FEATURES.txt
@@ -30,5 +30,6 @@ Turn-based Realetten game uses Firestore for shared state and scoring
 Winner celebration overlay highlights top score
 Kill all Realetten sessions from admin
 Super likes to signal strong interest and improve match rates
+Monthly profile boosts depending on subscription tier
 Incognito mode lets subscribers browse profiles anonymously
 Video creation tools with music and longer uploads for richer profiles

--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@ Profiles are presented as short episodes rather than a catalog of faces. Each ep
 * Invite friends with a shareable link
 * Seed data includes 11 mandlige profiler der matcher standardbrugeren så du kan teste premium og ekstra klip
 * Super likes let you signal strong interest and improve match rates
+* Boost your profile for increased visibility (1, 2 or 4 times per month depending on subscription)
 * Incognito mode allows subscribers to browse profiles anonymously
 * Video creation tools add background music and support longer uploads
 * Videoklip begrænset til 10 sekunder (op til 25 sekunder med premium)

--- a/src/VideotpushApp.jsx
+++ b/src/VideotpushApp.jsx
@@ -172,12 +172,15 @@ export default function VideotpushApp() {
     const base = current > now ? current : now;
     const expiry = new Date(base);
     expiry.setMonth(expiry.getMonth() + 1);
+    const month = now.toISOString().slice(0,7);
     try {
       await updateDoc(doc(db,'profiles',userId), {
         subscriptionActive: true,
         subscriptionPurchased: now.toISOString(),
         subscriptionExpires: expiry.toISOString(),
-        subscriptionTier: tier
+        subscriptionTier: tier,
+        boostMonth: month,
+        boostsUsed: 0
       });
     } catch(err) {
       console.error('Failed to purchase subscription', err);

--- a/src/components/LikesScreen.jsx
+++ b/src/components/LikesScreen.jsx
@@ -69,11 +69,14 @@ export default function LikesScreen({ userId, onSelectProfile, onBack }) {
     const base = current > now ? current : now;
     const expiry = new Date(base);
     expiry.setMonth(expiry.getMonth() + 1);
+    const month = now.toISOString().slice(0,7);
     await setDoc(doc(db,'profiles',userId),{
       subscriptionActive:true,
       subscriptionPurchased: now.toISOString(),
       subscriptionExpires: expiry.toISOString(),
-      subscriptionTier: tier
+      subscriptionTier: tier,
+      boostMonth: month,
+      boostsUsed: 0
     },{ merge:true });
     setShowPurchase(false);
   };

--- a/src/components/ProfileSettings.jsx
+++ b/src/components/ProfileSettings.jsx
@@ -69,13 +69,16 @@ export default function ProfileSettings({ userId, ageRange, onChangeAgeRange, pu
     const base = current > now ? current : now;
     const expiry = new Date(base);
     expiry.setMonth(expiry.getMonth() + 1);
+    const month = now.toISOString().slice(0,7);
     await updateDoc(doc(db, 'profiles', userId), {
       subscriptionActive: true,
       subscriptionPurchased: now.toISOString(),
       subscriptionExpires: expiry.toISOString(),
-      subscriptionTier: tier
+      subscriptionTier: tier,
+      boostMonth: month,
+      boostsUsed: 0
     });
-    setProfile({ ...profile, subscriptionActive: true, subscriptionPurchased: now.toISOString(), subscriptionExpires: expiry.toISOString(), subscriptionTier: tier });
+    setProfile({ ...profile, subscriptionActive: true, subscriptionPurchased: now.toISOString(), subscriptionExpires: expiry.toISOString(), subscriptionTier: tier, boostMonth: month, boostsUsed: 0 });
     setShowSub(false);
   };
 

--- a/src/components/SubscriptionOverlay.jsx
+++ b/src/components/SubscriptionOverlay.jsx
@@ -4,9 +4,9 @@ import { Button } from './ui/button.js';
 
 export default function SubscriptionOverlay({ onClose, onBuy }) {
   const plans = [
-    { tier: 'silver', title: 'Sølv', price: '39 kr/md', daily: 5, seconds: 10 },
-    { tier: 'gold', title: 'Guld', price: '79 kr/md', daily: 8, seconds: 15 },
-    { tier: 'platinum', title: 'Platin', price: '139 kr/md', daily: 10, seconds: 25 }
+    { tier: 'silver', title: 'Sølv', price: '39 kr/md', daily: 5, seconds: 10, boosts: 1 },
+    { tier: 'gold', title: 'Guld', price: '79 kr/md', daily: 8, seconds: 15, boosts: 2 },
+    { tier: 'platinum', title: 'Platin', price: '139 kr/md', daily: 10, seconds: 25, boosts: 4 }
   ];
   const [selected, setSelected] = useState('silver');
   return React.createElement('div', { className: 'fixed inset-0 z-50 bg-black/50 flex items-center justify-center' },
@@ -20,7 +20,8 @@ export default function SubscriptionOverlay({ onClose, onBuy }) {
               onClick: () => setSelected(p.tier)
             },
               React.createElement('span', { className: 'font-medium' }, `${p.title} – ${p.price}`),
-              React.createElement('span', { className: 'text-sm' }, `Dagligt kliplimit ${p.daily}, video op til ${p.seconds} sek`)
+              React.createElement('span', { className: 'text-sm' }, `Dagligt kliplimit ${p.daily}, video op til ${p.seconds} sek`),
+              React.createElement('span', { className: 'text-sm' }, `Boosts pr. måned ${p.boosts}`)
             )
           )
         ))

--- a/src/components/WelcomeScreen.jsx
+++ b/src/components/WelcomeScreen.jsx
@@ -226,6 +226,8 @@ export default function WelcomeScreen({ onLogin }) {
       profile.subscriptionPurchased = now.toISOString();
       profile.subscriptionExpires = expiry.toISOString();
       profile.subscriptionTier = 'silver';
+      profile.boostMonth = now.toISOString().slice(0,7);
+      profile.boostsUsed = 0;
       profile.giftedBy = giftFrom;
       try {
         await updateDoc(doc(db, 'profiles', giftFrom), { premiumInvitesUsed: increment(1) });
@@ -347,6 +349,8 @@ export default function WelcomeScreen({ onLogin }) {
       profile.subscriptionPurchased = now.toISOString();
       profile.subscriptionExpires = expiry.toISOString();
       profile.subscriptionTier = 'silver';
+      profile.boostMonth = now.toISOString().slice(0,7);
+      profile.boostsUsed = 0;
       profile.giftedBy = giftFrom;
       try {
         await updateDoc(doc(db, 'profiles', giftFrom), { premiumInvitesUsed: increment(1) });

--- a/src/seedData.js
+++ b/src/seedData.js
@@ -10,8 +10,9 @@ export default async function seedData() {
   const expiry = new Date(now); expiry.setMonth(now.getMonth() + 1);
   const purchase = now.toISOString();
   const nowIso = new Date().toISOString();
+  const month = now.toISOString().slice(0,7);
   const testUsers = [
-    {id:'101',name:'Maria',verified:true,age:49,gender:'Kvinde',interest:'Mand',city:'Odense',distanceRange:[10,25],videoClips:[],clip:'Elsker bøger og gåture.',subscriptionActive:true,subscriptionPurchased:purchase,subscriptionExpires:expiry.toISOString(),subscriptionTier:'silver',language:'da',preferredLanguages:['da'],allowOtherLanguages:true,photoUploadedAt:nowIso,interests:['Litteratur','Vandreture','Mad & vin']},
+    {id:'101',name:'Maria',verified:true,age:49,gender:'Kvinde',interest:'Mand',city:'Odense',distanceRange:[10,25],videoClips:[],clip:'Elsker bøger og gåture.',subscriptionActive:true,subscriptionPurchased:purchase,subscriptionExpires:expiry.toISOString(),subscriptionTier:'silver',boostMonth:month,boostsUsed:0,language:'da',preferredLanguages:['da'],allowOtherLanguages:true,photoUploadedAt:nowIso,interests:['Litteratur','Vandreture','Mad & vin']},
     {id:'102',name:'Sofie',age:35,gender:'Kvinde',interest:'Mand',city:'Aarhus',distanceRange:[10,25],videoClips:[],clip:'Yoga-entusiast.',language:'da',preferredLanguages:['da'],allowOtherLanguages:true,photoUploadedAt:nowIso,interests:['Yoga','Musik','Rejser']},
     {id:'103',name:'Emma',age:41,gender:'Kvinde',interest:'Mand',city:'Aalborg',distanceRange:[10,25],videoClips:[],clip:'Musikalsk sjæl.',language:'da',preferredLanguages:['da'],allowOtherLanguages:true,photoUploadedAt:nowIso,interests:['Musik','Kunst','Løb']},
     {id:'104',name:'Peter',verified:true,age:45,gender:'Mand',interest:'Kvinde',city:'København',distanceRange:[10,25],videoClips:[],clip:'Cykler i weekenden.',language:'da',preferredLanguages:['da'],allowOtherLanguages:true,photoUploadedAt:nowIso,interests:['Cykling','Mad & vin','Rejser']},

--- a/src/utils.js
+++ b/src/utils.js
@@ -90,6 +90,12 @@ export function getSuperLikeLimit(user){
   return limits[tier] ?? limits.free;
 }
 
+export function getMonthlyBoostLimit(user){
+  const tier = user?.subscriptionTier || 'free';
+  const limits = { free:0, silver:1, gold:2, platinum:4 };
+  return limits[tier] ?? limits.free;
+}
+
 export function getMaxVideoSeconds(user){
   const tier = user?.subscriptionTier || 'free';
   const caps = { free:10, silver:10, gold:15, platinum:25 };

--- a/src/utils.test.js
+++ b/src/utils.test.js
@@ -10,6 +10,7 @@ import {
   detectBrowser,
   getDailyProfileLimit,
   getSuperLikeLimit,
+  getMonthlyBoostLimit,
   getMaxVideoSeconds,
   hasInterestChat,
   getWeekId
@@ -91,6 +92,11 @@ describe('utils', () => {
   test('getSuperLikeLimit respects tier', () => {
     expect(getSuperLikeLimit({ subscriptionTier: 'platinum' })).toBe(5);
     expect(getSuperLikeLimit({})).toBe(0);
+  });
+
+  test('getMonthlyBoostLimit respects tier', () => {
+    expect(getMonthlyBoostLimit({ subscriptionTier: 'gold' })).toBe(2);
+    expect(getMonthlyBoostLimit({})).toBe(0);
   });
 
   test('getMaxVideoSeconds respects tier', () => {


### PR DESCRIPTION
## Summary
- add `getMonthlyBoostLimit` utility with tests
- show plan-specific boosts in subscription overlay
- track monthly boost usage when subscriptions are purchased or gifted

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689344dfffac832da979a3cf96ca5482