### PR TITLE
Fix service worker parse error on iOS

### DIFF
--- a/public/service-worker.js
+++ b/public/service-worker.js
@@ -39,7 +39,11 @@ self.addEventListener('activate', event => {
 // Vis notifikationer ved push (iOS Safari m.fl.)
 self.addEventListener('push', (event) => {
   let data = {};
-  try { data = event.data ? event.data.json() : {}; } catch { data = {}; }
+  try {
+    data = event.data ? event.data.json() : {};
+  } catch (err) {
+    data = {};
+  }
   const title = data.title || 'Notifikation';
   const body  = data.body  || '';
   const options = {

--- a/src/consoleLogs.js
+++ b/src/consoleLogs.js
@@ -17,7 +17,7 @@ function add(type, args) {
     if (typeof a === 'object') {
       try {
         return JSON.stringify(a);
-      } catch {
+      } catch (err) {
         return String(a);
       }
     }

--- a/src/ensureWebPush.js
+++ b/src/ensureWebPush.js
@@ -41,7 +41,7 @@ export async function ensureWebPush({
   try {
     const old = await reg.pushManager.getSubscription();
     if (old) await old.unsubscribe();
-  } catch {
+  } catch (err) {
     // ignore
   }
 

--- a/src/firebase-messaging-sw.js
+++ b/src/firebase-messaging-sw.js
@@ -36,7 +36,11 @@ self.addEventListener('push', event => {
   console.log('Push event received');
   let data = {};
   if (event.data) {
-    try { data = event.data.json(); } catch { data = { body: event.data.text() }; }
+    try {
+      data = event.data.json();
+    } catch (err) {
+      data = { body: event.data.text() };
+    }
   }
   console.log('Push payload', data);
   const title = data.title || 'RealDate';

--- a/src/firebase.js
+++ b/src/firebase.js
@@ -297,10 +297,12 @@ export async function deleteAccount(profileId) {
     try {
       const list = await listAll(ref(storage, `profiles/${profileId}`));
       await Promise.all(list.items.map(i => deleteObject(i)));
-    } catch {}
+    } catch (err) {}
 
     if (auth.currentUser) {
-      try { await deleteUser(auth.currentUser); } catch {}
+      try {
+        await deleteUser(auth.currentUser);
+      } catch (err) {}
     }
   } catch (err) {
     console.error('Failed to delete account', err);

--- a/src/notifications.js
+++ b/src/notifications.js
@@ -4,7 +4,7 @@ function read() {
   if (typeof localStorage === 'undefined') return [];
   try {
     return JSON.parse(localStorage.getItem('notifications') || '[]');
-  } catch {
+  } catch (err) {
     return [];
   }
 }


### PR DESCRIPTION
## Summary
- Replace optional catch bindings with explicit error parameters in service worker and helper scripts to avoid syntax errors on older Safari

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68988d707070832d9f023eaa8c65d293