### PR TITLE
Remove undefined onMessage export

### DIFF
--- a/src/firebase.js
+++ b/src/firebase.js
@@ -217,7 +217,6 @@ export {
   getDownloadURL,
   listAll,
   deleteObject,
-  onMessage,
   createUserWithEmailAndPassword,
   signInWithEmailAndPassword,
   sendPasswordResetEmail,


### PR DESCRIPTION
## Summary
- remove stray onMessage export from firebase module

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689a4a46d11c832dbb2a03979fffc000