### PR TITLE
Delay task button until profile data loaded

### DIFF
--- a/src/VideotpushApp.jsx
+++ b/src/VideotpushApp.jsx
@@ -487,7 +487,7 @@ export default function VideotpushApp() {
       videoCallId ?
         React.createElement(VideoCallPage, { matchId: videoCallId, userId, onBack: () => setVideoCallId(null) }) :
         React.createElement(React.Fragment, null,
-          React.createElement(TaskButton, { profile: currentUser, onClick: handleTaskClick }),
+          profiles.loaded && React.createElement(TaskButton, { profile: currentUser, onClick: handleTaskClick }),
           tab==='discovery' && !viewProfile && (
             React.createElement(DailyDiscovery, { userId, profiles, onSelectProfile: selectProfile, ageRange, onOpenProfile: openProfileSettings })
           ),


### PR DESCRIPTION
## Summary
- prevent task button from showing before profile data loads

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68985067dedc832dacfed370c4f9e9a7