### PR TITLE
Enable fullscreen mode to hide mobile status bar

### DIFF
--- a/public/manifest.json
+++ b/public/manifest.json
@@ -2,7 +2,7 @@
   "name": "RealDate",
   "short_name": "RealDate",
   "start_url": ".",
-  "display": "standalone",
+  "display": "fullscreen",
   "background_color": "#ffffff",
   "theme_color": "#ff4957",
   "description": "Swipe short videos and connect for a speed date",

--- a/src/index.js
+++ b/src/index.js
@@ -5,6 +5,19 @@ import VideotpushApp from './VideotpushApp.jsx';
 
 ReactDOM.render(React.createElement(VideotpushApp), document.getElementById('root'));
 
+// Attempt to enter fullscreen on first user interaction so the app fills the entire screen.
+function enableFullscreen() {
+  const el = document.documentElement;
+  const request = el.requestFullscreen || el.webkitRequestFullscreen || el.msRequestFullscreen;
+  if (request && !document.fullscreenElement) {
+    request.call(el).catch(() => {});
+  }
+}
+
+['click', 'touchend'].forEach(evt => {
+  document.addEventListener(evt, enableFullscreen, { once: true });
+});
+
 // >>> Service Worker registration with dynamic base path <<<
 if ('serviceWorker' in navigator) {
   window.addEventListener('load', () => {


### PR DESCRIPTION
## Summary
- Request fullscreen on first user interaction so the app fills the entire display
- Set PWA manifest display mode to `fullscreen` to remove OS status bar when installed

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689b5b20671c832daa036fa5da6925ee