### PR TITLE
feat: add clear cache button

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -17,12 +17,41 @@
   <link rel="stylesheet" href="../src/style.css" />
   <div id="root"></div>
   <script>
+    async function clearAppCache() {
+      try {
+        if ('caches' in window) {
+          const keys = await caches.keys();
+          await Promise.all(keys.map(k => caches.delete(k)));
+        }
+        if ('localStorage' in window) localStorage.clear();
+        if ('indexedDB' in window && indexedDB.databases) {
+          const dbs = await indexedDB.databases();
+          await Promise.all(
+            dbs.map(db => db.name && indexedDB.deleteDatabase(db.name))
+          );
+        }
+      } catch (err) {
+        console.error('Failed to clear app cache', err);
+      }
+    }
+
     function showLoadError() {
       const root = document.getElementById('root');
       root.innerHTML =
-        '<div style="padding:1rem;background-color:#fff;color:#000;">'+
-        'Appen kunne ikke indlæses. Ryd venligst din browsers cache og prøv igen.'+
+        '<div style="padding:1rem;background-color:#fff;color:#000;">' +
+        'Appen kunne ikke indlæses. Ryd venligst din browsers cache og prøv igen.' +
+        '<button id="clear-cache-btn" style="margin-top:1rem;padding:0.5rem 1rem;background-color:#6b7280;color:#fff;">Ryd cache</button>' +
         '</div>';
+      const btn = document.getElementById('clear-cache-btn');
+      if (btn) {
+        btn.addEventListener('click', async () => {
+          try {
+            await clearAppCache();
+          } finally {
+            window.location.reload();
+          }
+        });
+      }
     }
   </script>
   <script type="module" src="../src/index.js" onerror="showLoadError()"></script>

--- a/src/utils.js
+++ b/src/utils.js
@@ -130,3 +130,20 @@ export function getWeekId(date = getCurrentDate()){
   const weekNo = Math.ceil(((d - yearStart)/86400000 + 1)/7);
   return `${d.getUTCFullYear()}-${weekNo}`;
 }
+
+export async function clearAppCache(){
+  if(typeof window === 'undefined') return;
+  try{
+    if('caches' in window){
+      const keys = await caches.keys();
+      await Promise.all(keys.map(k => caches.delete(k)));
+    }
+    if('localStorage' in window) localStorage.clear();
+    if('indexedDB' in window && indexedDB.databases){
+      const dbs = await indexedDB.databases();
+      await Promise.all(dbs.map(db => db.name && indexedDB.deleteDatabase(db.name)));
+    }
+  }catch(err){
+    console.error('Failed to clear app cache', err);
+  }
+}

--- a/src/utils.test.js
+++ b/src/utils.test.js
@@ -17,6 +17,7 @@ import {
   hasReadReceipts,
   hasRatings,
   getWeekId
+  ,clearAppCache
 } from './utils';
 
 describe('utils', () => {
@@ -132,5 +133,9 @@ describe('utils', () => {
   test('getWeekId returns ISO week id', () => {
     const date = new Date('2023-01-05T00:00:00Z');
     expect(getWeekId(date)).toBe('2023-1');
+  });
+
+  test('clearAppCache resolves', async () => {
+    await expect(clearAppCache()).resolves.toBeUndefined();
   });
 });


### PR DESCRIPTION
## Summary
- inline cache-clearing logic in `index.html` so it works without module imports
- show cache clearing button when initial script fails to load
- test `clearAppCache` resolves without error

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68999736e250832d8047ad74dc24418d