### PR TITLE
Disable source map generation to avoid missing .map file errors

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "start": "npx serve .",
     "dev": "parcel public/index.html",
     "prebuild": "node scripts/bump-version.js",
-    "build": "parcel build public/index.html public/invite.html public/testers.html --dist-dir dist --public-url ./ && cp public/service-worker.js dist/ && cp src/firebase-messaging-sw.js dist/",
+    "build": "parcel build public/index.html public/invite.html public/testers.html --dist-dir dist --no-source-maps --public-url ./ && cp public/service-worker.js dist/ && cp src/firebase-messaging-sw.js dist/",
     "test": "jest",
     "screenshots": "node scripts/capture-screens.js"
   },


### PR DESCRIPTION
## Summary
- disable source map generation in Parcel build to avoid 404 errors for `.js.map` files

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6898b0c59ef8832dad27b8eeaddf4098