### PR TITLE
Rename video cancel button to stop and save recording

### DIFF
--- a/src/components/SnapVideoRecorder.jsx
+++ b/src/components/SnapVideoRecorder.jsx
@@ -148,7 +148,14 @@ export default function SnapVideoRecorder({ onCancel, onRecorded, maxDuration = 
           React.createElement(CameraIcon, { className:'w-10 h-10' })
         ),
         React.createElement('div', { className:'absolute inset-0 flex items-center justify-center text-white text-4xl font-bold pointer-events-none' }, remainingSeconds),
-        React.createElement('button', { onClick: cancel, className:'absolute -bottom-12 left-1/2 -translate-x-1/2 text-white bg-black/40 px-4 py-1 rounded' }, t('cancel'))
+        React.createElement(
+          'button',
+          {
+            onClick: recording ? stop : cancel,
+            className: 'absolute -bottom-12 left-1/2 -translate-x-1/2 text-white bg-black/40 px-4 py-1 rounded'
+          },
+          t(recording ? 'stop' : 'cancel')
+        )
       )
     ),
     React.createElement('div', { className:'flex-1 flex items-center justify-center w-full' },

--- a/src/i18n.js
+++ b/src/i18n.js
@@ -51,6 +51,7 @@ export const messages = {
   aboutMe:{ en:'About me', da:'Om mig', sv:'Om mig', es:'Sobre mí', fr:'À propos de moi', de:'Über mich' },
   register:{ en:'Create profile', da:'Opret profil', sv:'Skapa profil', es:'Crear perfil', fr:'Créer un profil', de:'Profil erstellen' },
   cancel:{ en:'Cancel', da:'Annuller', sv:'Avbryt', es:'Cancelar', fr:'Annuler', de:'Abbrechen' },
+  stop:{ en:'Stop', da:'Stop', sv:'Stoppa', es:'Detener', fr:'Arrêter', de:'Stopp' },
   skip:{ en:'Skip', da:'Skip', sv:'Skip', es:'Skip', fr:'Skip', de:'Skip' },
   deleteAccount:{ en:'Delete account', da:'Slet konto' },
   viewAnalytics:{ en:'View analytics', da:'Se statistik' },


### PR DESCRIPTION
## Summary
- Add dedicated `stop` label to translations
- Change SnapVideoRecorder to show a Stop button that saves the clip instead of canceling

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68997554b434832da488f0f993c1317a