### PR TITLE
Replace deprecated waitForTimeout with manual delay

### DIFF
--- a/scripts/capture-screens.js
+++ b/scripts/capture-screens.js
@@ -65,7 +65,8 @@ async function capture() {
     const file = path.join(shotsDir, `${route.name}.png`);
     await page.goto(url, { waitUntil: 'networkidle0', timeout: 60000 });
     // Allow extra time for client-side data to render before capturing
-    await page.waitForTimeout(1000);
+    // `waitForTimeout` was removed in newer Puppeteer versions; use a manual delay instead
+    await new Promise(resolve => setTimeout(resolve, 1000));
     await page.screenshot({ path: file, fullPage: true });
     console.log('Saved', file);
   }


### PR DESCRIPTION
## Summary
- avoid TypeError in screenshot script by replacing deprecated `page.waitForTimeout` with a manual delay

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68937c3ecf78832dbca763e9d182c6b7