### PR TITLE
Localize logout labels

### DIFF
--- a/src/components/AdminScreen.jsx
+++ b/src/components/AdminScreen.jsx
@@ -221,7 +221,7 @@ export default function AdminScreen({ onOpenStats, onOpenBugReports, onOpenMatch
       onSaveUserLogout && React.createElement(Button, {
         className: 'bg-blue-500 text-white px-4 py-2 rounded whitespace-nowrap',
         onClick: onSaveUserLogout
-      }, 'Save & Logout')
+      }, t('saveAndLogout'))
     ),
 
   // Daily admin section

--- a/src/components/ProfileSettings.jsx
+++ b/src/components/ProfileSettings.jsx
@@ -546,7 +546,7 @@ export default function ProfileSettings({ userId, ageRange, onChangeAgeRange, pu
         onLogout && React.createElement(Button, {
           className: 'bg-gray-200 text-gray-700 px-4 py-2 rounded',
           onClick: onLogout
-        }, 'Logout')
+        }, t('logout'))
       ),
       React.createElement('div', { className: 'mt-4 flex justify-end' },
         React.createElement(Button, {

--- a/src/i18n.js
+++ b/src/i18n.js
@@ -36,6 +36,8 @@ export const messages = {
   register:{ en:'Create profile', da:'Opret profil', sv:'Skapa profil', es:'Crear perfil', fr:'Créer un profil', de:'Profil erstellen' },
   cancel:{ en:'Cancel', da:'Annuller', sv:'Avbryt', es:'Cancelar', fr:'Annuler', de:'Abbrechen' },
   stop:{ en:'Stop', da:'Stop', sv:'Stoppa', es:'Detener', fr:'Arrêter', de:'Stopp' },
+  logout:{ en:'Logout', da:'Log ud', sv:'Logga ut', es:'Cerrar sesión', fr:'Déconnexion', de:'Abmelden' },
+  saveAndLogout:{ en:'Save & Logout', da:'Gem og log ud', sv:'Spara och logga ut', es:'Guardar y cerrar sesión', fr:'Enregistrer et se déconnecter', de:'Speichern und abmelden' },
   deleteAccount:{ en:'Delete account', da:'Slet konto' },
   viewPublicProfile:{ en:'View public profile', da:'Vis offentlig profil' },
   premiumInvites:{ en:'Premium invites', da:'Premium invitationer' },


### PR DESCRIPTION
## Summary
- Add i18n entries for logout and save-and-logout
- Use translations for profile settings and admin logout buttons

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689af702feb8832d9bd1c560c9aa431f