### PR TITLE
Remove skip button from welcome screen

### DIFF
--- a/src/components/WelcomeScreen.jsx
+++ b/src/components/WelcomeScreen.jsx
@@ -40,11 +40,6 @@ export default function WelcomeScreen({ onLogin }) {
   const { lang } = useLang();
   const t = useT();
 
-
-  const handleSkip = async () => {
-    onLogin('101', 'admin');
-  };
-
   const handleBirthdayChange = e => {
     const val = e.target.value;
     setBirthdayInput(val);
@@ -598,16 +593,10 @@ export default function WelcomeScreen({ onLogin }) {
           className: 'bg-pink-500 text-white mb-4',
           onClick: () => setShowLoginForm(true)
         }, t('login')),
-        React.createElement('div', { className: 'flex gap-2' },
-          React.createElement(Button, {
-            className: 'bg-pink-500 text-white flex-1',
-            onClick: () => { setShowRegisterChoice(true); setName(''); setCity(''); }
-          }, t('register')),
-          React.createElement(Button, {
-            className: 'bg-blue-500 text-white flex-1',
-            onClick: handleSkip
-          }, t('skip'))
-        )
+        React.createElement(Button, {
+          className: 'bg-pink-500 text-white',
+          onClick: () => { setShowRegisterChoice(true); setName(''); setCity(''); }
+        }, t('register'))
       )
     )
   ));

--- a/src/i18n.js
+++ b/src/i18n.js
@@ -53,7 +53,6 @@ export const messages = {
   register:{ en:'Create profile', da:'Opret profil', sv:'Skapa profil', es:'Crear perfil', fr:'Créer un profil', de:'Profil erstellen' },
   cancel:{ en:'Cancel', da:'Annuller', sv:'Avbryt', es:'Cancelar', fr:'Annuler', de:'Abbrechen' },
   stop:{ en:'Stop', da:'Stop', sv:'Stoppa', es:'Detener', fr:'Arrêter', de:'Stopp' },
-  skip:{ en:'Skip', da:'Skip', sv:'Skip', es:'Skip', fr:'Skip', de:'Skip' },
   deleteAccount:{ en:'Delete account', da:'Slet konto' },
   viewPublicProfile:{ en:'View public profile', da:'Vis offentlig profil' },
   premiumInvites:{ en:'Premium invites', da:'Premium invitationer' },


### PR DESCRIPTION
## Summary
- Remove obsolete skip option from welcome screen
- Drop unused `skip` translation entries

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689ad8701580832da38fdfa6623cc89b