### PR TITLE
Fix missing video preview during recording

### DIFF
--- a/src/components/SnapVideoRecorder.jsx
+++ b/src/components/SnapVideoRecorder.jsx
@@ -30,6 +30,14 @@ export default function SnapVideoRecorder({ onCancel, onRecorded, maxDuration = 
     };
   }, []);
 
+  useEffect(() => {
+    if ((stage === 'countdown' || stage === 'recording') && videoRef.current && streamRef.current) {
+      videoRef.current.srcObject = streamRef.current;
+      const p = videoRef.current.play();
+      if (p && p.catch) p.catch(() => {});
+    }
+  }, [stage]);
+
   const startCountdown = async () => {
     streamRef.current = await navigator.mediaDevices.getUserMedia({
       video: true,


### PR DESCRIPTION
## Summary
- Ensure SnapVideoRecorder maintains media stream after stage transitions so video preview remains visible while recording

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689b7efaadb0832da21dcc8e1663c221