### PR TITLE
fix: fit interest chat within viewport

### DIFF
--- a/src/components/InterestChatScreen.jsx
+++ b/src/components/InterestChatScreen.jsx
@@ -95,7 +95,7 @@ export default function InterestChatScreen({ userId, onSelectProfile = null }) {
   if(showRealetten && interest){
     return React.createElement(RealettenPage, { interest, userId, onBack:()=>setShowRealetten(false) });
   }
-  return React.createElement(Card, { className: 'p-6 shadow-xl bg-white/90 flex flex-col h-screen w-full flex-1', style:{overflow:'hidden'} },
+  return React.createElement(Card, { className: 'p-6 shadow-xl bg-white/90 flex flex-col h-full w-full flex-1', style:{overflow:'hidden'} },
     React.createElement(SectionTitle, { title: interest ? `${t('interestChatsTitle')} - ${interest}` : t('interestChatsTitle') }),
     React.createElement('div', { className:'flex gap-2 mb-4 overflow-x-auto' },
       (profile.interests || []).map(i =>


### PR DESCRIPTION
## Summary
- constrain InterestChatScreen height to available space so it doesn't overflow past the header and navigation bars

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689994757c7c832d8a191a0455cfd33b