### PR TITLE
Translate 'Need help?' to Danish

### DIFF
--- a/src/components/ProfileEpisode.jsx
+++ b/src/components/ProfileEpisode.jsx
@@ -188,7 +188,7 @@ export default function ProfileEpisode({ userId, profileId, onBack }) {
       stage === 1 && React.createElement('p', {
         className: 'text-xs text-blue-500 underline cursor-pointer',
         onClick: () => setShowHelp(true)
-      }, 'Need help?')
+      }, t('dailyHelpLabel'))
     ),
     // The old level 2 intro box has been removed
     React.createElement(SectionTitle, { title: `${profile.name || ''}, ${profile.birthday ? getAge(profile.birthday) : profile.age || ''}${profile.city ? ', ' + profile.city : ''}` }),
@@ -260,10 +260,10 @@ export default function ProfileEpisode({ userId, profileId, onBack }) {
       React.createElement(Button, { className: 'bg-pink-500 text-white', onClick: saveReaction }, 'Gem')
     )
   ),
-  showHelp && React.createElement(InfoOverlay, {
-    title: 'Need help?',
-    onClose: () => setShowHelp(false)
-  },
+    showHelp && React.createElement(InfoOverlay, {
+      title: t('dailyHelpTitle'),
+      onClose: () => setShowHelp(false)
+    },
     React.createElement('p', { className:'text-sm text-center' },
       t('level2Intro')
         .replace('{name}', profile.name || '')

--- a/src/i18n.js
+++ b/src/i18n.js
@@ -139,7 +139,7 @@ inviteAccepted:{ en:"Profile created", da:"Oprettet", sv:"Skapad", es:"Perfil cr
   helpLevels:{ en:'On the Daily Life page each profile has three levels. Watch clips to unlock more content.', da:'På siden Dagens liv har hver profil tre niveauer. Se klip for at låse mere op.' },
   helpSupport:{ en:'Need assistance? Choose "Report bug" on the About page to contact support.', da:'Brug for hjælp? Vælg \"Fejlmeld\" på Om RealDate-siden for at kontakte support.' },
   helpInvites:{ en:'You can send up to ten invitations. Follow each invitation until your friend has created a profile.', da:'Du kan sende op til ti invitationer. Følg hver invitation, indtil din ven har oprettet en profil.' },
-  dailyHelpLabel:{ en:'Need help?', da:'Need help?' },
+  dailyHelpLabel:{ en:'Need help?', da:'Brug for hjælp?' },
   dailyHelpTitle:{ en:'Daily Clips Help', da:'Hjælp til Dagens klip' },
   dailyHelpText:{
     en:'Feel the energy and consider carefully before matching. We use video clips to show the person\'s energy and personality. Take your time with the profiles. We support reflection time and want to avoid endless swiping. Therefore you get one video at a time and can look forward to more clips of the same person being released in the next days. To make the videos unique we ask for different content: introduction, biggest interest and free choice.',


### PR DESCRIPTION
## Summary
- Localize "Need help?" link in ProfileEpisode using translation keys
- Provide Danish translation "Brug for hjælp?" for help label
- Show translated help overlay title

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6898ab728530832db1d74a05fb3f765f