### PR TITLE
Expand interest chat and describe Realetten

### DIFF
--- a/src/components/InterestChatScreen.jsx
+++ b/src/components/InterestChatScreen.jsx
@@ -95,7 +95,10 @@ export default function InterestChatScreen({ userId, onSelectProfile = null }) {
   if(showRealetten && interest){
     return React.createElement(RealettenPage, { interest, userId, onBack:()=>setShowRealetten(false) });
   }
-  return React.createElement(Card, { className: 'p-6 m-4 shadow-xl bg-white/90 flex flex-col h-full flex-1', style:{maxHeight:'calc(100vh - 10rem)', overflow:'hidden'} },
+  return React.createElement(Card, {
+    className: 'p-6 shadow-xl bg-white/90 flex flex-col h-full w-full flex-1',
+    style: { height: 'calc(100vh - 8rem)', overflow: 'hidden' }
+  },
     React.createElement(SectionTitle, { title: interest ? `${t('interestChatsTitle')} - ${interest}` : t('interestChatsTitle') }),
     React.createElement('div', { className:'flex gap-2 mb-4 overflow-x-auto' },
       (profile.interests || []).map(i =>

--- a/src/components/RealettenPage.jsx
+++ b/src/components/RealettenPage.jsx
@@ -162,6 +162,7 @@ export default function RealettenPage({ interest, userId, onBack }) {
   const buttons = React.createElement('div', { className:'flex gap-2 mt-2 self-center' }, turnBtn, shooterBtn);
   return React.createElement(Card, { className:'p-6 m-4 shadow-xl bg-white/90 flex flex-col h-full flex-1 overflow-y-auto' },
     React.createElement(SectionTitle,{ title:'Realetten', action }),
+    React.createElement('p', { className:'text-gray-600 text-center mb-4' }, 'M\u00f8d op til 4 andre p\u00e5 videokald'),
     React.createElement(RealettenCallScreen,{ interest, userId, botId:BOT_ID, onEnd:onBack, onParticipantsChange:setPlayers }),
     !game && buttons,
     game === 'turn' && React.createElement(TurnGame,{ sessionId: sanitizeInterest(interest), players: playerNames, myName, botName:BOT_NAME, onExit:()=>setGame(null) }),


### PR DESCRIPTION
## Summary
- Expand interest chat to occupy entire page for a full-screen experience while accounting for title and navigation bar height
- Add a short note under the Realetten heading explaining the video call feature

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68984a0689e8832dbdba8e802821c933