### PR TITLE
Add read receipt feature for premium tiers

### DIFF
--- a/src/components/ChatScreen.jsx
+++ b/src/components/ChatScreen.jsx
@@ -1,5 +1,5 @@
 import React, { useState, useEffect, useRef } from 'react';
-import { getAge } from '../utils.js';
+import { getAge, hasReadReceipts } from '../utils.js';
 import { User as UserIcon, Smile, MessageCircle as ChatIcon, ArrowLeft } from 'lucide-react';
 import VerificationBadge from './VerificationBadge.jsx';
 import { Card } from './ui/card.js';
@@ -15,6 +15,8 @@ export default function ChatScreen({ userId, onStartCall }) {
   const chats = useCollection('matches', 'userId', userId);
   const t = useT();
   const profileMap = Object.fromEntries(profiles.map(p => [p.id, p]));
+  const currentUser = profileMap[userId] || {};
+  const showReadReceipts = hasReadReceipts(currentUser);
   const [active, setActive] = useState(null);
   const [text, setText] = useState('');
   const [incomingCall, setIncomingCall] = useState(false);
@@ -177,14 +179,14 @@ export default function ChatScreen({ userId, onStartCall }) {
                 React.createElement('div', {
                   className: `inline-block px-3 py-2 rounded-lg ${fromSelf ? 'bg-pink-500 text-white' : 'bg-gray-200 text-black'}`
                 }, m.text),
-                fromSelf && lastSelf && m.ts === lastSelf.ts && active.lastReadByOther && active.lastReadByOther >= m.ts &&
+                showReadReceipts && fromSelf && lastSelf && m.ts === lastSelf.ts && active.lastReadByOther && active.lastReadByOther >= m.ts &&
                   React.createElement('div',{className:'text-xs text-gray-500 text-right'},'Seen')
               )
             );
           })
         ),
         React.createElement('div', { className: 'flex flex-col gap-2 mt-2' },
-          active.typing && React.createElement('p',{className:'text-sm text-gray-500'},`${activeProfile.name || 'Someone'} is typing...`),
+          showReadReceipts && active.typing && React.createElement('p',{className:'text-sm text-gray-500'},`${activeProfile.name || 'Someone'} is typing...`),
           React.createElement('div', { className: 'flex items-center gap-2' },
             React.createElement(Textarea, {
               className: 'flex-1',

--- a/src/utils.js
+++ b/src/utils.js
@@ -112,6 +112,11 @@ export function hasAdvancedFilters(user){
   return tier !== 'free';
 }
 
+export function hasReadReceipts(user){
+  const tier = user?.subscriptionTier || 'free';
+  return ['gold','platinum'].includes(tier);
+}
+
 export function getWeekId(date = getCurrentDate()){
   const d = new Date(Date.UTC(date.getFullYear(), date.getMonth(), date.getDate()));
   const day = d.getUTCDay() || 7;

--- a/src/utils.test.js
+++ b/src/utils.test.js
@@ -14,6 +14,7 @@ import {
   getMaxVideoSeconds,
   hasInterestChat,
   hasAdvancedFilters,
+  hasReadReceipts,
   getWeekId
 } from './utils';
 
@@ -113,6 +114,12 @@ describe('utils', () => {
   test('hasAdvancedFilters requires paid tier', () => {
     expect(hasAdvancedFilters({ subscriptionTier: 'silver' })).toBe(true);
     expect(hasAdvancedFilters({ subscriptionTier: 'free' })).toBe(false);
+  });
+
+  test('hasReadReceipts only for gold and above', () => {
+    expect(hasReadReceipts({ subscriptionTier: 'gold' })).toBe(true);
+    expect(hasReadReceipts({ subscriptionTier: 'platinum' })).toBe(true);
+    expect(hasReadReceipts({ subscriptionTier: 'silver' })).toBe(false);
   });
 
   test('getWeekId returns ISO week id', () => {


### PR DESCRIPTION
## Summary
- add `hasReadReceipts` utility to gate read receipts to Gold and Platinum subscriptions
- show typing indicator and "Seen" receipts only when current user has read receipt access
- cover read receipt logic with unit tests

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6894b3cbfa6c832da56573e58c218b2f