### PR TITLE
feat: add defaults for test push html

### DIFF
--- a/netlify/functions/test-push.html
+++ b/netlify/functions/test-push.html
@@ -13,8 +13,8 @@ button{margin-top:1em;padding:0.5em 1em;}
 </head>
 <body>
 <h1>Send Test Push</h1>
-<label>Title <input id="title" type="text" placeholder="Optional" /></label>
-<label>Body <input id="body" type="text" placeholder="Notification text" /></label>
+<label>Title <input id="title" type="text" placeholder="Optional" value="Test titel" /></label>
+<label>Body <input id="body" type="text" placeholder="Notification text" value="Test besked" /></label>
 <label><input id="silent" type="checkbox" /> Silent</label>
 <fieldset style="margin-top:1em;">
   <legend>Send to</legend>
@@ -37,8 +37,8 @@ button{margin-top:1em;padding:0.5em 1em;}
   };
 
   document.getElementById('send').addEventListener('click', async () => {
-    const title = document.getElementById('title').value;
-    const body = document.getElementById('body').value;
+    const title = document.getElementById('title').value || 'Test titel';
+    const body = document.getElementById('body').value || 'Test besked';
     const silent = document.getElementById('silent').checked;
     const target = document.querySelector('input[name="target"]:checked').value;
     const statusEl = document.getElementById('status');


### PR DESCRIPTION
## Summary
- prefill test push title and body inputs with default text
- fallback to default texts if fields are empty when sending

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68986f58c668832da59fa90882abff43