### PR TITLE
Prevent add-photo helper flicker

### DIFF
--- a/src/VideotpushApp.jsx
+++ b/src/VideotpushApp.jsx
@@ -510,7 +510,7 @@ export default function VideotpushApp() {
       videoCallId ?
         React.createElement(VideoCallPage, { matchId: videoCallId, userId, onBack: () => setVideoCallId(null) }) :
         React.createElement(React.Fragment, null,
-          profiles.loaded && React.createElement(TaskButton, { profile: currentUser, onClick: handleTaskClick }),
+          profiles.loaded && React.createElement(TaskButton, { profile: currentUser, cachedPhotoURL, onClick: handleTaskClick }),
           tab==='discovery' && !viewProfile && (
             React.createElement(DailyDiscovery, { userId, profiles, onSelectProfile: selectProfile, ageRange, onOpenProfile: openProfileSettings })
           ),

--- a/src/components/TaskButton.jsx
+++ b/src/components/TaskButton.jsx
@@ -2,9 +2,11 @@ import React from 'react';
 import { getNextTask } from '../tasks.js';
 import { useT } from '../i18n.js';
 
-export default function TaskButton({ profile, onClick }) {
+export default function TaskButton({ profile, cachedPhotoURL, onClick }) {
   const t = useT();
-  const task = getNextTask(profile || {});
+  const prof = { ...(profile || {}) };
+  if (!prof.photoURL && cachedPhotoURL) prof.photoURL = cachedPhotoURL;
+  const task = getNextTask(prof);
   if (!task) return null;
   return React.createElement('button', {
     className: 'w-full bg-green-500 text-white font-bold p-2 mb-4',

--- a/src/components/TaskButton.test.jsx
+++ b/src/components/TaskButton.test.jsx
@@ -59,4 +59,15 @@ describe('TaskButton', () => {
     );
     expect(container.innerHTML).toBe('');
   });
+
+  test('uses cached photo when profile lacks photoURL', () => {
+    getNextTask.mockReturnValue(null);
+    ReactDOM.render(
+      <LanguageProvider value={{ lang: 'en', setLang: () => {} }}>
+        <TaskButton profile={{}} cachedPhotoURL="url123" onClick={() => {}} />
+      </LanguageProvider>,
+      container
+    );
+    expect(getNextTask).toHaveBeenCalledWith({ photoURL: 'url123' });
+  });
 });


### PR DESCRIPTION
## Summary
- Use cached photo URL in TaskButton to treat existing photos as present
- Pass cached photo from main app to TaskButton
- Add regression test covering cached photo usage

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689b44056930832d8bef742be5f70221