### PR TITLE
Increase screenshot capture delay for profile data

### DIFF
--- a/scripts/capture-screens.js
+++ b/scripts/capture-screens.js
@@ -66,7 +66,7 @@ async function capture() {
     await page.goto(url, { waitUntil: 'networkidle0', timeout: 60000 });
     // Allow extra time for client-side data to render before capturing
     // `waitForTimeout` was removed in newer Puppeteer versions; use a manual delay instead
-    await new Promise(resolve => setTimeout(resolve, 1000));
+    await new Promise(resolve => setTimeout(resolve, 5000));
     await page.screenshot({ path: file, fullPage: true });
     console.log('Saved', file);
   }


### PR DESCRIPTION
## Summary
- wait 5 seconds before capturing screenshots to allow profile data to load

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68937e454c04832db08a0e8660dab4b0