### PR TITLE
Use gray color for Google auth buttons

### DIFF
--- a/src/components/WelcomeScreen.jsx
+++ b/src/components/WelcomeScreen.jsx
@@ -523,7 +523,7 @@ export default function WelcomeScreen({ onLogin }) {
               }, t('cancel'))
             ),
             React.createElement(Button, {
-              className: 'mt-4 bg-red-500 text-white w-full',
+              className: 'mt-4 bg-gray-500 text-white w-full',
               onClick: handleGoogleRegister
             }, t('registerGoogle')),
             React.createElement(Button, {
@@ -534,7 +534,7 @@ export default function WelcomeScreen({ onLogin }) {
         ) : (
           React.createElement(React.Fragment, null,
             React.createElement(Button, {
-              className: `mt-4 w-full ${pendingProvider==='facebook' ? 'bg-blue-600 text-white' : 'bg-red-500 text-white'}`,
+              className: `mt-4 w-full ${pendingProvider==='facebook' ? 'bg-blue-600 text-white' : 'bg-gray-500 text-white'}`,
               onClick: pendingProvider === 'google' ? handleGoogleRegister : handleFacebookRegister
             }, t(pendingProvider === 'google' ? 'registerGoogle' : 'registerFacebook')),
             React.createElement(Button, {
@@ -549,7 +549,7 @@ export default function WelcomeScreen({ onLogin }) {
       React.createElement(React.Fragment, null,
         React.createElement('h1', { className: 'text-3xl font-bold mb-4 text-pink-600 text-center' }, t('register')),
         React.createElement(Button, {
-          className: 'bg-red-500 text-white w-full mb-2',
+          className: 'bg-gray-500 text-white w-full mb-2',
           onClick: handleGoogleRegister
         }, t('registerGoogle')),
         React.createElement(Button, {
@@ -592,7 +592,7 @@ export default function WelcomeScreen({ onLogin }) {
           onClick: () => setShowForgot(true)
         }, t('forgotPassword')),
         React.createElement(Button, {
-          className: 'mt-4 bg-red-500 text-white w-full',
+          className: 'mt-4 bg-gray-500 text-white w-full',
           onClick: handleGoogleLogin
         }, t('loginGoogle')),
         React.createElement(Button, {


### PR DESCRIPTION
## Summary
- Switch Google login and registration buttons to gray with white text for better style consistency

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689993aa533c832d90bd75a920c824cb