### PR TITLE
feat: add pricing page

### DIFF
--- a/public/pricing.html
+++ b/public/pricing.html
@@ -1,0 +1,39 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Pricing - RealDate</title>
+  <script src="https://cdn.tailwindcss.com"></script>
+</head>
+<body class="p-4">
+  <h1 class="text-3xl font-bold mb-4">Premium Plans</h1>
+  <p class="mb-6">Choose the subscription that fits your needs.</p>
+  <table class="table-auto w-full border border-gray-200">
+    <thead>
+      <tr class="bg-gray-100">
+        <th class="px-4 py-2 border-b">Plan</th>
+        <th class="px-4 py-2 border-b">Price</th>
+        <th class="px-4 py-2 border-b">Features</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td class="px-4 py-2 border-b">Basic</td>
+        <td class="px-4 py-2 border-b">$9.99/month</td>
+        <td class="px-4 py-2 border-b">Unlimited swipes</td>
+      </tr>
+      <tr class="bg-gray-50">
+        <td class="px-4 py-2 border-b">Pro</td>
+        <td class="px-4 py-2 border-b">$19.99/month</td>
+        <td class="px-4 py-2 border-b">Everything in Basic plus priority matches</td>
+      </tr>
+      <tr>
+        <td class="px-4 py-2">Elite</td>
+        <td class="px-4 py-2">$29.99/month</td>
+        <td class="px-4 py-2">All Pro features with VIP support</td>
+      </tr>
+    </tbody>
+  </table>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add standalone pricing page describing premium plans

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689360ecad58832d957f554c3fc5039d