### PR TITLE
Ensure service workers are deployed with build

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "start": "npx serve .",
     "dev": "parcel public/index.html",
     "prebuild": "node scripts/bump-version.js",
-    "build": "parcel build public/index.html public/invite.html public/testers.html --dist-dir dist --public-url ./",
+    "build": "parcel build public/index.html public/invite.html public/testers.html --dist-dir dist --public-url ./ && cp public/service-worker.js dist/ && cp src/firebase-messaging-sw.js dist/",
     "test": "jest",
     "screenshots": "node scripts/capture-screens.js"
   },

--- a/public/service-worker.js
+++ b/public/service-worker.js
@@ -4,12 +4,11 @@ const CACHE_NAME = 'VideoTinder-cache-v5';
 console.log('ServiceWorker script loaded', CACHE_NAME);
 // Cache for images and video so large media files work offline
 const MEDIA_CACHE = 'media-cache-v1';
-const URLS_TO_CACHE = [
-  '/',
-  '/public/index.html',
-];
-
 const rel = (p) => new URL(p, self.registration.scope).href;
+const URLS_TO_CACHE = [
+  rel(''),
+  rel('index.html'),
+];
 
 self.addEventListener('install', event => {
   console.log('ServiceWorker installing', CACHE_NAME);


### PR DESCRIPTION
## Summary
- Copy `service-worker.js` and `firebase-messaging-sw.js` into `dist` during build so the PWA can register its service workers on GitHub Pages.
- Use scope-relative URLs in the service worker preload list for reliable caching across subdirectory deployments.

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68989f93c2a0832d8c8a043508dbc3a9