### PR TITLE
Restrict music recording to premium tiers

### DIFF
--- a/src/components/ProfileSettings.jsx
+++ b/src/components/ProfileSettings.jsx
@@ -502,7 +502,7 @@ export default function ProfileSettings({ userId, ageRange, onChangeAgeRange, pu
       onChange: handleVideoChange,
       className: 'hidden'
     }),
-    !publicView && showSnapVideoRecorder && React.createElement(SnapVideoRecorder, { onCancel: () => setShowSnapVideoRecorder(false), onRecorded: handleVideoRecorded, maxDuration: getMaxVideoSeconds(profile)*1000 })
+    !publicView && showSnapVideoRecorder && React.createElement(SnapVideoRecorder, { onCancel: () => setShowSnapVideoRecorder(false), onRecorded: handleVideoRecorded, maxDuration: getMaxVideoSeconds(profile)*1000, user: profile })
   );
 
 


### PR DESCRIPTION
## Summary
- Allow adding music in SnapVideoRecorder only for active Gold/Platinum subscriptions
- Pass current profile to the recorder for tier checks

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689448222f04832dbb0d2ead53354fa3