### PR TITLE
Add VAPID-based web push for iOS

### DIFF
--- a/netlify/functions/get-vapid-public-key.js
+++ b/netlify/functions/get-vapid-public-key.js
@@ -1,0 +1,15 @@
+const headers = {
+  'Access-Control-Allow-Origin': '*',
+  'Access-Control-Allow-Headers': 'Content-Type'
+};
+
+exports.handler = async function(event) {
+  if (event.httpMethod === 'OPTIONS') {
+    return { statusCode: 200, headers, body: '' };
+  }
+  if (event.httpMethod !== 'GET') {
+    return { statusCode: 405, headers, body: 'Method Not Allowed' };
+  }
+  const key = process.env.WEB_PUSH_PUBLIC_KEY || '';
+  return { statusCode: 200, headers, body: key };
+};

--- a/netlify/functions/send-webpush.js
+++ b/netlify/functions/send-webpush.js
@@ -1,0 +1,76 @@
+const webpush = require('web-push');
+const admin = require('firebase-admin');
+const fs = require('fs');
+const path = require('path');
+
+if (!admin.apps.length) {
+  try {
+    let serviceAccount = null;
+    if (process.env.FIREBASE_SERVICE_ACCOUNT_JSON) {
+      serviceAccount = JSON.parse(process.env.FIREBASE_SERVICE_ACCOUNT_JSON);
+    } else {
+      const credPath = process.env.GOOGLE_APPLICATION_CREDENTIALS || path.join(__dirname, '../../videotinder-38b8b-firebase-adminsdk-fbsvc-5f3bef3136.json');
+      if (fs.existsSync(credPath)) {
+        serviceAccount = require(credPath);
+      }
+    }
+    if (serviceAccount) {
+      admin.initializeApp({ credential: admin.credential.cert(serviceAccount) });
+    }
+  } catch (err) {
+    console.error('Failed to initialize Firebase admin:', err);
+  }
+}
+
+const db = admin.firestore();
+
+const headers = {
+  'Access-Control-Allow-Origin': '*',
+  'Access-Control-Allow-Headers': 'Content-Type'
+};
+
+if (process.env.WEB_PUSH_PUBLIC_KEY && process.env.WEB_PUSH_PRIVATE_KEY) {
+  webpush.setVapidDetails('mailto:example@example.com', process.env.WEB_PUSH_PUBLIC_KEY, process.env.WEB_PUSH_PRIVATE_KEY);
+}
+
+exports.handler = async function(event) {
+  if (event.httpMethod === 'OPTIONS') {
+    return { statusCode: 200, headers, body: '' };
+  }
+  if (event.httpMethod !== 'POST') {
+    return { statusCode: 405, headers, body: 'Method Not Allowed' };
+  }
+  try {
+    const { title, body, subscriptions, silent } = JSON.parse(event.body || '{}');
+    let subs = [];
+    if (Array.isArray(subscriptions) && subscriptions.length) {
+      subs = subscriptions;
+    } else {
+      const snap = await db.collection('webPushSubscriptions').get();
+      subs = snap.docs.map(d => ({ id: d.id, ...d.data().subscription }));
+    }
+    let success = 0;
+    const failed = [];
+    await Promise.all(subs.map(async sub => {
+      try {
+        await webpush.sendNotification(sub, JSON.stringify({ title, body, silent }));
+        success++;
+      } catch (err) {
+        if (err.statusCode === 410 || err.statusCode === 404) {
+          try {
+            if (sub.id) await db.collection('webPushSubscriptions').doc(sub.id).delete();
+          } catch (_) {}
+        }
+        failed.push({ endpoint: sub.endpoint, error: err.message });
+      }
+    }));
+    return {
+      statusCode: 200,
+      headers: { ...headers, 'Content-Type': 'application/json' },
+      body: JSON.stringify({ success, failed: failed.length })
+    };
+  } catch (err) {
+    console.error('send-webpush error', err);
+    return { statusCode: 500, headers, body: err.message };
+  }
+};

--- a/package-lock.json
+++ b/package-lock.json
@@ -16,7 +16,8 @@
         "qrcode.react": "^4.2.0",
         "rc-slider": "^11.1.8",
         "react": "^17.0.0",
-        "react-dom": "^17.0.0"
+        "react-dom": "^17.0.0",
+        "web-push": "^3.6.7"
       },
       "devDependencies": {
         "@babel/core": "^7.28.0",
@@ -6616,6 +6617,18 @@
         "node": ">=8"
       }
     },
+    "node_modules/asn1.js": {
+      "version": "5.4.1",
+      "resolved": "https://registry.npmjs.org/asn1.js/-/asn1.js-5.4.1.tgz",
+      "integrity": "sha512-+I//4cYPccV8LdmBLiX8CYvf9Sp3vQsrqu2QNXRcrbiWvcx/UdlFiqUJJzxRQxgsZmvhXhn4cSKeSmoFjVdupA==",
+      "license": "MIT",
+      "dependencies": {
+        "bn.js": "^4.0.0",
+        "inherits": "^2.0.1",
+        "minimalistic-assert": "^1.0.0",
+        "safer-buffer": "^2.1.0"
+      }
+    },
     "node_modules/ast-types": {
       "version": "0.13.4",
       "resolved": "https://registry.npmjs.org/ast-types/-/ast-types-0.13.4.tgz",
@@ -6946,6 +6959,12 @@
       "integrity": "sha512-XpNj6GDQzdfW+r2Wnn7xiSAd7TM3jzkxGXBGTtWKuSXv1xUV+azxAm8jdWZN06QTQk+2N2XB9jRDkvbmQmcRtg==",
       "license": "MIT",
       "optional": true
+    },
+    "node_modules/bn.js": {
+      "version": "4.12.2",
+      "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.12.2.tgz",
+      "integrity": "sha512-n4DSx829VRTRByMRGdjQ9iqsN0Bh4OolPsFnaZBLcbi8iXcB+kJ9s7EnRt4wILZNV3kPLHkRVfOc/HvhC3ovDw==",
+      "license": "MIT"
     },
     "node_modules/body-parser": {
       "version": "2.2.0",
@@ -8992,6 +9011,15 @@
         "node": ">=8.0.0"
       }
     },
+    "node_modules/http_ece": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/http_ece/-/http_ece-1.2.0.tgz",
+      "integrity": "sha512-JrF8SSLVmcvc5NducxgyOrKXe3EsyHMgBFgSaIUGmArKe+rwr0uphRkRXvwiom3I+fpIfoItveHrfudL8/rxuA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=16"
+      }
+    },
     "node_modules/http-errors": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.0.tgz",
@@ -9156,7 +9184,6 @@
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
       "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
-      "devOptional": true,
       "license": "ISC"
     },
     "node_modules/ip-address": {
@@ -10450,7 +10477,6 @@
       "resolved": "https://registry.npmjs.org/jwa/-/jwa-2.0.1.tgz",
       "integrity": "sha512-hRF04fqJIP8Abbkq5NKGN0Bbr3JxlQ+qhZufXVr0DvujKy93ZCbXZMHDL4EOtodSbCWxOqR8MS1tXA5hwqCXDg==",
       "license": "MIT",
-      "optional": true,
       "dependencies": {
         "buffer-equal-constant-time": "^1.0.1",
         "ecdsa-sig-formatter": "1.0.11",
@@ -10479,7 +10505,6 @@
       "resolved": "https://registry.npmjs.org/jws/-/jws-4.0.0.tgz",
       "integrity": "sha512-KDncfTmOZoOMTFG4mBlG0qUIOlc03fmzH+ru6RgYVZhPkyiy/92Owlt/8UEN+a4TXR1FQetfIpJE8ApdvdVxTg==",
       "license": "MIT",
-      "optional": true,
       "dependencies": {
         "jwa": "^2.0.0",
         "safe-buffer": "^5.0.1"
@@ -11138,6 +11163,12 @@
         "node": ">=6"
       }
     },
+    "node_modules/minimalistic-assert": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/minimalistic-assert/-/minimalistic-assert-1.0.1.tgz",
+      "integrity": "sha512-UtJcAD4yEaGtjPezWuO9wC4nwUnVH/8/Im3yEHQP4b67cXlD/Qr9hdITCU1xDbSEXg2XKNaP8jsReV7vQd00/A==",
+      "license": "ISC"
+    },
     "node_modules/minimatch": {
       "version": "5.1.6",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.1.6.tgz",
@@ -11156,7 +11187,6 @@
       "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
       "integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==",
       "license": "MIT",
-      "optional": true,
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
@@ -12536,7 +12566,6 @@
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
       "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/saxes": {
@@ -13609,6 +13638,47 @@
       "integrity": "sha512-DEAoo25RfSYMuTGc9vPJzZcZullwIqRDSI9LOy+fkCJPi6hykCnfKaXTuPBDuXAUcqHXyOgFtHNp/kB2FjYHbw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/web-push": {
+      "version": "3.6.7",
+      "resolved": "https://registry.npmjs.org/web-push/-/web-push-3.6.7.tgz",
+      "integrity": "sha512-OpiIUe8cuGjrj3mMBFWY+e4MMIkW3SVT+7vEIjvD9kejGUypv8GPDf84JdPWskK8zMRIJ6xYGm+Kxr8YkPyA0A==",
+      "license": "MPL-2.0",
+      "dependencies": {
+        "asn1.js": "^5.3.0",
+        "http_ece": "1.2.0",
+        "https-proxy-agent": "^7.0.0",
+        "jws": "^4.0.0",
+        "minimist": "^1.2.5"
+      },
+      "bin": {
+        "web-push": "src/cli.js"
+      },
+      "engines": {
+        "node": ">= 16"
+      }
+    },
+    "node_modules/web-push/node_modules/agent-base": {
+      "version": "7.1.4",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.4.tgz",
+      "integrity": "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/web-push/node_modules/https-proxy-agent": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.6.tgz",
+      "integrity": "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==",
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "^7.1.2",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
     },
     "node_modules/webidl-conversions": {
       "version": "3.0.1",

--- a/package.json
+++ b/package.json
@@ -19,7 +19,8 @@
     "qrcode.react": "^4.2.0",
     "rc-slider": "^11.1.8",
     "react": "^17.0.0",
-    "react-dom": "^17.0.0"
+    "react-dom": "^17.0.0",
+    "web-push": "^3.6.7"
   },
   "devDependencies": {
     "@babel/core": "^7.28.0",

--- a/public/service-worker.js
+++ b/public/service-worker.js
@@ -50,6 +50,28 @@ self.addEventListener('notificationclick', (event) => {
 });
 
 
+self.addEventListener('push', event => {
+  console.log('ServiceWorker push', event.data ? event.data.text() : '(no data)');
+  let data = {};
+  try {
+    data = event.data ? event.data.json() : {};
+  } catch (err) {}
+  const title = data.title || 'VideoTinder';
+  const options = {
+    body: data.body,
+    icon: 'icon-192.png',
+    silent: !!data.silent,
+    data: data.data || {}
+  };
+  event.waitUntil(
+    self.registration.showNotification(title, options).then(() =>
+      self.clients.matchAll({ includeUncontrolled: true }).then(list => {
+        list.forEach(c => c.postMessage({ type: 'PUSH_RECEIVED', title, body: data.body }));
+      })
+    )
+  );
+});
+
 self.addEventListener('fetch', event => {
   console.log('ServiceWorker fetch', event.request.url);
   const dest = event.request.destination;

--- a/src/ensureWebPush.js
+++ b/src/ensureWebPush.js
@@ -1,0 +1,56 @@
+import { db, auth, doc, setDoc } from './firebase.js';
+import { detectOS, detectBrowser } from './utils.js';
+
+function urlBase64ToUint8Array(base64String) {
+  const padding = '='.repeat((4 - base64String.length % 4) % 4);
+  const base64 = (base64String + padding).replace(/-/g, '+').replace(/_/g, '/');
+  const rawData = atob(base64);
+  const outputArray = new Uint8Array(rawData.length);
+  for (let i = 0; i < rawData.length; ++i) {
+    outputArray[i] = rawData.charCodeAt(i);
+  }
+  return outputArray;
+}
+
+async function defaultSaveSubscription(sub) {
+  try {
+    const id = btoa(sub.endpoint);
+    const user = auth.currentUser;
+    await setDoc(doc(db, 'webPushSubscriptions', id), {
+      subscription: sub,
+      uid: user?.uid || null,
+      os: detectOS(),
+      browser: detectBrowser(),
+      loginMethod: user ? (user.providerData?.[0]?.providerId === 'password' ? 'password' : 'admin') : 'unknown',
+      updated: new Date().toISOString()
+    });
+  } catch (err) {
+    console.error('Failed to save subscription', err);
+  }
+}
+
+export async function ensureWebPush(saveSubscription = defaultSaveSubscription) {
+  try {
+    if (typeof window === 'undefined' || !('serviceWorker' in navigator) || !('PushManager' in window)) {
+      return null;
+    }
+    const base = process.env.FUNCTIONS_BASE_URL || '';
+    const res = await fetch(`${base}/.netlify/functions/get-vapid-public-key`);
+    const vapidKey = (await res.text()).trim();
+    if (!vapidKey) return null;
+    const reg = await navigator.serviceWorker.ready;
+    const sub = await reg.pushManager.getSubscription();
+    if (sub) {
+      try { await sub.unsubscribe(); } catch (_) {}
+    }
+    const newSub = await reg.pushManager.subscribe({
+      userVisibleOnly: true,
+      applicationServerKey: urlBase64ToUint8Array(vapidKey)
+    });
+    await saveSubscription(newSub.toJSON ? newSub.toJSON() : newSub);
+    return newSub;
+  } catch (err) {
+    console.error('ensureWebPush failed', err);
+    return null;
+  }
+}

--- a/src/index.js
+++ b/src/index.js
@@ -2,9 +2,7 @@ import React from 'react';
 import ReactDOM from 'react-dom';
 import './consoleLogs.js';
 import VideotpushApp from './VideotpushApp.jsx';
-import { firebaseConfig, logEvent } from './firebase.js';
-import { addNotification } from './notifications.js';
-import { detectOS, detectBrowser } from './utils.js';
+import { ensureWebPush } from './ensureWebPush.js';
 
 ReactDOM.render(React.createElement(VideotpushApp), document.getElementById('root'));
 
@@ -16,8 +14,9 @@ if ('serviceWorker' in navigator) {
     const swUrl = `${base}service-worker.js`;
     navigator.serviceWorker
       .register(swUrl, { scope: base })
-      .then(reg => {
+      .then(async reg => {
         console.log('SW scope:', reg.scope);
+        await ensureWebPush();
       })
       .catch(err => console.error('SW register failed:', err));
   });


### PR DESCRIPTION
## Summary
- implement ensureWebPush helper to manage Web Push subscriptions using VAPID
- handle push events in service worker and broadcast reception
- add Netlify functions for VAPID key retrieval and Web Push sending

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689a4c7bd5ec832d9c5826e4d8462bd7