### PR TITLE
Request push permission before service worker is active

### DIFF
--- a/src/components/WelcomeScreen.jsx
+++ b/src/components/WelcomeScreen.jsx
@@ -40,13 +40,18 @@ export default function WelcomeScreen({ onLogin }) {
 
   const requestPushPermissions = async (pid, method = 'password') => {
     if (typeof Notification === 'undefined' || !('serviceWorker' in navigator)) return;
-    await navigator.serviceWorker.ready;
-    if (!navigator.serviceWorker.controller) {
-      console.log('Service worker er endnu ikke aktiv; prøv at genindlæse siden.');
-      return;
-    }
+
+    // Request permission immediately to avoid being blocked by other overlays
     const perm = await Notification.requestPermission();
     if (perm !== 'granted') return;
+
+    try {
+      await navigator.serviceWorker.ready;
+    } catch (err) {
+      console.error('Service worker not ready', err);
+      return;
+    }
+
     await requestNotificationPermission(pid, method);
     await subscribeToWebPush(pid, method);
   };


### PR DESCRIPTION
## Summary
- Request push notification permission immediately during login
- Handle service worker readiness separately to avoid missing the prompt

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6898f5bb2040832d8602d473504c6bb6