### PR TITLE
fix: support caching opaque media responses

### DIFF
--- a/src/cacheMedia.js
+++ b/src/cacheMedia.js
@@ -9,8 +9,13 @@ export async function cacheMediaIfNewer(url, uploadedAt) {
   if (stored === ts) return;
   try {
     const cache = await caches.open('media-cache-v1');
-    await cache.add(new Request(url, { mode: 'no-cors' }));
-    localStorage.setItem(key, ts);
+    const response = await fetch(new Request(url, { mode: 'no-cors' }));
+    if (response.ok || response.type === 'opaque') {
+      await cache.put(url, response);
+      localStorage.setItem(key, ts);
+    } else {
+      throw new Error(`Response not OK: ${response.status}`);
+    }
   } catch (err) {
     const msg = err && err.message ? err.message : String(err);
     console.error(`Failed to cache media ${url}`, msg);


### PR DESCRIPTION
## Summary
- handle cross-origin media fetches by caching opaque responses

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68989e1e3094832d81b1b644a29af6a5