### PR TITLE
feat: send push notifications for chats and matches

### DIFF
--- a/src/VideotpushApp.jsx
+++ b/src/VideotpushApp.jsx
@@ -37,7 +37,7 @@ import { useCollection, db, doc, setDoc, updateDoc, arrayUnion, getDoc, incremen
 import { getCurrentDate } from './utils.js';
 import { cacheMediaIfNewer } from './cacheMedia.js';
 import version from './version.js';
-import { getNotifications, subscribeNotifications, markNotificationsRead } from './notifications.js';
+import { getNotifications, subscribeNotifications, markNotificationsRead, showLocalNotification, sendWebPushToProfile } from './notifications.js';
 import SubscriptionOverlay from './components/SubscriptionOverlay.jsx';
 import NotificationsScreen from './components/NotificationsScreen.jsx';
 import { Button } from './components/ui/button.js';
@@ -177,6 +177,8 @@ export default function VideotpushApp() {
         setDoc(doc(db, 'matches', m1.id), m1),
         setDoc(doc(db, 'matches', m2.id), m2)
       ]);
+      showLocalNotification("It's a match!", 'You have a new match');
+      sendWebPushToProfile('105', "It's a match!", 'You have a new match');
     } catch (err) {
       console.error('Failed to create match', err);
     }
@@ -203,6 +205,7 @@ export default function VideotpushApp() {
           newMatch: false
         })
       ]);
+      sendWebPushToProfile(to, 'New message', text);
     } catch (err) {
       console.error('Failed to send message', err);
     }

--- a/src/components/ChatScreen.jsx
+++ b/src/components/ChatScreen.jsx
@@ -8,6 +8,7 @@ import { Textarea } from './ui/textarea.js';
 import SectionTitle from './SectionTitle.jsx';
 import { useT } from '../i18n.js';
 import { useCollection, db, doc, updateDoc, deleteDoc, arrayUnion, onSnapshot } from '../firebase.js';
+import { sendWebPushToProfile } from '../notifications.js';
 
 export default function ChatScreen({ userId, onStartCall }) {
   const profiles = useCollection('profiles');
@@ -99,6 +100,7 @@ export default function ChatScreen({ userId, onStartCall }) {
         typing:false
       })
     ]);
+    sendWebPushToProfile(active.profileId, 'New message', trimmed);
     setText('');
     if(messagesRef.current){
       messagesRef.current.scrollTop = messagesRef.current.scrollHeight;

--- a/src/components/DailyDiscovery.jsx
+++ b/src/components/DailyDiscovery.jsx
@@ -16,6 +16,7 @@ import InfoOverlay from './InfoOverlay.jsx';
 import ExtendAreaOverlay from './ExtendAreaOverlay.jsx';
 import { triggerHaptic } from '../haptics.js';
 import useDayOffset from '../useDayOffset.js';
+import { showLocalNotification, sendWebPushToProfile } from '../notifications.js';
 
 export default function DailyDiscovery({ userId, profiles = [], onSelectProfile, ageRange, onOpenProfile }) {
   const t = useT();
@@ -197,7 +198,11 @@ export default function DailyDiscovery({ userId, profiles = [], onSelectProfile,
           setDoc(doc(db,'matches',m2.id),m2)
         ]);
         const prof = profiles.find(p => p.id === profileId);
-        if(prof) setMatchedProfile(prof);
+        if(prof){
+          setMatchedProfile(prof);
+          showLocalNotification("It's a match!", `You and ${prof.name} like each other`);
+          sendWebPushToProfile(profileId, "It's a match!", `${user.name || 'Someone'} matched with you`);
+        }
         triggerHaptic([100,50,100]);
       }
     }

--- a/src/components/LikesScreen.jsx
+++ b/src/components/LikesScreen.jsx
@@ -11,6 +11,7 @@ import { useCollection, db, doc, setDoc, deleteDoc, getDoc } from '../firebase.j
 import { useT } from '../i18n.js';
 import { triggerHaptic } from '../haptics.js';
 import VerificationBadge from './VerificationBadge.jsx';
+import { showLocalNotification, sendWebPushToProfile } from '../notifications.js';
 
 export default function LikesScreen({ userId, onSelectProfile, onBack }) {
   const profiles = useCollection('profiles');
@@ -59,7 +60,11 @@ export default function LikesScreen({ userId, onSelectProfile, onBack }) {
         ]);
         await setDoc(doc(db,'episodeProgress', `${userId}-${profileId}`), { removed: true }, { merge: true });
         const prof = profiles.find(p => p.id === profileId);
-        if(prof) setMatchedProfile(prof);
+        if(prof){
+          setMatchedProfile(prof);
+          showLocalNotification("It's a match!", `You and ${prof.name} like each other`);
+          sendWebPushToProfile(profileId, "It's a match!", `${currentUser.name || 'Someone'} matched with you`);
+        }
         triggerHaptic([100,50,100]);
       }
     }

--- a/src/components/ProfileSettings.jsx
+++ b/src/components/ProfileSettings.jsx
@@ -21,6 +21,7 @@ import { getAge, getCurrentDate, getMaxVideoSeconds, getMonthlyBoostLimit, hasAd
 import PremiumIcon from './PremiumIcon.jsx';
 import { triggerHaptic } from '../haptics.js';
 import VerificationBadge from './VerificationBadge.jsx';
+import { showLocalNotification, sendWebPushToProfile } from '../notifications.js';
 
 export default function ProfileSettings({ userId, ageRange, onChangeAgeRange, publicView = false, onViewPublicProfile = () => {}, onOpenAbout = () => {}, onLogout = null, viewerId = userId, onBack, activeTask, taskTrigger = 0 }) {
   const [profile,setProfile]=useState(null);
@@ -462,6 +463,8 @@ export default function ProfileSettings({ userId, ageRange, onChangeAgeRange, pu
         ]);
         await setDoc(doc(db,'episodeProgress', `${currentUserId}-${userId}`), { removed: true }, { merge: true });
         setMatchedProfile(profile);
+        showLocalNotification("It's a match!", `You and ${profile.name} like each other`);
+        sendWebPushToProfile(userId, "It's a match!", `${viewerProfile?.name || 'Someone'} matched with you`);
         triggerHaptic([100,50,100]);
       }
     }


### PR DESCRIPTION
## Summary
- add `sendWebPushToProfile` helper to dispatch push notifications from the server
- notify chat recipients with web push when a message is sent
- show local match popups and send push notifications to the other user on match

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689a57b1a77c832db1445c3dfcc67acc