### PR TITLE
Translate push notification text to Danish

### DIFF
--- a/src/VideotpushApp.jsx
+++ b/src/VideotpushApp.jsx
@@ -177,8 +177,8 @@ export default function VideotpushApp() {
         setDoc(doc(db, 'matches', m1.id), m1),
         setDoc(doc(db, 'matches', m2.id), m2)
       ]);
-      showLocalNotification("It's a match!", 'You have a new match');
-      sendWebPushToProfile('105', "It's a match!", 'You have a new match');
+      showLocalNotification('Det er et match!', 'Du har et nyt match');
+      sendWebPushToProfile('105', 'Det er et match!', 'Du har et nyt match');
     } catch (err) {
       console.error('Failed to create match', err);
     }
@@ -205,7 +205,7 @@ export default function VideotpushApp() {
           newMatch: false
         })
       ]);
-      sendWebPushToProfile(to, 'New message', text);
+      sendWebPushToProfile(to, 'Ny besked', text);
     } catch (err) {
       console.error('Failed to send message', err);
     }

--- a/src/components/ChatScreen.jsx
+++ b/src/components/ChatScreen.jsx
@@ -100,7 +100,7 @@ export default function ChatScreen({ userId, onStartCall }) {
         typing:false
       })
     ]);
-    sendWebPushToProfile(active.profileId, 'New message', trimmed);
+    sendWebPushToProfile(active.profileId, 'Ny besked', trimmed);
     setText('');
     if(messagesRef.current){
       messagesRef.current.scrollTop = messagesRef.current.scrollHeight;

--- a/src/components/DailyDiscovery.jsx
+++ b/src/components/DailyDiscovery.jsx
@@ -200,8 +200,8 @@ export default function DailyDiscovery({ userId, profiles = [], onSelectProfile,
         const prof = profiles.find(p => p.id === profileId);
         if(prof){
           setMatchedProfile(prof);
-          showLocalNotification("It's a match!", `You and ${prof.name} like each other`);
-          sendWebPushToProfile(profileId, "It's a match!", `${user.name || 'Someone'} matched with you`);
+          showLocalNotification('Det er et match!', `Du og ${prof.name} kan lide hinanden`);
+          sendWebPushToProfile(profileId, 'Det er et match!', `${user.name || 'En person'} har matchet med dig`);
         }
         triggerHaptic([100,50,100]);
       }

--- a/src/components/LikesScreen.jsx
+++ b/src/components/LikesScreen.jsx
@@ -62,8 +62,8 @@ export default function LikesScreen({ userId, onSelectProfile, onBack }) {
         const prof = profiles.find(p => p.id === profileId);
         if(prof){
           setMatchedProfile(prof);
-          showLocalNotification("It's a match!", `You and ${prof.name} like each other`);
-          sendWebPushToProfile(profileId, "It's a match!", `${currentUser.name || 'Someone'} matched with you`);
+          showLocalNotification('Det er et match!', `Du og ${prof.name} kan lide hinanden`);
+          sendWebPushToProfile(profileId, 'Det er et match!', `${currentUser.name || 'En person'} har matchet med dig`);
         }
         triggerHaptic([100,50,100]);
       }

--- a/src/components/ProfileSettings.jsx
+++ b/src/components/ProfileSettings.jsx
@@ -463,8 +463,8 @@ export default function ProfileSettings({ userId, ageRange, onChangeAgeRange, pu
         ]);
         await setDoc(doc(db,'episodeProgress', `${currentUserId}-${userId}`), { removed: true }, { merge: true });
         setMatchedProfile(profile);
-        showLocalNotification("It's a match!", `You and ${profile.name} like each other`);
-        sendWebPushToProfile(userId, "It's a match!", `${viewerProfile?.name || 'Someone'} matched with you`);
+        showLocalNotification('Det er et match!', `Du og ${profile.name} kan lide hinanden`);
+        sendWebPushToProfile(userId, 'Det er et match!', `${viewerProfile?.name || 'En person'} har matchet med dig`);
         triggerHaptic([100,50,100]);
       }
     }


### PR DESCRIPTION
## Summary
- Translate match notification titles and bodies to Danish across the app
- Send Danish title for new chat message notifications

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689a5d84e0bc832d87687c3d177d210e