### PR TITLE
Add spacing before cache clear message

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -39,6 +39,7 @@
       const root = document.getElementById('root');
       root.innerHTML =
         '<div style="padding:1rem;background-color:#fff;color:#000;">' +
+          '<br /><br />' +
           '<h1 style="margin-bottom:1rem;">Lige et øjeblik …</h1>' +
           '<p style="margin-bottom:1rem;">Appen kunne ikke indlæses. Ryd venligst din browsers cache og prøv igen.</p>' +
           '<button id="clear-cache-btn" style="padding:0.5rem 1rem;background-color:#6b7280;color:#fff;">Ryd cache</button>' +


### PR DESCRIPTION
## Summary
- add line breaks before cache clear message to reduce cramped layout

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689b02a83dec832dbec3147e32b36db1