### PR TITLE
fix: save recorded video clips

### DIFF
--- a/src/components/ProfileSettings.jsx
+++ b/src/components/ProfileSettings.jsx
@@ -314,7 +314,7 @@ export default function ProfileSettings({ userId, ageRange, onChangeAgeRange, pu
       return;
     }
     setShowSnapVideoRecorder(false);
-    replaceFile(file, 'videoClips', recordClipIndex, music);
+    await replaceFile(file, 'videoClips', recordClipIndex, music);
     setRecordClipIndex(null);
   };
 


### PR DESCRIPTION
## Summary
- ensure recorded video clips are uploaded and stored before resetting the recorder state

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6899d4f91ce4832d814da4e841609ef9