### PR TITLE
Allow firebase network in screenshot capture

### DIFF
--- a/scripts/capture-screens.js
+++ b/scripts/capture-screens.js
@@ -64,7 +64,9 @@ async function capture() {
       const allowed =
         url.startsWith(`http://localhost:${port}`) ||
         url.startsWith('data:') ||
-        url.startsWith('https://cdn.tailwindcss.com');
+        url.startsWith('https://cdn.tailwindcss.com') ||
+        url.includes('googleapis.com') ||
+        url.startsWith('https://firebasestorage.googleapis.com');
       allowed ? req.continue() : req.abort();
     });
     const shotsDir = path.join(__dirname, '..', 'screenshots', u.tier);


### PR DESCRIPTION
## Summary
- allow Firebase/Google API requests when capturing screenshots

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6893a021f65c832d9ae18d9331a0f363