### PR TITLE
Add pricing page with subscription tiers

### DIFF
--- a/netlify/functions/pricing.html
+++ b/netlify/functions/pricing.html
@@ -1,0 +1,184 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>RealDate - Pricing</title>
+  <style>
+    body {
+      font-family: Arial, sans-serif;
+      margin: 0;
+      padding: 0;
+      color: #333;
+      background: linear-gradient(to bottom right, #fce7f3, #ffffff);
+    }
+    header {
+      background: #ff4957;
+      color: #fff;
+      padding: 2rem 1rem;
+      text-align: center;
+    }
+    header h1 { margin: 0; font-size: 2.5rem; }
+    header p { margin: 0.5rem 0 1.5rem; font-size: 1.2rem; }
+    .cta {
+      display: inline-block;
+      background: #ff4957;
+      color: #fff;
+      text-decoration: none;
+      padding: 0.75rem 1.5rem;
+      font-size: 1.2rem;
+      border-radius: 4px;
+      cursor: pointer;
+      transition: transform 0.2s, box-shadow 0.2s;
+    }
+    table {
+      width: 100%;
+      border-collapse: collapse;
+      margin-top: 2rem;
+    }
+    th, td {
+      border: 1px solid #ddd;
+      padding: 0.75rem;
+      text-align: center;
+    }
+    th {
+      background: #ff4957;
+      color: #fff;
+    }
+    tr:nth-child(even) { background: #f9f9f9; }
+  </style>
+</head>
+<body>
+  <header>
+    <h1>RealDate Pricing</h1>
+    <p>Choose the plan that's right for you</p>
+    <a class="cta" href="index.html">Back to Home</a>
+  </header>
+  <section>
+    <table>
+      <tr>
+        <th>Feature</th>
+        <th>Free</th>
+        <th>Silver</th>
+        <th>Gold</th>
+        <th>Platinum</th>
+      </tr>
+      <tr>
+        <td>Daily profile limit</td>
+        <td>3</td>
+        <td>5</td>
+        <td>8</td>
+        <td>10</td>
+      </tr>
+      <tr>
+        <td>Group chat based on interests</td>
+        <td>&#10060;</td>
+        <td>&#10003;</td>
+        <td>&#10003;</td>
+        <td>&#10003;</td>
+      </tr>
+      <tr>
+        <td>Ratings</td>
+        <td>&#10060;</td>
+        <td>&#10060;</td>
+        <td>&#10003;</td>
+        <td>&#10003;</td>
+      </tr>
+      <tr>
+        <td>See who liked you</td>
+        <td>&#10060;</td>
+        <td>&#10060;</td>
+        <td>&#10003;</td>
+        <td>&#10003;</td>
+      </tr>
+      <tr>
+        <td>Undo removes</td>
+        <td>&#10060;</td>
+        <td>last</td>
+        <td>&#10003;</td>
+        <td>&#10003;</td>
+      </tr>
+      <tr>
+        <td>Super like per week</td>
+        <td>&#10060;</td>
+        <td>1</td>
+        <td>3</td>
+        <td>5</td>
+      </tr>
+      <tr>
+        <td>Boost visibility</td>
+        <td>&#10060;</td>
+        <td>1/month</td>
+        <td>2/month</td>
+        <td>4/month</td>
+      </tr>
+      <tr>
+        <td>Advanced filters (gender, age, distance, etc.)</td>
+        <td>gender, age</td>
+        <td>+distance</td>
+        <td>Full</td>
+        <td>Full</td>
+      </tr>
+      <tr>
+        <td>Incognito mode</td>
+        <td>&#10060;</td>
+        <td>&#10060;</td>
+        <td>&#10060;</td>
+        <td>&#10003;</td>
+      </tr>
+      <tr>
+        <td>Video creation tools (music)</td>
+        <td>&#10060;</td>
+        <td>&#10060;</td>
+        <td>&#10003;</td>
+        <td>&#10003;</td>
+      </tr>
+      <tr>
+        <td>Longer videos</td>
+        <td>&#10060;</td>
+        <td>&#10060;</td>
+        <td>15 sec</td>
+        <td>25 sec</td>
+      </tr>
+      <tr>
+        <td>Ad-free experience</td>
+        <td>Ads</td>
+        <td>&#10003;</td>
+        <td>&#10003; (priority)</td>
+        <td>&#10003; (priority)</td>
+      </tr>
+      <tr>
+        <td>Profile verification badge</td>
+        <td>&#10060;</td>
+        <td>&#10060;</td>
+        <td>&#10003;</td>
+        <td>&#10003;</td>
+      </tr>
+      <tr>
+        <td>Read receipts & typing indicators</td>
+        <td>&#10060;</td>
+        <td>&#10060;</td>
+        <td>&#10003;</td>
+        <td>&#10003;</td>
+      </tr>
+      <tr>
+        <td>Advanced profile analytics</td>
+        <td>&#10060;</td>
+        <td>&#10060;</td>
+        <td>&#10003; (basic)</td>
+        <td>&#10003; (advanced)</td>
+      </tr>
+      <tr>
+        <td><strong>Price (DKK/month)</strong></td>
+        <td><strong>Free</strong></td>
+        <td><strong>39</strong></td>
+        <td><strong>79</strong></td>
+        <td><strong>139</strong></td>
+      </tr>
+    </table>
+  </section>
+  <footer>
+    <p>RealDate &copy; 2025</p>
+  </footer>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- Add pricing page in Netlify functions showing Free, Silver, Gold, and Platinum plans with feature comparison and monthly prices

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689362e84894832d9963eb3e3270fdab