### PR TITLE
Expand interest chat to full height

### DIFF
--- a/src/components/InterestChatScreen.jsx
+++ b/src/components/InterestChatScreen.jsx
@@ -95,7 +95,7 @@ export default function InterestChatScreen({ userId, onSelectProfile = null }) {
   if(showRealetten && interest){
     return React.createElement(RealettenPage, { interest, userId, onBack:()=>setShowRealetten(false) });
   }
-  return React.createElement(Card, { className: 'p-6 shadow-xl bg-white/90 flex flex-col h-full w-full flex-1', style:{overflow:'hidden'} },
+  return React.createElement(Card, { className: 'p-6 shadow-xl bg-white/90 flex flex-col h-full flex-1', style:{height:'calc(100vh - 10rem)', maxHeight:'calc(100vh - 10rem)', overflow:'hidden'} },
     React.createElement(SectionTitle, { title: interest ? `${t('interestChatsTitle')} - ${interest}` : t('interestChatsTitle') }),
     React.createElement('div', { className:'flex gap-2 mb-4 overflow-x-auto' },
       (profile.interests || []).map(i =>
@@ -140,8 +140,10 @@ export default function InterestChatScreen({ userId, onSelectProfile = null }) {
         }),
         React.createElement(Button, { className:'bg-pink-500 text-white', disabled:!text.trim(), onClick:sendMessage }, 'Send')
       ),
-      React.createElement(Button, { className:'bg-blue-600 text-white font-bold mt-2', onClick:()=>setShowRealetten(true) }, realettenStarted ? 'Realetten started - Join now!' : 'Tag Chancen - Pr\u00f8v Realetten'),
-      React.createElement('p', { className:'text-gray-600 text-sm mt-1' }, 'M\u00f8d andre i et videokald - op til 4 deltagere')
+      React.createElement('div', { className:'flex flex-col items-center mt-2 mb-4' },
+        React.createElement(Button, { className:'bg-blue-600 text-white font-bold', onClick:()=>setShowRealetten(true) }, realettenStarted ? 'Realetten started - Join now!' : 'Tag Chancen - Pr\u00f8v Realetten'),
+        React.createElement('p', { className:'text-gray-600 text-sm mt-1' }, 'M\u00f8d andre i et videokald - op til 4 deltagere')
+      )
     )
   );
 }


### PR DESCRIPTION
## Summary
- Make interest chat card fill the available viewport height
- Group Realetten button and description above navigation for consistent layout

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6899b6eb64e0832dbfc9fa27109ab7ad