### PR TITLE
Default app language changed to Danish

### DIFF
--- a/netlify/functions/index.html
+++ b/netlify/functions/index.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="en">
+<html lang="da">
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">

--- a/netlify/functions/pricing.html
+++ b/netlify/functions/pricing.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="en">
+<html lang="da">
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">

--- a/netlify/functions/test-push.html
+++ b/netlify/functions/test-push.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="en">
+<html lang="da">
 <head>
 <meta charset="UTF-8">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">

--- a/public/index.html
+++ b/public/index.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="en">
+<html lang="da">
 <head>
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover" />

--- a/public/testers.html
+++ b/public/testers.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="en">
+<html lang="da">
 <head>
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover" />

--- a/src/VideotpushApp.jsx
+++ b/src/VideotpushApp.jsx
@@ -43,7 +43,7 @@ import NotificationsScreen from './components/NotificationsScreen.jsx';
 
 export default function VideotpushApp() {
   const [lang, setLang] = useState(() =>
-    localStorage.getItem('lang') || 'en'
+    localStorage.getItem('lang') || 'da'
   );
   const [loggedIn, setLoggedIn] = useState(() => {
     const stored = localStorage.getItem('loggedIn');

--- a/src/i18n.js
+++ b/src/i18n.js
@@ -275,7 +275,7 @@ export const adminKeys = [
   'textPiecesTitle',
   'trackUserTitle',
 ];
-const LangContext = createContext({ lang: 'en', setLang: () => {} });
+const LangContext = createContext({ lang: 'da', setLang: () => {} });
 
 export const LanguageProvider = LangContext.Provider;
 


### PR DESCRIPTION
## Summary
- default language changed from English to Danish in app context
- HTML pages now declare Danish as document language

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6898acf4c5a0832da900ad6cfc13f6b9