### PR TITLE
fix: set mobile viewport for screenshots

### DIFF
--- a/scripts/capture-screens.js
+++ b/scripts/capture-screens.js
@@ -32,6 +32,12 @@ async function capture() {
     args: ['--no-sandbox']
   });
   const page = await browser.newPage();
+  await page.setViewport({
+    width: 360,
+    height: 640,
+    deviceScaleFactor: 2,
+    isMobile: true
+  });
   await page.evaluateOnNewDocument(() => {
     localStorage.setItem('loggedIn', 'true');
     localStorage.setItem('preferredUserId', '101');


### PR DESCRIPTION
## Summary
- ensure automated screenshots use a mobile viewport so icon sizes match the app

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68937105df4c832db2ae83296ced0af1