### PR TITLE
Ensure Safari compatibility via browserslist

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,5 +34,12 @@
     "jest-environment-jsdom": "^30.0.5",
     "parcel": "^2.9.3",
     "puppeteer": "^24.14.0"
-  }
+  },
+  "browserslist": [
+    ">0.5%",
+    "last 2 versions",
+    "not dead",
+    "safari >= 12",
+    "ios_saf >= 12"
+  ]
 }


### PR DESCRIPTION
## Summary
- Target Safari 12 and iOS Safari 12 in browserslist so Parcel transpiles features like optional chaining

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6898c2cba9a8832dbb291b906b76f188