### PR TITLE
Add payment solutions comparison documentation

### DIFF
--- a/docs/payment-solutions.md
+++ b/docs/payment-solutions.md
@@ -1,0 +1,9 @@
+# Payment Solutions Comparison
+
+| Solution | Platforms | Fees | Notes |
+|----------|-----------|------|-------|
+| Stribe | Web, iOS, Android | 2.9% + $0.30 per transaction | Popular for startups |
+| PayPal | Web, iOS, Android | 2.9% + $0.30 per transaction | Global brand recognition |
+| Apple Pay | iOS, macOS | Determined by card issuer | Integrated with Apple devices[^1] |
+
+[^1]: Apple might not accept an alternative.


### PR DESCRIPTION
## Summary
- add documentation comparing Stribe, PayPal, and Apple Pay options, noting Apple's stance on alternatives

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68999d3b2724832db0d0820ec4770af2