### PR TITLE
Set default age range to +/-10 years on new profiles

### DIFF
--- a/src/VideotpushApp.jsx
+++ b/src/VideotpushApp.jsx
@@ -86,6 +86,12 @@ export default function VideotpushApp() {
   const [cachedPhotoURL, setCachedPhotoURL] = useState('');
 
   useEffect(() => {
+    if (currentUser.ageRange) {
+      setAgeRange(currentUser.ageRange);
+    }
+  }, [currentUser.ageRange]);
+
+  useEffect(() => {
     if (!userId) {
       setCachedPhotoURL('');
       return;

--- a/src/components/WelcomeScreen.jsx
+++ b/src/components/WelcomeScreen.jsx
@@ -225,6 +225,7 @@ export default function WelcomeScreen({ onLogin }) {
     }
 
     const trimmedEmail = cred.user.email || '';
+    const age = parsedBirthday ? getAge(parsedBirthday) : 18;
     const profile = {
       id,
       name: trimmedNameFinal,
@@ -233,7 +234,8 @@ export default function WelcomeScreen({ onLogin }) {
       gender,
       interest: gender === 'Kvinde' ? 'Mand' : 'Kvinde',
       birthday: parsedBirthday,
-      age: parsedBirthday ? getAge(parsedBirthday) : 18,
+      age,
+      ageRange: [Math.max(18, age - 10), age + 10],
       language: lang,
       preferredLanguages: [lang],
       allowOtherLanguages: true,
@@ -349,6 +351,7 @@ export default function WelcomeScreen({ onLogin }) {
         inviteValid = false;
       }
     }
+    const age = birthday ? getAge(birthday) : 18;
     const profile = {
       id,
       name: trimmedName,
@@ -357,7 +360,8 @@ export default function WelcomeScreen({ onLogin }) {
       gender,
       interest: gender === 'Kvinde' ? 'Mand' : 'Kvinde',
       birthday,
-      age: birthday ? getAge(birthday) : 18,
+      age,
+      ageRange: [Math.max(18, age - 10), age + 10],
       language: lang,
       preferredLanguages: [lang],
       allowOtherLanguages: true,


### PR DESCRIPTION
## Summary
- Initialize new profiles with an age range spanning ten years younger and older than the user's age
- Load the user's stored age range on login without recalculating it

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68998efc16c0832da092d27452a25c26