### PR TITLE
Translate read receipt 'Seen' to Danish

### DIFF
--- a/src/components/ChatScreen.jsx
+++ b/src/components/ChatScreen.jsx
@@ -180,7 +180,7 @@ export default function ChatScreen({ userId, onStartCall }) {
                   className: `inline-block px-3 py-2 rounded-lg ${fromSelf ? 'bg-pink-500 text-white' : 'bg-gray-200 text-black'}`
                 }, m.text),
                 showReadReceipts && fromSelf && lastSelf && m.ts === lastSelf.ts && active.lastReadByOther && active.lastReadByOther >= m.ts &&
-                  React.createElement('div',{className:'text-xs text-gray-500 text-right'},'Seen')
+                  React.createElement('div',{className:'text-xs text-gray-500 text-right'},t('seen'))
               )
             );
           })

--- a/src/i18n.js
+++ b/src/i18n.js
@@ -15,6 +15,7 @@ export const messages = {
   chooseLanguage: { en:'Language', da:'Sprog', sv:'Språk', es:'Idioma', fr:'Langue', de:'Sprache' },
   dailyClips: { en:'Daily Clips', da:'Dagens klip', sv:'Dagens klipp', es:'Clips diarios', fr:'Clips du jour', de:'Tägliche Clips' },
   chat: { en:'Chat', da:'Samtale', sv:'Chat', es:'Chat', fr:'Discussion', de:'Chat' },
+  seen: { en:'Seen', da:'Set', sv:'Sett', es:'Visto', fr:'Vu', de:'Gesehen' },
   checkInTitle:{ en:'Daily reflection', da:'Dagens refleksion', sv:'Dagens reflektion', es:'Reflexión diaria', fr:'Réflexion du jour', de:'Tägliche Reflexion' },
   profile:{ en:'Profile', da:'Profil', sv:'Profil', es:'Perfil', fr:'Profil', de:'Profil' },
   about:{ en:'About RealDate', da:'Om RealDate', sv:'Om RealDate', es:'Acerca de RealDate', fr:'À propos de RealDate', de:'Über RealDate' },


### PR DESCRIPTION
## Summary
- localize read receipt in chat screen via translation key
- add internationalized translations for the new key in i18n messages

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6899b79f7224832d9ccc9fc3510ab4b3