### PR TITLE
chore: log VAPID keys for debugging

### DIFF
--- a/netlify/functions/get-vapid-public-key.js
+++ b/netlify/functions/get-vapid-public-key.js
@@ -1,6 +1,8 @@
 // netlify/functions/get-vapid-public-key.js
 exports.handler = async () => {
   const publicKey = process.env.WEB_PUSH_PUBLIC_KEY || '';
+  // Temporary debug output of VAPID key - remove before production.
+  console.log('DEBUG: WEB_PUSH_PUBLIC_KEY', publicKey); // TODO: Remove before production
   if (!publicKey) {
     return { statusCode: 500, body: JSON.stringify({ error: 'WEB_PUSH_PUBLIC_KEY not set' }) };
   }

--- a/src/components/AdminScreen.jsx
+++ b/src/components/AdminScreen.jsx
@@ -25,6 +25,10 @@ export default function AdminScreen({ onOpenStats, onOpenBugReports, onOpenMatch
   const config = useDoc('config', 'app') || {};
   const invitesEnabled = config.premiumInvitesEnabled !== false;
   const showLevels = config.showLevels !== false;
+  // Temporary debug output of VAPID keys - remove before production.
+  console.log('DEBUG: FCM_VAPID_KEY', process.env.FCM_VAPID_KEY); // TODO: Remove before production
+  console.log('DEBUG: WEB_PUSH_PUBLIC_KEY', process.env.WEB_PUSH_PUBLIC_KEY); // TODO: Remove before production
+  console.log('DEBUG: WEB_PUSH_PRIVATE_KEY', process.env.WEB_PUSH_PRIVATE_KEY); // TODO: Remove before production
 
   const toggleLog = () => {
     const val = !logEnabled;
@@ -67,6 +71,8 @@ export default function AdminScreen({ onOpenStats, onOpenBugReports, onOpenMatch
 
   const logClientToken = async () => {
     try {
+      // Temporary debug output of VAPID key - remove before production.
+      console.log('DEBUG: FCM_VAPID_KEY (logClientToken)', process.env.FCM_VAPID_KEY); // TODO: Remove before production
       const token = await getToken(messaging, {
         vapidKey: process.env.FCM_VAPID_KEY,
         serviceWorkerRegistration: fcmReg
@@ -84,6 +90,9 @@ export default function AdminScreen({ onOpenStats, onOpenBugReports, onOpenMatch
   const showVapidKeys = () => {
     const pub = process.env.WEB_PUSH_PUBLIC_KEY || '';
     const priv = process.env.WEB_PUSH_PRIVATE_KEY || '';
+    // Temporary debug output of VAPID keys - remove before production.
+    console.log('DEBUG: WEB_PUSH_PUBLIC_KEY (showVapidKeys)', pub); // TODO: Remove before production
+    console.log('DEBUG: WEB_PUSH_PRIVATE_KEY (showVapidKeys)', priv); // TODO: Remove before production
     alert('Public: ' + pub + '\nPrivate: ' + priv);
   };
 
@@ -92,6 +101,9 @@ export default function AdminScreen({ onOpenStats, onOpenBugReports, onOpenMatch
     const toHex = buf => Array.from(new Uint8Array(buf)).map(b => b.toString(16).padStart(2, '0')).join('');
     const hash = async str => toHex(await crypto.subtle.digest('SHA-256', new TextEncoder().encode(str)));
     try {
+      // Temporary debug output of VAPID keys - remove before production.
+      console.log('DEBUG: WEB_PUSH_PUBLIC_KEY (compareVapidKeys)', process.env.WEB_PUSH_PUBLIC_KEY); // TODO: Remove before production
+      console.log('DEBUG: WEB_PUSH_PRIVATE_KEY (compareVapidKeys)', process.env.WEB_PUSH_PRIVATE_KEY); // TODO: Remove before production
       const resp = await fetch(`${base}/.netlify/functions/vapid-info`);
       if (!resp.ok) throw new Error('status ' + resp.status);
       const server = await resp.json();
@@ -113,6 +125,9 @@ export default function AdminScreen({ onOpenStats, onOpenBugReports, onOpenMatch
   };
 
   const showPushInfo = async () => {
+    // Temporary debug output of VAPID keys - remove before production.
+    console.log('DEBUG: WEB_PUSH_PUBLIC_KEY (showPushInfo)', process.env.WEB_PUSH_PUBLIC_KEY); // TODO: Remove before production
+    console.log('DEBUG: WEB_PUSH_PRIVATE_KEY (showPushInfo)', process.env.WEB_PUSH_PRIVATE_KEY); // TODO: Remove before production
     const values = {
       FIREBASE_API_KEY: process.env.FIREBASE_API_KEY,
       FIREBASE_AUTH_DOMAIN: process.env.FIREBASE_AUTH_DOMAIN,
@@ -448,6 +463,10 @@ export default function AdminScreen({ onOpenStats, onOpenBugReports, onOpenMatch
     React.createElement('div', { className: 'mt-2 flex flex-wrap gap-2' },
       React.createElement(Button, { className: 'bg-blue-500 text-white px-4 py-2 rounded', onClick: onOpenCallLog }, 'Se aktive opkald'),
       React.createElement(Button, { className: 'bg-blue-500 text-white px-4 py-2 rounded', onClick: onOpenGroupCallLog }, 'Se gruppeopkald')
+    ),
+    // Temporary debug output of VAPID keys - remove before production.
+    React.createElement('pre', { className: 'mt-4 p-2 bg-gray-100 text-xs break-words' },
+      `FCM_VAPID_KEY: ${process.env.FCM_VAPID_KEY}\nWEB_PUSH_PUBLIC_KEY: ${process.env.WEB_PUSH_PUBLIC_KEY}\nWEB_PUSH_PRIVATE_KEY: ${process.env.WEB_PUSH_PRIVATE_KEY}`
     )
   ),
     showBugReport && React.createElement(BugReportOverlay, { onClose: () => setShowBugReport(false) }),

--- a/src/components/TrackUserScreen.jsx
+++ b/src/components/TrackUserScreen.jsx
@@ -14,6 +14,9 @@ export default function TrackUserScreen({ profiles = [], onBack }) {
   const hasReceivedNotification = logs.some(l => l.event === 'push received');
   const t = useT();
 
+  // Temporary debug output of VAPID key - remove before production.
+  console.log('DEBUG: FCM_VAPID_KEY (TrackUserScreen)', process.env.FCM_VAPID_KEY); // TODO: Remove before production
+
   const [checkResult, setCheckResult] = useState({});
 
   useEffect(() => {
@@ -35,6 +38,8 @@ export default function TrackUserScreen({ profiles = [], onBack }) {
       } catch {}
       if (messaging && permission === 'granted') {
         try {
+          // Temporary debug output of VAPID key - remove before production.
+          console.log('DEBUG: FCM_VAPID_KEY (runChecks)', process.env.FCM_VAPID_KEY); // TODO: Remove before production
           const tok = await getToken(messaging, { vapidKey: process.env.FCM_VAPID_KEY, serviceWorkerRegistration: fcmReg });
           fcmToken = !!tok;
         } catch {}
@@ -114,6 +119,8 @@ export default function TrackUserScreen({ profiles = [], onBack }) {
           )
         )
       ) :
-      React.createElement('p', { className: 'text-center mt-4 text-gray-500' }, 'Ingen logs')
+      React.createElement('p', { className: 'text-center mt-4 text-gray-500' }, 'Ingen logs'),
+    // Temporary debug output of VAPID key - remove before production.
+    React.createElement('pre', { className: 'mt-4 p-2 bg-gray-100 text-xs break-words' }, `FCM_VAPID_KEY: ${process.env.FCM_VAPID_KEY}`)
   );
 }

--- a/src/ensureWebPush.js
+++ b/src/ensureWebPush.js
@@ -32,6 +32,8 @@ export async function ensureWebPush({
   // 1) Hent serverens public key (kilden til sandhed)
   const res = await fetch('/.netlify/functions/get-vapid-public-key', { cache: 'no-store' });
   const { publicKey } = await res.json();
+  // Temporary debug output of VAPID key - remove before production.
+  console.log('DEBUG: WEB_PUSH_PUBLIC_KEY (ensureWebPush)', publicKey); // TODO: Remove before production
   if (!publicKey) throw new Error('Missing publicKey from server');
 
   // 2) Sørg for service worker er klar

--- a/src/firebase.js
+++ b/src/firebase.js
@@ -95,7 +95,10 @@ export async function subscribeToWebPush(userId, loginMethod = 'password') {
     const reg = await navigator.serviceWorker.ready;
     let sub = await reg.pushManager.getSubscription();
     if (!sub) {
-      const appKey = urlB64ToUint8Array(process.env.WEB_PUSH_PUBLIC_KEY);
+      const rawKey = process.env.WEB_PUSH_PUBLIC_KEY;
+      // Temporary debug output of VAPID key - remove before production.
+      console.log('DEBUG: WEB_PUSH_PUBLIC_KEY', rawKey); // TODO: Remove before production
+      const appKey = urlB64ToUint8Array(rawKey);
       sub = await reg.pushManager.subscribe({
         userVisibleOnly: true,
         applicationServerKey: appKey
@@ -169,6 +172,8 @@ export async function requestNotificationPermission(userId, loginMethod = 'passw
   try {
     logEvent('requestNotificationPermission start', { userId });
     const reg = fcmReg || await fcmRegReady;
+    // Temporary debug output of VAPID key - remove before production.
+    console.log('DEBUG: FCM_VAPID_KEY', process.env.FCM_VAPID_KEY); // TODO: Remove before production
     const token = await getToken(messaging, {
       vapidKey: process.env.FCM_VAPID_KEY,
       serviceWorkerRegistration: reg


### PR DESCRIPTION
## Summary
- temporarily log VAPID keys wherever they are used for easier troubleshooting
- show current VAPID values on admin and user tracking screens

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6898eeca5f48832d85176a8e45de5583