### PR TITLE
Style forgot password link and move Google login lower

### DIFF
--- a/src/components/WelcomeScreen.jsx
+++ b/src/components/WelcomeScreen.jsx
@@ -596,13 +596,13 @@ export default function WelcomeScreen({ onLogin }) {
           }, t('cancel'))
         ),
         React.createElement(Button, {
-          className: 'mt-2',
-          variant: 'outline',
+          type: 'button',
+          className: 'mt-2 text-blue-600 underline bg-transparent border-0 p-0 disabled:opacity-50 disabled:cursor-not-allowed',
           onClick: () => setShowForgot(true),
           disabled: loggingIn
         }, t('forgotPassword')),
         React.createElement(Button, {
-          className: `mt-4 bg-gray-500 text-white w-full${loggingIn ? ' opacity-50 cursor-not-allowed' : ''}`,
+          className: `mt-6 bg-gray-500 text-white w-full${loggingIn ? ' opacity-50 cursor-not-allowed' : ''}`,
           onClick: handleGoogleLogin,
           disabled: loggingIn
         }, loggingIn ? t('loggingIn') : t('loginGoogle')),


### PR DESCRIPTION
## Summary
- Style "Forgot password" as an underlined text link for better subtlety
- Move Google login button further down to provide visual separation

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6899da08934c832d86b1b3dbf416c680