### PR TITLE
Allow CDN for screenshot styling

### DIFF
--- a/scripts/capture-screens.js
+++ b/scripts/capture-screens.js
@@ -44,7 +44,11 @@ async function capture() {
   });
   await page.setRequestInterception(true);
   page.on('request', req => {
-    const allowed = req.url().startsWith(`http://localhost:${port}`) || req.url().startsWith('data:');
+    const url = req.url();
+    const allowed =
+      url.startsWith(`http://localhost:${port}`) ||
+      url.startsWith('data:') ||
+      url.startsWith('https://cdn.tailwindcss.com');
     allowed ? req.continue() : req.abort();
   });
   const routes = [


### PR DESCRIPTION
## Summary
- Include Tailwind CDN requests when taking automated screenshots so icons render at the correct size

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68937306e750832db6e09895c1d5e8cd