### PR TITLE
Fix expiration badge overlap on daily clips

### DIFF
--- a/src/components/DailyDiscovery.jsx
+++ b/src/components/DailyDiscovery.jsx
@@ -294,7 +294,7 @@ export default function DailyDiscovery({ userId, profiles = [], onSelectProfile,
           onClick: () => onSelectProfile(p.id)
         },
           showLevels && React.createElement('span', { className:'absolute top-2 left-2 bg-pink-100 text-pink-600 text-xs font-semibold px-2 rounded' }, `Level ${stage}`),
-          React.createElement('span', { className:`absolute bottom-2 left-2 z-10 ${daysLeft <= 0 ? 'bg-red-100 text-red-600' : 'bg-yellow-100 text-yellow-600'} text-xs font-semibold px-2 rounded` },
+          React.createElement('span', { className:`absolute top-2 right-2 z-10 ${daysLeft <= 0 ? 'bg-red-100 text-red-600' : 'bg-yellow-100 text-yellow-600'} text-xs font-semibold px-2 rounded` },
             daysLeft <= 0 ? t('lastDay') : t('expiresIn').replace('{days}', daysLeft)
           ),
           React.createElement('div', { className: 'flex items-center gap-4 mb-2' },


### PR DESCRIPTION
## Summary
- Position expiration badge at top-right of daily clip cards to avoid overlapping action buttons

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6898ab612afc832d959f13398bc69479