### PR TITLE
Avoid blur on likes screen with no profiles

### DIFF
--- a/src/components/LikesScreen.jsx
+++ b/src/components/LikesScreen.jsx
@@ -89,6 +89,8 @@ export default function LikesScreen({ userId, onSelectProfile, onBack }) {
     setShowPurchase(false);
   };
 
+  const showBlur = !canSeeLikes && likedProfiles.length > 0;
+
   return React.createElement(Card,{className:'relative p-6 m-4 shadow-xl bg-white/90 flex flex-col'},
     React.createElement(SectionTitle,{title:t('likesTitle'), colorClass:'text-yellow-600', action: React.createElement(Button,{onClick:onBack, className:'bg-yellow-500 text-white'}, t('back'))}),
     React.createElement('p',{className:'mb-4 text-gray-500'},`${likedProfiles.length} profiler`),
@@ -96,7 +98,7 @@ export default function LikesScreen({ userId, onSelectProfile, onBack }) {
       React.createElement('p', {
         className: 'text-sm text-gray-600 mb-2'
       }, `${tierLabel} abonnement aktivt til ${new Date(currentUser.subscriptionExpires).toLocaleDateString('da-DK')}`),
-    React.createElement('div',{className: canSeeLikes ? 'flex-1' : 'flex-1 filter blur-sm pointer-events-none'},
+    React.createElement('div',{className: showBlur ? 'flex-1 filter blur-sm pointer-events-none' : 'flex-1'},
       React.createElement('ul',{className:'space-y-4'},
         likedProfiles.length ? likedProfiles.map(p => {
           const like = likes.find(l => l.userId === p.id);
@@ -133,7 +135,7 @@ export default function LikesScreen({ userId, onSelectProfile, onBack }) {
           React.createElement('li',{className:'text-center text-gray-500'},'Ingen har liket dig endnu')
       )
     ),
-    !canSeeLikes && React.createElement('span',{className:'absolute inset-0 m-auto text-yellow-500 text-sm font-semibold pointer-events-none flex items-center justify-center text-center px-2'},'Kr\u00e6ver Guld eller Platin'),
+    showBlur && React.createElement('span',{className:'absolute inset-0 m-auto text-yellow-500 text-sm font-semibold pointer-events-none flex items-center justify-center text-center px-2'},'Kr\u00e6ver Guld eller Platin'),
     !canSeeLikes && React.createElement(Button,{className:'mt-4 w-full bg-yellow-500 text-white',onClick:()=>setShowPurchase(true)},'Køb Guld eller Platin (gratis nu - betaling ikke implementeret)'),
     showPurchase && React.createElement(SubscriptionOverlay,{onClose:()=>setShowPurchase(false), onBuy:handlePurchase}),
     matchedProfile && React.createElement(MatchOverlay,{name:matchedProfile.name,onClose:()=>setMatchedProfile(null)}),


### PR DESCRIPTION
## Summary
- Prevent blur effect on likes screen when there are no liked profiles
- Hide upgrade overlay unless there are profiles to reveal

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689b655e0a94832d8d2dfcf9cd6be2d3