### PR TITLE
Wait for service worker before push

### DIFF
--- a/src/components/WelcomeScreen.jsx
+++ b/src/components/WelcomeScreen.jsx
@@ -39,7 +39,12 @@ export default function WelcomeScreen({ onLogin }) {
 
 
   const requestPushPermissions = async (pid, method = 'password') => {
-    if (typeof Notification === 'undefined') return;
+    if (typeof Notification === 'undefined' || !('serviceWorker' in navigator)) return;
+    await navigator.serviceWorker.ready;
+    if (!navigator.serviceWorker.controller) {
+      console.log('Service worker er endnu ikke aktiv; prøv at genindlæse siden.');
+      return;
+    }
     const perm = await Notification.requestPermission();
     if (perm !== 'granted') return;
     await requestNotificationPermission(pid, method);

--- a/src/index.js
+++ b/src/index.js
@@ -19,8 +19,8 @@ if ('serviceWorker' in navigator) {
       .register(swUrl, { scope: base })
       .then(reg => {
         console.log('SW scope:', reg.scope);
-        setFcmReg(reg);
       })
       .catch(err => console.error('SW register failed:', err));
+    navigator.serviceWorker.ready.then(setFcmReg);
   });
 }


### PR DESCRIPTION
## Summary
- ensure service worker registration resolves to ready before storing FCM registration
- defer push permission request until service worker is active

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6898e335be1c832dbe8f14a8e677ff86