### PR TITLE
Enable profile photo upload only in edit mode

### DIFF
--- a/src/components/ProfileSettings.jsx
+++ b/src/components/ProfileSettings.jsx
@@ -570,12 +570,12 @@ export default function ProfileSettings({ userId, ageRange, onChangeAgeRange, pu
             React.createElement('img', {
               src: profile.photoURL,
               alt: 'Profil',
-              className:`w-24 h-24 rounded object-cover ${!publicView ? 'cursor-pointer' : ''}`,
-              onClick: !publicView ? () => photoRef.current && photoRef.current.click() : undefined
+              className:`w-24 h-24 rounded object-cover ${!publicView && editInfo ? 'cursor-pointer' : ''}`,
+              onClick: !publicView && editInfo ? () => photoRef.current && photoRef.current.click() : undefined
             }) :
             React.createElement('div', {
-              className:`w-24 h-24 rounded bg-gray-200 flex items-center justify-center ${!publicView ? 'cursor-pointer' : ''}`,
-              onClick: !publicView ? () => photoRef.current && photoRef.current.click() : undefined
+              className:`w-24 h-24 rounded bg-gray-200 flex items-center justify-center ${!publicView && editInfo ? 'cursor-pointer' : ''}`,
+              onClick: !publicView && editInfo ? () => photoRef.current && photoRef.current.click() : undefined
             },
               React.createElement(UserIcon,{ className:'w-12 h-12 text-gray-500' })
             ),


### PR DESCRIPTION
## Summary
- Require edit mode before profile picture can be clicked to upload a new image

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689b1d19599c832d8dd0a08f84ce8b59