### PR TITLE
Mark purchase options as not implemented

### DIFF
--- a/docs/marketing/app-pages-da.md
+++ b/docs/marketing/app-pages-da.md
@@ -38,7 +38,7 @@
   - Vælg "Remove" for at fjerne profilen helt, medmindre rating 3 eller 4 er givet
     (så vises den under ratede eller likede profiler).
   - Silver kan fortryde den seneste "Remove"; Gold og Platinum kan fortryde flere.
-  - Brugeren kan én gang dagligt købe ekstra profiler.
+  - Brugeren kan én gang dagligt købe ekstra profiler (ikke implementeret).
 
 ### Offentlig kandidatprofil
 - Brugerens clip er altid tilgængeligt, men videoen afsløres gradvist:

--- a/src/components/InterestChatScreen.jsx
+++ b/src/components/InterestChatScreen.jsx
@@ -89,7 +89,7 @@ export default function InterestChatScreen({ userId, onSelectProfile = null }) {
     return React.createElement(Card, { className:'p-6 m-4 shadow-xl bg-white/90 flex flex-col items-center text-center' },
       React.createElement(SectionTitle, { title: t('interestChatsTitle') }),
       React.createElement('p', { className:'text-gray-600 mb-4' }, 'Kræver Sølv, Guld eller Platin'),
-      React.createElement(Button, { className:'bg-pink-500 text-white', onClick:()=>window.dispatchEvent(new CustomEvent('showSubscription')) }, 'Køb abonnement')
+      React.createElement(Button, { className:'bg-pink-500 text-white', onClick:()=>window.dispatchEvent(new CustomEvent('showSubscription')) }, 'Køb abonnement (ikke implementeret)')
     );
   }
   if(showRealetten && interest){

--- a/src/components/LikesScreen.jsx
+++ b/src/components/LikesScreen.jsx
@@ -126,7 +126,7 @@ export default function LikesScreen({ userId, onSelectProfile, onBack }) {
       )
     ),
     !canSeeLikes && React.createElement('span',{className:'absolute inset-0 m-auto text-yellow-500 text-sm font-semibold pointer-events-none flex items-center justify-center text-center px-2'},'Kr\u00e6ver Guld eller Platin'),
-    !canSeeLikes && React.createElement(Button,{className:'mt-4 w-full bg-yellow-500 text-white',onClick:()=>setShowPurchase(true)},'Køb Guld/Platin'),
+    !canSeeLikes && React.createElement(Button,{className:'mt-4 w-full bg-yellow-500 text-white',onClick:()=>setShowPurchase(true)},'Køb Guld/Platin (ikke implementeret)'),
     showPurchase && React.createElement(SubscriptionOverlay,{onClose:()=>setShowPurchase(false), onBuy:handlePurchase}),
     matchedProfile && React.createElement(MatchOverlay,{name:matchedProfile.name,onClose:()=>setMatchedProfile(null)}),
     activeVideo && React.createElement(VideoOverlay,{src:activeVideo,onClose:()=>setActiveVideo(null)})

--- a/src/components/MoreProfilesOverlay.jsx
+++ b/src/components/MoreProfilesOverlay.jsx
@@ -14,7 +14,7 @@ export default function MoreProfilesOverlay({ hasFree, canBuy, onClaimFree, onBu
         )}
         {canBuy && (
           <Button className="w-full bg-yellow-500 text-white mb-2" onClick={onBuy}>
-            Køb 3 ekstra for 9 kr
+            Køb 3 ekstra for 9 kr (ikke implementeret)
           </Button>
         )}
         <Button className="w-full bg-gray-200 text-black" onClick={onClose}>

--- a/src/components/ProfileSettings.jsx
+++ b/src/components/ProfileSettings.jsx
@@ -842,7 +842,7 @@ export default function ProfileSettings({ userId, ageRange, onChangeAgeRange, pu
     !publicView && React.createElement(Button, {
         className: 'mt-2 w-full bg-yellow-500 text-white',
         onClick: () => setShowSub(true)
-      }, subscriptionActive ? 'Skift abonnement' : 'Køb abonnement'),
+      }, subscriptionActive ? 'Skift abonnement' : 'Køb abonnement (ikke implementeret)'),
     !publicView && React.createElement(Button, {
         className: 'mt-6 w-full bg-red-500 text-white',
         onClick: () => setShowDelete(true)

--- a/src/components/PurchaseOverlay.jsx
+++ b/src/components/PurchaseOverlay.jsx
@@ -8,7 +8,7 @@ export default function PurchaseOverlay({ title, price, children, onClose, onBuy
       React.createElement('h2', { className: 'text-xl font-semibold mb-4 text-yellow-600 text-center' }, title),
       children,
       price && React.createElement('p', { className: 'text-center font-bold my-4' }, price),
-      React.createElement(Button, { className: 'w-full bg-yellow-500 text-white mb-2', onClick: onBuy }, 'Køb'),
+      React.createElement(Button, { className: 'w-full bg-yellow-500 text-white mb-2', onClick: onBuy }, 'Køb (ikke implementeret)'),
       React.createElement(Button, { className: 'w-full bg-gray-200 text-black', onClick: onClose }, 'Luk')
     )
   );

--- a/src/components/SubscriptionOverlay.jsx
+++ b/src/components/SubscriptionOverlay.jsx
@@ -27,7 +27,7 @@ export default function SubscriptionOverlay({ onClose, onBuy, allowFree = false 
           )
         ))
       ),
-      React.createElement(Button, { className: 'w-full bg-yellow-500 text-white mb-2', onClick: () => onBuy(selected) }, 'Køb'),
+      React.createElement(Button, { className: 'w-full bg-yellow-500 text-white mb-2', onClick: () => onBuy(selected) }, 'Køb (ikke implementeret)'),
       React.createElement(Button, { className: 'w-full bg-gray-200 text-black', onClick: onClose }, 'Luk')
     )
   );


### PR DESCRIPTION
## Summary
- Append "(ikke implementeret)" to all buttons and messages offering purchases or upgrades
- Document that daily extra profile purchases are not implemented

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6898ac5096cc832db5c6c4aa59b78a16