### PR TITLE
Align RealDate header title across app

### DIFF
--- a/public/invite.html
+++ b/public/invite.html
@@ -10,7 +10,7 @@
 </head>
 <body class="bg-gradient-to-br from-pink-100 to-white min-h-screen flex items-center justify-center p-4">
   <div id="invite" class="bg-white/90 p-6 rounded-lg shadow-xl max-w-md w-full">
-    <h1 class="text-3xl font-bold text-pink-600 text-center mb-4">RealDate</h1>
+    <h1 class="text-3xl font-bold text-pink-600 text-center mb-4 mt-0">RealDate</h1>
     <div class="flex items-center mb-4">
       <div id="profile-pic" class="mr-4"></div>
       <h2 id="invite-text" class="text-xl font-bold text-pink-600"></h2>

--- a/src/VideotpushApp.jsx
+++ b/src/VideotpushApp.jsx
@@ -465,7 +465,7 @@ export default function VideotpushApp() {
           hasUnreadNotifications && React.createElement('span', { className: 'absolute -top-1 -right-2 bg-red-500 text-white text-xs rounded-full min-w-4 h-4 flex items-center justify-center px-1' }, unreadNotifications)
         )
       ),
-      'RealDate',
+      React.createElement('span', { className: 'leading-none' }, 'RealDate'),
       React.createElement('div', {
         className: 'absolute top-1/2 right-16 -translate-y-1/2 flex items-center gap-1'
       },


### PR DESCRIPTION
## Summary
- remove top margin from "RealDate" heading on invite page so it sits higher
- vertically center the "RealDate" title in the app header so it aligns with notification, help, and profile icons

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6899d48459e4832d91d95b00390d1765