### PR TITLE
Allow switching back to freemium

### DIFF
--- a/src/components/ProfileSettings.jsx
+++ b/src/components/ProfileSettings.jsx
@@ -67,6 +67,17 @@ export default function ProfileSettings({ userId, ageRange, onChangeAgeRange, pu
 
   const handlePurchase = async (tier) => {
     const now = getCurrentDate();
+    if (tier === 'free') {
+      await updateDoc(doc(db, 'profiles', userId), {
+        subscriptionActive: false,
+        subscriptionPurchased: null,
+        subscriptionExpires: null,
+        subscriptionTier: 'free'
+      });
+      setProfile({ ...profile, subscriptionActive: false, subscriptionPurchased: null, subscriptionExpires: null, subscriptionTier: 'free' });
+      setShowSub(false);
+      return;
+    }
     const current = profile.subscriptionExpires ? new Date(profile.subscriptionExpires) : now;
     const base = current > now ? current : now;
     const expiry = new Date(base);
@@ -820,17 +831,18 @@ export default function ProfileSettings({ userId, ageRange, onChangeAgeRange, pu
         className: 'mt-2 w-full bg-blue-500 text-white',
         onClick: () => setShowAnalytics(true)
       }, t('viewAnalytics')),
-    !publicView && !subscriptionActive && React.createElement(Button, {
+    !publicView && React.createElement(Button, {
         className: 'mt-2 w-full bg-yellow-500 text-white',
         onClick: () => setShowSub(true)
-      }, 'Køb abonnement'),
+      }, subscriptionActive ? 'Skift abonnement' : 'Køb abonnement'),
     !publicView && React.createElement(Button, {
         className: 'mt-6 w-full bg-red-500 text-white',
         onClick: () => setShowDelete(true)
       }, t('deleteAccount')),
     showSub && React.createElement(SubscriptionOverlay, {
         onClose: () => setShowSub(false),
-        onBuy: handlePurchase
+        onBuy: handlePurchase,
+        allowFree: subscriptionActive
       }),
     showInterests && React.createElement(InterestsOverlay, {
         current: profile.interests || [],

--- a/src/components/SubscriptionOverlay.jsx
+++ b/src/components/SubscriptionOverlay.jsx
@@ -2,13 +2,14 @@ import React, { useState } from 'react';
 import { Card } from './ui/card.js';
 import { Button } from './ui/button.js';
 
-export default function SubscriptionOverlay({ onClose, onBuy }) {
+export default function SubscriptionOverlay({ onClose, onBuy, allowFree = false }) {
   const plans = [
+    ...(allowFree ? [{ tier: 'free', title: 'Freemium', price: '0 kr/md', daily: 3, seconds: 10, boosts: 0 }] : []),
     { tier: 'silver', title: 'Sølv', price: '39 kr/md', daily: 5, seconds: 10, boosts: 1 },
     { tier: 'gold', title: 'Guld', price: '79 kr/md', daily: 8, seconds: 15, boosts: 2 },
     { tier: 'platinum', title: 'Platin', price: '139 kr/md', daily: 10, seconds: 25, boosts: 4 }
   ];
-  const [selected, setSelected] = useState('silver');
+  const [selected, setSelected] = useState(plans[0].tier);
   return React.createElement('div', { className: 'fixed inset-0 z-50 bg-black/50 flex items-center justify-center' },
     React.createElement(Card, { className: 'bg-white p-6 rounded shadow-xl max-w-sm w-full' },
       React.createElement('h2', { className: 'text-xl font-semibold mb-4 text-yellow-600 text-center' }, 'Vælg abonnement'),


### PR DESCRIPTION
## Summary
- Add Freemium plan to subscription overlay and expose via optional prop
- Enable downgrading to freemium from profile settings and allow subscription changes when active

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6894bf267280832d9772e0ab621514b1