### PR TITLE
style: add bottom padding to section title

### DIFF
--- a/src/components/SectionTitle.jsx
+++ b/src/components/SectionTitle.jsx
@@ -3,7 +3,7 @@ import PremiumIcon from './PremiumIcon.jsx';
 
 export default function SectionTitle({ title, action, colorClass = 'text-pink-600', premium = false }) {
   return React.createElement('div', { className: 'flex items-center justify-between mb-2' },
-    React.createElement('h2', { className: `text-2xl font-semibold flex items-center gap-2 leading-tight ${colorClass}` },
+    React.createElement('h2', { className: `text-2xl font-semibold flex items-center gap-2 leading-tight pb-[3px] ${colorClass}` },
       premium && React.createElement(PremiumIcon, null),
       title
     ),

--- a/src/components/SectionTitle.test.jsx
+++ b/src/components/SectionTitle.test.jsx
@@ -33,4 +33,10 @@ describe('SectionTitle', () => {
     const h2 = container.querySelector('h2');
     expect(h2.className).toContain('text-blue-500');
   });
+
+  test('adds bottom padding to title', () => {
+    ReactDOM.render(<SectionTitle title="Pad" />, container);
+    const h2 = container.querySelector('h2');
+    expect(h2.className).toContain('pb-[3px]');
+  });
 });


### PR DESCRIPTION
## Summary
- extend section title line downward by 3px via bottom padding
- test SectionTitle includes pb-[3px]

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689b404d9228832da57891b7dec624e4