### PR TITLE
Reset title bar element positions

### DIFF
--- a/public/invite.html
+++ b/public/invite.html
@@ -10,7 +10,7 @@
 </head>
 <body class="bg-gradient-to-br from-pink-100 to-white min-h-screen flex items-center justify-center p-4">
   <div id="invite" class="bg-white/90 p-6 rounded-lg shadow-xl max-w-md w-full">
-    <h1 class="text-3xl font-bold text-pink-600 text-center mb-4 mt-0">RealDate</h1>
+    <h1 class="text-3xl font-bold text-pink-600 text-center mb-4">RealDate</h1>
     <div class="flex items-center mb-4">
       <div id="profile-pic" class="mr-4"></div>
       <h2 id="invite-text" class="text-xl font-bold text-pink-600"></h2>

--- a/src/VideotpushApp.jsx
+++ b/src/VideotpushApp.jsx
@@ -476,7 +476,7 @@ export default function VideotpushApp() {
       }
     },
       userId && React.createElement('div', {
-        className: 'absolute top-1/2 left-4 -translate-y-1/2 flex gap-4 mt-0.5'
+        className: 'absolute top-1/2 left-4 -translate-y-1/2 flex gap-4'
       },
         isAdminUser(auth.currentUser) && React.createElement('div', { className: 'relative cursor-pointer', onClick: openAdmin },
           React.createElement(Shield, { className: 'w-6 h-6 text-white' })
@@ -486,9 +486,9 @@ export default function VideotpushApp() {
           hasUnreadNotifications && React.createElement('span', { className: 'absolute -top-1 -right-2 bg-red-500 text-white text-xs rounded-full min-w-4 h-4 flex items-center justify-center px-1' }, unreadNotifications)
         )
       ),
-      React.createElement('span', { className: 'leading-none' }, 'RealDate'),
+      'RealDate',
       React.createElement('div', {
-        className: 'absolute top-1/2 right-16 -translate-y-1/2 flex items-center gap-1 mt-0.5'
+        className: 'absolute top-1/2 right-16 -translate-y-1/2 flex items-center gap-1'
       },
         React.createElement('span', { className: 'text-xs leading-none' }, `v${version}`),
         React.createElement(HelpCircle, {
@@ -497,7 +497,7 @@ export default function VideotpushApp() {
         })
       ),
       userId && React.createElement('div', {
-        className: 'absolute top-1/2 right-4 -translate-y-1/2 cursor-pointer mt-0.5',
+        className: 'absolute top-1/2 right-4 -translate-y-1/2 cursor-pointer',
         onClick: openProfileSettings
       },
         cachedPhotoURL ?


### PR DESCRIPTION
## Summary
- Remove custom top offsets from header icons and profile picture for default alignment
- Use plain title text and restore invite page header styling

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689b461fca98832d9c54fb906b9c67aa