### PR TITLE
Add cooperative shooter mini-game

### DIFF
--- a/src/components/CoopShootingGame.jsx
+++ b/src/components/CoopShootingGame.jsx
@@ -1,0 +1,68 @@
+import React, { useState, useEffect } from 'react';
+import { Card } from './ui/card.js';
+import { Button } from './ui/button.js';
+import SectionTitle from './SectionTitle.jsx';
+import { db, doc, setDoc, updateDoc, deleteDoc, onSnapshot, arrayUnion, arrayRemove, increment } from '../firebase.js';
+
+function sanitizeInterest(i){
+  return encodeURIComponent(i || '').replace(/%20/g,'_');
+}
+
+export default function CoopShootingGame({ interest, userId, onBack }){
+  const [game, setGame] = useState(null);
+  useEffect(() => {
+    if(!interest) return;
+    const id = sanitizeInterest(interest);
+    const ref = doc(db, 'coopShooter', id);
+    const unsub = onSnapshot(ref, snap => {
+      setGame(snap.exists() ? snap.data() : null);
+    });
+    return () => unsub();
+  }, [interest]);
+
+  if(!interest){
+    return null;
+  }
+
+  const id = sanitizeInterest(interest);
+  const ref = doc(db, 'coopShooter', id);
+  const startGame = async () => {
+    await setDoc(ref, { interest, score: 0, target: 20, players: [userId] });
+  };
+  const joinGame = async () => {
+    await updateDoc(ref, { players: arrayUnion(userId) });
+  };
+  const leaveGame = async () => {
+    await updateDoc(ref, { players: arrayRemove(userId) });
+  };
+  const endGame = async () => {
+    await deleteDoc(ref).catch(() => {});
+  };
+  const shoot = async () => {
+    await updateDoc(ref, { score: increment(1) });
+  };
+
+  if(!game){
+    return React.createElement(Card, { className:'p-6 m-4 shadow-xl bg-white/90 flex flex-col items-center' },
+      React.createElement(SectionTitle, { title:'Co-op Shooter', action: React.createElement(Button, { className:'bg-gray-500 text-white', onClick:onBack }, 'Tilbage') }),
+      React.createElement(Button, { className:'bg-green-600 text-white mt-4', onClick:startGame }, 'Start spil')
+    );
+  }
+
+  const players = game.players || [];
+  const inGame = players.includes(userId);
+  const canJoin = !inGame && players.length < 4;
+  const finished = game.score >= game.target;
+
+  return React.createElement(Card, { className:'p-6 m-4 shadow-xl bg-white/90 flex flex-col items-center' },
+    React.createElement(SectionTitle, { title:'Co-op Shooter', action: React.createElement(Button, { className:'bg-gray-500 text-white', onClick:onBack }, 'Tilbage') }),
+    React.createElement('p', { className:'mb-2' }, `Score: ${game.score} / ${game.target}`),
+    React.createElement('p', { className:'mb-4' }, `Spillere: ${players.length}/4`),
+    canJoin && React.createElement(Button, { className:'bg-blue-600 text-white mb-2', onClick:joinGame }, 'Join'),
+    inGame && !finished && React.createElement(Button, { className:'bg-red-600 text-white mb-2', onClick:shoot }, 'Shoot'),
+    inGame && React.createElement(Button, { className:'bg-gray-700 text-white mb-2', onClick:leaveGame }, 'Leave'),
+    finished && React.createElement('p', { className:'mb-2 font-semibold text-green-700' }, 'Mission complete!'),
+    React.createElement(Button, { className:'bg-yellow-600 text-white mt-2', onClick:endGame }, 'End Game')
+  );
+}
+

--- a/src/components/InterestChatScreen.jsx
+++ b/src/components/InterestChatScreen.jsx
@@ -7,6 +7,7 @@ import SectionTitle from './SectionTitle.jsx';
 import { useT } from '../i18n.js';
 import { useDoc, useCollection, db, doc, setDoc, arrayUnion, onSnapshot, getDoc } from '../firebase.js';
 import RealettenPage from './RealettenPage.jsx';
+import CoopShootingGame from './CoopShootingGame.jsx';
 
 function sanitizeInterest(i){
   return encodeURIComponent(i || '').replace(/%20/g,'_');
@@ -21,6 +22,8 @@ export default function InterestChatScreen({ userId, onSelectProfile = null }) {
   const [text, setText] = useState('');
   const [showRealetten, setShowRealetten] = useState(false);
   const [realettenStarted, setRealettenStarted] = useState(false);
+  const [showShooter, setShowShooter] = useState(false);
+  const [shooterStarted, setShooterStarted] = useState(false);
   const messagesRef = useRef(null);
   const textareaRef = useRef(null);
   const t = useT();
@@ -69,6 +72,23 @@ export default function InterestChatScreen({ userId, onSelectProfile = null }) {
     };
   }, [interest]);
 
+  useEffect(() => {
+    if(!interest) return;
+    let ignore = false;
+    setShooterStarted(false);
+    const ref = doc(db, 'coopShooter', sanitizeInterest(interest));
+    getDoc(ref).then(snap => {
+      if(!ignore) setShooterStarted(snap.exists());
+    });
+    const unsub = onSnapshot(ref, snap => {
+      if(!ignore) setShooterStarted(snap.exists());
+    });
+    return () => {
+      ignore = true;
+      unsub();
+    };
+  }, [interest]);
+
   const sendMessage = async () => {
     const trimmed = text.trim();
     if(!trimmed || !interest) return;
@@ -94,6 +114,9 @@ export default function InterestChatScreen({ userId, onSelectProfile = null }) {
   }
   if(showRealetten && interest){
     return React.createElement(RealettenPage, { interest, userId, onBack:()=>setShowRealetten(false) });
+  }
+  if(showShooter && interest){
+    return React.createElement(CoopShootingGame, { interest, userId, onBack:()=>setShowShooter(false) });
   }
 
   return React.createElement(Card, { className: 'p-6 m-4 shadow-xl bg-white/90 flex flex-col h-full flex-1', style:{maxHeight:'calc(100vh - 10rem)', overflow:'hidden'} },
@@ -141,7 +164,8 @@ export default function InterestChatScreen({ userId, onSelectProfile = null }) {
         }),
         React.createElement(Button, { className:'bg-pink-500 text-white', disabled:!text.trim(), onClick:sendMessage }, 'Send')
       ),
-      React.createElement(Button, { className:'bg-blue-600 text-white font-bold mt-2', onClick:()=>setShowRealetten(true) }, realettenStarted ? 'Realetten started - Join now!' : 'Tag Chancen - Pr\u00f8v Realetten')
+      React.createElement(Button, { className:'bg-blue-600 text-white font-bold mt-2', onClick:()=>setShowRealetten(true) }, realettenStarted ? 'Realetten started - Join now!' : 'Tag Chancen - Pr\u00f8v Realetten'),
+      React.createElement(Button, { className:'bg-green-600 text-white font-bold mt-2', onClick:()=>setShowShooter(true) }, shooterStarted ? 'Shooter active - Join!' : 'Start Co-op Shooter')
     )
   );
 }


### PR DESCRIPTION
## Summary
- add CoopShootingGame component so up to four players can collaborate to hit a shared score
- expose shooter game from InterestChatScreen with button and realtime availability tracking

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689361a94ed0832d9b2a1432dd9f1036