### PR TITLE
Show video preview during countdown and remove recording animation

### DIFF
--- a/src/components/SnapVideoRecorder.jsx
+++ b/src/components/SnapVideoRecorder.jsx
@@ -1,5 +1,4 @@
 import React, { useEffect, useRef, useState } from 'react';
-import { Camera as CameraIcon } from 'lucide-react';
 import { useT } from '../i18n.js';
 import { getCurrentDate } from '../utils.js';
 
@@ -10,7 +9,7 @@ export default function SnapVideoRecorder({ onCancel, onRecorded, maxDuration = 
   const timeoutRef = useRef();
   const videoRef = useRef();
   const [recording, setRecording] = useState(false);
-  const [progress, setProgress] = useState(0);
+  const [remaining, setRemaining] = useState(Math.round(maxDuration / 1000));
   const startTimeRef = useRef(null);
   const [music, setMusic] = useState(null);
   const [stage, setStage] = useState('intro');
@@ -70,10 +69,11 @@ export default function SnapVideoRecorder({ onCancel, onRecorded, maxDuration = 
     recorder.start();
     setRecording(true);
     startTimeRef.current = Date.now();
+    setRemaining(Math.round(maxDuration / 1000));
     const tick = () => {
       const elapsed = Date.now() - startTimeRef.current;
-      setProgress(Math.min(elapsed / maxDuration, 1));
-      if(elapsed >= maxDuration){
+      setRemaining(Math.max(0, Math.ceil((maxDuration - elapsed) / 1000)));
+      if (elapsed >= maxDuration) {
         stop();
       } else {
         timeoutRef.current = requestAnimationFrame(tick);
@@ -101,12 +101,7 @@ export default function SnapVideoRecorder({ onCancel, onRecorded, maxDuration = 
     onCancel && onCancel();
   };
 
-  const radius = 45;
-  const circumference = 2 * Math.PI * radius;
-  const offset = circumference * (1 - progress);
-  const remainingSeconds = startTimeRef.current
-    ? Math.max(0, Math.ceil((maxDuration - (Date.now() - startTimeRef.current)) / 1000))
-    : Math.round(maxDuration / 1000);
+  const remainingSeconds = remaining;
 
   if(stage === 'intro'){
     const clipLabel = clipIndex != null ? t(`clip${clipIndex+1}`) : '';
@@ -123,46 +118,21 @@ export default function SnapVideoRecorder({ onCancel, onRecorded, maxDuration = 
   }
 
   if(stage === 'countdown'){
-    return React.createElement('div', { className:'fixed inset-0 z-50 flex items-center justify-center bg-black/60' },
-      React.createElement('div', { className:'relative w-72 h-72' },
-        React.createElement('video', { ref: videoRef, className:'w-72 h-72 object-cover rounded', autoPlay:true, muted:true, playsInline:true }),
-        React.createElement('div', { className:'absolute inset-0 flex items-center justify-center text-white text-6xl font-bold' }, count),
-        React.createElement('div', { className:'absolute top-2 left-1/2 -translate-x-1/2 bg-black/50 text-white px-2 py-1 rounded text-sm' }, 'vent')
-      )
+    return React.createElement('div', { className:'fixed inset-0 z-50 flex flex-col items-center justify-center bg-black/60' },
+      React.createElement('div', { className:'text-white text-6xl font-bold mb-4' }, count),
+      React.createElement('video', { ref: videoRef, className:'w-72 h-72 object-cover rounded', autoPlay:true, muted:true, playsInline:true })
     );
   }
 
-  return React.createElement('div', { className:'fixed inset-0 z-50 flex flex-col items-center justify-center bg-black/60 relative' },
-    recording && React.createElement('div', { className:'absolute top-2 left-1/2 -translate-x-1/2 bg-black/50 text-white px-2 py-1 rounded text-sm' }, 'optager nu!'),
-    React.createElement('div', { className:'flex-1 flex items-center justify-center w-full' },
-      React.createElement('div', { className:'relative w-72 h-72' },
-        canAddMusic && React.createElement('label', { className:'absolute -top-10 left-1/2 -translate-x-1/2 bg-blue-500 text-white px-2 py-1 rounded cursor-pointer' },
-          t('addMusic'),
-          React.createElement('input', { type:'file', accept:'audio/*', className:'hidden', onChange:e=>setMusic(e.target.files[0]) })
-        ),
-        React.createElement('svg', { className:'absolute inset-0 w-full h-full rotate-animation pointer-events-none z-10', viewBox:'0 0 100 100' },
-          React.createElement('circle', { cx:'50', cy:'50', r:radius, stroke:'#9ca3af', strokeWidth:'8', fill:'none' }),
-          React.createElement('circle', {
-            cx:'50', cy:'50', r:radius, stroke:'#ff4895', strokeWidth:'8', fill:'none',
-            strokeDasharray:circumference, strokeDashoffset:offset
-          })
-        ),
-        React.createElement('button', { onClick: recording ? stop : start, className:'absolute inset-0 flex items-center justify-center text-pink-500 bg-white rounded-full border border-pink-500 w-20 h-20 z-20' },
-          React.createElement(CameraIcon, { className:'w-10 h-10' })
-        ),
-        React.createElement('div', { className:'absolute inset-0 flex items-center justify-center text-white text-4xl font-bold pointer-events-none' }, remainingSeconds),
-        React.createElement(
-          'button',
-          {
-            onClick: recording ? stop : cancel,
-            className: 'absolute -bottom-12 left-1/2 -translate-x-1/2 text-white bg-black/40 px-4 py-1 rounded'
-          },
-          t(recording ? 'stop' : 'cancel')
-        )
-      )
-    ),
-    React.createElement('div', { className:'flex-1 flex items-center justify-center w-full' },
-      React.createElement('video', { ref: videoRef, className:'w-72 h-72 object-cover rounded', autoPlay:true, muted:true, playsInline:true })
+  return React.createElement('div', { className:'fixed inset-0 z-50 flex flex-col items-center justify-center bg-black/60' },
+    React.createElement('div', { className:'text-white text-4xl font-bold mb-4' }, remainingSeconds),
+    React.createElement('div', { className:'relative' },
+      canAddMusic && React.createElement('label', { className:'absolute -top-10 left-1/2 -translate-x-1/2 bg-blue-500 text-white px-2 py-1 rounded cursor-pointer' },
+        t('addMusic'),
+        React.createElement('input', { type:'file', accept:'audio/*', className:'hidden', onChange:e=>setMusic(e.target.files[0]) })
+      ),
+      React.createElement('video', { ref: videoRef, className:'w-72 h-72 object-cover rounded', autoPlay:true, muted:true, playsInline:true }),
+      React.createElement('button', { onClick: recording ? stop : cancel, className:'absolute bottom-2 left-1/2 -translate-x-1/2 bg-black/40 text-white px-4 py-1 rounded' }, t(recording ? 'stop' : 'cancel'))
     )
   );
 }


### PR DESCRIPTION
## Summary
- Show camera preview below countdown so users see themselves before recording
- Simplify recording layout to display remaining time above video with stop button
- Remove rotating progress ring animation for a cleaner UI

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689b6c2c7a50832d933a0aba1dd0ed6b