### PR TITLE
Ensure expiry tag overlays buttons in DailyDiscovery

### DIFF
--- a/src/components/DailyDiscovery.jsx
+++ b/src/components/DailyDiscovery.jsx
@@ -294,7 +294,7 @@ export default function DailyDiscovery({ userId, profiles = [], onSelectProfile,
           onClick: () => onSelectProfile(p.id)
         },
           showLevels && React.createElement('span', { className:'absolute top-2 left-2 bg-pink-100 text-pink-600 text-xs font-semibold px-2 rounded' }, `Level ${stage}`),
-          React.createElement('span', { className:`absolute bottom-2 left-2 ${daysLeft <= 0 ? 'bg-red-100 text-red-600' : 'bg-yellow-100 text-yellow-600'} text-xs font-semibold px-2 rounded` },
+          React.createElement('span', { className:`absolute bottom-2 left-2 z-10 ${daysLeft <= 0 ? 'bg-red-100 text-red-600' : 'bg-yellow-100 text-yellow-600'} text-xs font-semibold px-2 rounded` },
             daysLeft <= 0 ? t('lastDay') : t('expiresIn').replace('{days}', daysLeft)
           ),
           React.createElement('div', { className: 'flex items-center gap-4 mb-2' },


### PR DESCRIPTION
## Summary
- Bring expiry tag in daily clips above action buttons by adding z-index

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68984a6b4c7c832d8403af86602f8995