### PR TITLE
Document Apple's 30% App Store commission

### DIFF
--- a/docs/payment-solutions.md
+++ b/docs/payment-solutions.md
@@ -4,6 +4,6 @@
 |----------|-----------|------|-------|
 | Stribe | Web, iOS, Android | 2.9% + $0.30 per transaction | Popular for startups |
 | PayPal | Web, iOS, Android | 2.9% + $0.30 per transaction | Global brand recognition |
-| Apple Pay | iOS, macOS | Determined by card issuer | Integrated with Apple devices[^1] |
+| Apple App Store | iOS, macOS | 30% of developer sales | Required for in-app purchases on Apple devices[^1] |
 
 [^1]: Apple might not accept an alternative.


### PR DESCRIPTION
## Summary
- replace Apple Pay row with Apple App Store to show 30% commission on developer sales

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6899b349ede4832d8d58f0f4b64ac5a8