### PR TITLE
fix: bypass CORS when caching media

### DIFF
--- a/src/cacheMedia.js
+++ b/src/cacheMedia.js
@@ -8,10 +8,8 @@ export async function cacheMediaIfNewer(url, uploadedAt) {
   const stored = localStorage.getItem(key);
   if (stored === ts) return;
   try {
-    const resp = await fetch(url);
-    if (!resp.ok) throw new Error('Failed request');
     const cache = await caches.open('media-cache-v1');
-    await cache.put(url, resp.clone());
+    await cache.add(new Request(url, { mode: 'no-cors' }));
     localStorage.setItem(key, ts);
   } catch (err) {
     const msg = err && err.message ? err.message : String(err);


### PR DESCRIPTION
## Summary
- fetch media with no-cors and add to Cache API to avoid CORS failures during caching

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6893acbda394832daddd3572b875b437