### PR TITLE
Add Realetten video call info text

### DIFF
--- a/src/components/InterestChatScreen.jsx
+++ b/src/components/InterestChatScreen.jsx
@@ -140,7 +140,8 @@ export default function InterestChatScreen({ userId, onSelectProfile = null }) {
         }),
         React.createElement(Button, { className:'bg-pink-500 text-white', disabled:!text.trim(), onClick:sendMessage }, 'Send')
       ),
-      React.createElement(Button, { className:'bg-blue-600 text-white font-bold mt-2', onClick:()=>setShowRealetten(true) }, realettenStarted ? 'Realetten started - Join now!' : 'Tag Chancen - Pr\u00f8v Realetten')
+      React.createElement(Button, { className:'bg-blue-600 text-white font-bold mt-2', onClick:()=>setShowRealetten(true) }, realettenStarted ? 'Realetten started - Join now!' : 'Tag Chancen - Pr\u00f8v Realetten'),
+      React.createElement('p', { className:'text-gray-600 text-sm mt-1' }, 'M\u00f8d andre i et videokald - op til 4 deltagere')
     )
   );
 }


### PR DESCRIPTION
## Summary
- Add explanatory text below the "Prøv Realetten" button highlighting the video call limit of 4 participants

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6899b42b395c832da21473e13deadde7