### PR TITLE
Ensure SnapVideoRecorder shows preview and waits for countdown

### DIFF
--- a/src/components/SnapVideoRecorder.jsx
+++ b/src/components/SnapVideoRecorder.jsx
@@ -38,19 +38,25 @@ export default function SnapVideoRecorder({ onCancel, onRecorded, maxDuration = 
     };
   }, []);
 
+  useEffect(() => {
+    if(videoRef.current && streamRef.current){
+      videoRef.current.srcObject = streamRef.current;
+      videoRef.current.play();
+    }
+  }, [stage]);
+
   const startCountdown = () => {
     setStage('countdown');
-    setCount(3);
+    let current = 3;
+    setCount(current);
     countdownRef.current = setInterval(() => {
-      setCount(prev => {
-        if(prev <= 1){
-          clearInterval(countdownRef.current);
-          setStage('recording');
-          start();
-          return 0;
-        }
-        return prev - 1;
-      });
+      current -= 1;
+      setCount(current);
+      if(current <= 0){
+        clearInterval(countdownRef.current);
+        setStage('recording');
+        start();
+      }
     }, 1000);
   };
 


### PR DESCRIPTION
## Summary
- Keep video stream visible when transitioning between countdown and recording
- Start recording only after the 3-2-1 countdown completes

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6898f7aa2528832dbe1177f8a0fd499e