### PR TITLE
Show VAPID key lengths in admin popup

### DIFF
--- a/src/components/AdminScreen.jsx
+++ b/src/components/AdminScreen.jsx
@@ -104,7 +104,7 @@ export default function AdminScreen({ onOpenStats, onOpenBugReports, onOpenMatch
         const localHash = await hash(v);
         const serverInfo = server[k] || { length: 0, sha256: '' };
         const match = localLen === serverInfo.length && localHash === serverInfo.sha256;
-        return `${k}: ${match ? '✔' : '✖'} local ${localLen}, server ${serverInfo.length}`;
+        return `${k}: ${match ? '✔' : '✖'} local len ${localLen} hash ${localHash}, server len ${serverInfo.length} hash ${serverInfo.sha256}`;
       }));
       alert(lines.join('\n'));
     } catch (err) {


### PR DESCRIPTION
## Summary
- display local and server hash and length when comparing VAPID keys on admin screen

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68988a064688832da496b41e01d5c862