### PR TITLE
Hide ads for paying users

### DIFF
--- a/src/components/AdBanner.jsx
+++ b/src/components/AdBanner.jsx
@@ -1,4 +1,4 @@
-import React, { useMemo } from 'react';
+import React from 'react';
 import { Card } from './ui/card.js';
 import { Button } from './ui/button.js';
 import { useT } from '../i18n.js';
@@ -6,17 +6,8 @@ import { useT } from '../i18n.js';
 export default function AdBanner({ user }){
   const t = useT();
   const tier = user?.subscriptionTier || 'free';
-  const tiers = ['free','silver','gold','platinum'];
-  const next = useMemo(()=>{
-    const idx = tiers.indexOf(tier);
-    return idx >= 0 ? tiers[idx+1] : null;
-  },[tier]);
-  if(!next) return null;
-  const tierLabel = {
-    silver: t('tierSilver'),
-    gold: t('tierGold'),
-    platinum: t('tierPlatinum')
-  }[next];
+  if(tier !== 'free') return null;
+  const tierLabel = t('tierSilver');
   return React.createElement(Card, {
     className:'fixed inset-x-0 p-4 bg-yellow-100 text-center shadow-lg z-20',
     style:{ bottom:'calc(env(safe-area-inset-bottom, 0px) + 4rem)' }

--- a/src/components/AdBanner.test.jsx
+++ b/src/components/AdBanner.test.jsx
@@ -7,9 +7,7 @@ jest.mock('../i18n.js', () => ({
     const map = {
       adBannerText: 'Upgrade to {tier}',
       adBannerButton: 'Upgrade',
-      tierSilver: 'Silver',
-      tierGold: 'Gold',
-      tierPlatinum: 'Platinum'
+      tierSilver: 'Silver'
     };
     return map[key] || key;
   }
@@ -33,14 +31,14 @@ describe('AdBanner', () => {
     expect(container.textContent).toContain('Upgrade to Silver');
   });
 
-  test('shows upgrade to Gold for silver tier', () => {
+  test('renders nothing for silver tier', () => {
     ReactDOM.render(<AdBanner user={{ subscriptionTier: 'silver' }} />, container);
-    expect(container.textContent).toContain('Upgrade to Gold');
+    expect(container.innerHTML).toBe('');
   });
 
-  test('shows upgrade to Platinum for gold tier', () => {
+  test('renders nothing for gold tier', () => {
     ReactDOM.render(<AdBanner user={{ subscriptionTier: 'gold' }} />, container);
-    expect(container.textContent).toContain('Upgrade to Platinum');
+    expect(container.innerHTML).toBe('');
   });
 
   test('renders nothing for platinum tier', () => {


### PR DESCRIPTION
## Summary
- Stop showing upgrade banner to paying subscribers by returning early when tier is not "free".
- Adjust AdBanner tests to expect no banner for Silver, Gold, and Platinum tiers.

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689446fb60b4832d9188563deb780445