### PR TITLE
feat: hide profile analytics option

### DIFF
--- a/src/components/ProfileSettings.jsx
+++ b/src/components/ProfileSettings.jsx
@@ -21,7 +21,6 @@ import { getAge, getCurrentDate, getMaxVideoSeconds, getMonthlyBoostLimit, hasAd
 import PremiumIcon from './PremiumIcon.jsx';
 import { triggerHaptic } from '../haptics.js';
 import { sendPushNotification } from '../notifications.js';
-import ProfileAnalytics from './ProfileAnalytics.jsx';
 import VerificationBadge from './VerificationBadge.jsx';
 
 export default function ProfileSettings({ userId, ageRange, onChangeAgeRange, publicView = false, onViewPublicProfile = () => {}, onOpenAbout = () => {}, onLogout = null, viewerId = userId, onBack, activeTask, taskTrigger = 0 }) {
@@ -39,7 +38,6 @@ export default function ProfileSettings({ userId, ageRange, onChangeAgeRange, pu
   const [showSub, setShowSub] = useState(false);
   const [showInterests, setShowInterests] = useState(false);
   const [showDelete, setShowDelete] = useState(false);
-  const [showAnalytics, setShowAnalytics] = useState(false);
   const [distanceRange, setDistanceRange] = useState([10,25]);
   const [editInfo, setEditInfo] = useState(false);
   const [editInterests, setEditInterests] = useState(false);
@@ -836,10 +834,6 @@ export default function ProfileSettings({ userId, ageRange, onChangeAgeRange, pu
       })
     ),
     !publicView && React.createElement(Button, {
-        className: 'mt-2 w-full bg-blue-500 text-white',
-        onClick: () => setShowAnalytics(true)
-      }, t('viewAnalytics')),
-    !publicView && React.createElement(Button, {
         className: 'mt-2 w-full bg-yellow-500 text-white',
         onClick: () => setShowSub(true)
       }, subscriptionActive ? 'Skift abonnement' : 'Køb abonnement (ikke implementeret)'),
@@ -868,7 +862,6 @@ export default function ProfileSettings({ userId, ageRange, onChangeAgeRange, pu
         text: reportItem.text || '',
         onClose: () => { setReportItem(null); setReportMode(false); }
       }),
-    showAnalytics && React.createElement(ProfileAnalytics, { userId, onBack: () => setShowAnalytics(false) }),
     showDelete && React.createElement(DeleteAccountOverlay, {
         onDelete: async () => { await deleteAccount(userId); onLogout && onLogout(); },
         onClose: () => setShowDelete(false)

--- a/src/i18n.js
+++ b/src/i18n.js
@@ -54,7 +54,6 @@ export const messages = {
   stop:{ en:'Stop', da:'Stop', sv:'Stoppa', es:'Detener', fr:'Arrêter', de:'Stopp' },
   skip:{ en:'Skip', da:'Skip', sv:'Skip', es:'Skip', fr:'Skip', de:'Skip' },
   deleteAccount:{ en:'Delete account', da:'Slet konto' },
-  viewAnalytics:{ en:'View analytics', da:'Se statistik' },
   viewPublicProfile:{ en:'View public profile', da:'Vis offentlig profil' },
   premiumInvites:{ en:'Premium invites', da:'Premium invitationer' },
   viewLevels:{ en:'View levels', da:'Vis niveauer' },


### PR DESCRIPTION
## Summary
- remove entry point to profile analytics from profile settings
- drop unused translation for viewing analytics

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689991feb2cc832dbd1e04e93ce63fbd