### PR TITLE
chore: delay screenshot to ensure profile data

### DIFF
--- a/scripts/capture-screens.js
+++ b/scripts/capture-screens.js
@@ -64,6 +64,8 @@ async function capture() {
     const url = `http://localhost:${port}/?tab=${route.tab}`;
     const file = path.join(shotsDir, `${route.name}.png`);
     await page.goto(url, { waitUntil: 'networkidle0', timeout: 60000 });
+    // Allow extra time for client-side data to render before capturing
+    await page.waitForTimeout(1000);
     await page.screenshot({ path: file, fullPage: true });
     console.log('Saved', file);
   }


### PR DESCRIPTION
## Summary
- wait briefly after route navigation before capturing screenshots so profile data can load

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68937894a484832d9c9c8804b5309bad