### PR TITLE
Remove social signup buttons from email registration screen

### DIFF
--- a/src/components/WelcomeScreen.jsx
+++ b/src/components/WelcomeScreen.jsx
@@ -525,15 +525,7 @@ export default function WelcomeScreen({ onLogin }) {
                 variant: 'outline',
                 onClick: () => { setShowRegister(false); setShowRegisterChoice(true); }
               }, t('cancel'))
-            ),
-            React.createElement(Button, {
-              className: 'mt-4 bg-gray-500 text-white w-full',
-              onClick: handleGoogleRegister
-            }, t('registerGoogle')),
-            React.createElement(Button, {
-              className: 'mt-2 bg-blue-600 text-white w-full',
-              onClick: handleFacebookRegister
-            }, t('registerFacebook'))
+            )
           )
         ) : (
           React.createElement(React.Fragment, null,


### PR DESCRIPTION
## Summary
- Remove Google and Facebook registration buttons from the email sign-up form
- Keep social sign-up options on the registration choice screen

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6899b5168bac832dac985100e9838f32