### PR TITLE
Adjust SectionTitle line height

### DIFF
--- a/src/components/SectionTitle.jsx
+++ b/src/components/SectionTitle.jsx
@@ -3,7 +3,7 @@ import PremiumIcon from './PremiumIcon.jsx';
 
 export default function SectionTitle({ title, action, colorClass = 'text-pink-600', premium = false }) {
   return React.createElement('div', { className: 'flex items-center justify-between mb-2' },
-    React.createElement('h2', { className: `text-2xl font-semibold flex items-center gap-2 ${colorClass}` },
+    React.createElement('h2', { className: `text-2xl font-semibold flex items-center gap-2 leading-tight ${colorClass}` },
       premium && React.createElement(PremiumIcon, null),
       title
     ),


### PR DESCRIPTION
## Summary
- Improve vertical alignment for title text by adding `leading-tight` to SectionTitle component

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6898b70dba28832da640580fc58ea089