### PR TITLE
fix: simplify Babel config for tests

### DIFF
--- a/babel.config.json
+++ b/babel.config.json
@@ -1,6 +1,10 @@
 {
-  "presets": [
-    ["@parcel/babel-preset-env", { "targets": { "node": "current" } }],
-    ["@babel/preset-react", { "runtime": "automatic" }]
-  ]
+  "env": {
+    "test": {
+      "presets": [
+        ["@babel/preset-env", { "targets": { "node": "current" } }],
+        ["@babel/preset-react", { "runtime": "automatic" }]
+      ]
+    }
+  }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -23,7 +23,6 @@
         "@babel/core": "^7.28.0",
         "@babel/preset-env": "^7.28.0",
         "@babel/preset-react": "^7.27.1",
-        "@parcel/babel-preset-env": "^2.15.4",
         "@parcel/packager-raw-url": "^2.15.4",
         "@parcel/transformer-webmanifest": "^2.15.4",
         "babel-jest": "^30.0.5",
@@ -3724,27 +3723,6 @@
         "@emnapi/core": "^1.4.3",
         "@emnapi/runtime": "^1.4.3",
         "@tybys/wasm-util": "^0.10.0"
-      }
-    },
-    "node_modules/@parcel/babel-preset-env": {
-      "version": "2.15.4",
-      "resolved": "https://registry.npmjs.org/@parcel/babel-preset-env/-/babel-preset-env-2.15.4.tgz",
-      "integrity": "sha512-EH474POtVOrYwXT8UpNfFYoMfdatdKMOqEiR+Y2xHZz/S5+pgOEo7hFr+atNteE5CZDUSvSmnar234VOPvYomw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@babel/preset-env": "^7.22.14",
-        "semver": "^7.7.1"
-      },
-      "engines": {
-        "node": ">= 16.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/parcel"
-      },
-      "peerDependencies": {
-        "@babel/core": "^7.22.11"
       }
     },
     "node_modules/@parcel/bundler-default": {

--- a/package.json
+++ b/package.json
@@ -26,7 +26,6 @@
     "@babel/core": "^7.28.0",
     "@babel/preset-env": "^7.28.0",
     "@babel/preset-react": "^7.27.1",
-    "@parcel/babel-preset-env": "^2.15.4",
     "@parcel/packager-raw-url": "^2.15.4",
     "@parcel/transformer-webmanifest": "^2.15.4",
     "babel-jest": "^30.0.5",


### PR DESCRIPTION
## Summary
- use Babel presets only during tests to avoid Parcel-specific dependency
- drop `@parcel/babel-preset-env` from development dependencies

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689365bd4150832db7df182f7d8b2034