### PR TITLE
Improve webpush logging for iOS diagnostics

### DIFF
--- a/netlify/functions/send-webpush.js
+++ b/netlify/functions/send-webpush.js
@@ -77,6 +77,13 @@ exports.handler = async (event) => {
 
   // Hent subs
   const subscriptions = await loadSubscriptions(userId);
+  console.log(`send-webpush: ${subscriptions.length} subscription(s)`, {
+    title,
+    url,
+    tag,
+    silent,
+    userId,
+  });
   if (!subscriptions.length) {
     return okJson({ success: true, count: 0, errors: 0, results: [] });
   }
@@ -92,11 +99,13 @@ exports.handler = async (event) => {
         TTL: 4500,
         urgency: 'normal',
       });
+      console.log('send-webpush OK', sub.endpoint);
       results.push({ endpoint: sub.endpoint, ok: true });
     } catch (err) {
       errors++;
       const status = err.statusCode || err.status || 0;
       const msg = String(err.body || err.message || err);
+      console.warn('send-webpush FAIL', sub.endpoint, status, msg);
       results.push({ endpoint: sub.endpoint, ok: false, status, msg });
 
       // Ryd op ved 404/410 (stale endpoint)
@@ -114,6 +123,10 @@ exports.handler = async (event) => {
       }
     }
   }
+
+  console.log(
+    `send-webpush complete: ${subscriptions.length - errors} ok, ${errors} error(s)`
+  );
 
   return okJson({
     success: true,

--- a/netlify/functions/test-push.html
+++ b/netlify/functions/test-push.html
@@ -49,9 +49,12 @@ button{margin-top:1em;padding:0.5em 1em;}
       const parts = [];
       if (target === 'ios' || target === 'both') {
         const data = await post('/.netlify/functions/send-webpush', { title, body, silent });
-        parts.push('iOS: ' + (data.count ?? '?') + ' subscriptions');
-        if (Array.isArray(data.subscriptions)) {
-          subsEl.textContent = JSON.stringify(data.subscriptions, null, 2);
+        parts.push('iOS: ' + (data.count ?? '?') + ' subscriptions, ' + (data.errors ?? 0) + ' errors');
+        if (Array.isArray(data.results)) {
+          subsEl.textContent = JSON.stringify(data.results, null, 2);
+        }
+        if (data.note) {
+          subsEl.textContent += (subsEl.textContent ? '\n' : '') + data.note;
         }
       }
       if (target === 'other' || target === 'both') {


### PR DESCRIPTION
## Summary
- add detailed logging to Netlify send-webpush function
- surface per-endpoint results and error counts on test push page

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6898b1e0f3d4832dbe2e79698b4c96f4