### PR TITLE
fix: persist profile photo after restart

### DIFF
--- a/src/VideotpushApp.jsx
+++ b/src/VideotpushApp.jsx
@@ -96,7 +96,7 @@ export default function VideotpushApp() {
   }, [userId]);
 
   useEffect(() => {
-    if (!userId) return;
+    if (!userId || !profiles.loaded) return;
     if (currentUser.photoURL) {
       localStorage.setItem(`photoURL-${userId}`, currentUser.photoURL);
       localStorage.setItem(`photoUploadedAt-${userId}`, currentUser.photoUploadedAt || '');
@@ -106,7 +106,7 @@ export default function VideotpushApp() {
       localStorage.removeItem(`photoUploadedAt-${userId}`);
       if (cachedPhotoURL) setCachedPhotoURL('');
     }
-  }, [userId, currentUser.photoURL, currentUser.photoUploadedAt]);
+  }, [userId, profiles.loaded, currentUser.photoURL, currentUser.photoUploadedAt]);
 
   useEffect(() => {
     if (!userId) return;


### PR DESCRIPTION
## Summary
- wait for profile data to load before updating cached photo

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68943c4a564c832da79b80e4cb9115ac