### PR TITLE
Fix Danish upgrade CTA text

### DIFF
--- a/src/components/LikesScreen.jsx
+++ b/src/components/LikesScreen.jsx
@@ -126,7 +126,7 @@ export default function LikesScreen({ userId, onSelectProfile, onBack }) {
       )
     ),
     !canSeeLikes && React.createElement('span',{className:'absolute inset-0 m-auto text-yellow-500 text-sm font-semibold pointer-events-none flex items-center justify-center text-center px-2'},'Kr\u00e6ver Guld eller Platin'),
-    !canSeeLikes && React.createElement(Button,{className:'mt-4 w-full bg-yellow-500 text-white',onClick:()=>setShowPurchase(true)},'Køb Guld/Platin'),
+    !canSeeLikes && React.createElement(Button,{className:'mt-4 w-full bg-yellow-500 text-white',onClick:()=>setShowPurchase(true)},'Køb Guld eller Platin'),
     showPurchase && React.createElement(SubscriptionOverlay,{onClose:()=>setShowPurchase(false), onBuy:handlePurchase}),
     matchedProfile && React.createElement(MatchOverlay,{name:matchedProfile.name,onClose:()=>setMatchedProfile(null)}),
     activeVideo && React.createElement(VideoOverlay,{src:activeVideo,onClose:()=>setActiveVideo(null)})


### PR DESCRIPTION
## Summary
- clarify Likes upgrade call-to-action by replacing "Køb Guld/Platin" with "Køb Guld eller Platin"

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6898abf90030832d9f96b95094457e93