### PR TITLE
Revised Danish market assumptions

### DIFF
--- a/docs/marketing/denmark-market-business-case.md
+++ b/docs/marketing/denmark-market-business-case.md
@@ -5,7 +5,7 @@
 - **Adults aged 18-65:** ~3.5 million
 - **Single adults (\~50% of adults):** ~1.75 million
 - **Smartphone penetration (\~90%):** ~1.58 million potential mobile users
-- **Dating app adoption among singles (\~60%):** ~0.95 million users familiar with dating apps
+- **Dating app adoption among singles (\~40%):** ~0.70 million users familiar with dating apps
 
 ## Subscription Tiers
 VideoTinder uses a freemium model with three paid membership levels that expand visibility and creative tools. Existing capabilities and planned extensions are summarized below.
@@ -34,53 +34,53 @@ Suggested pricing (DKK/month): **Silver 39**, **Gold 79**, **Platinum 139**
 
 ## Revenue Projection
 Assumptions:
-- Expected market penetration for VideoTinder: **10%** of dating app users -> **94,500 users**
-- Premium conversion: **10%** of VideoTinder users -> **9,450 paying subscribers**
+- Expected market penetration for VideoTinder: **10%** of dating app users -> **70,000 users**
+- Premium conversion: **10%** of VideoTinder users -> **7,000 paying subscribers**
 - Tier distribution: **60% Silver**, **30% Gold**, **10% Platinum**
 - App Store commission on subscriptions: **30%**
-- Average income pr user pr year: 10% premium conversion × 70% net subscription revenue (after Apple's fee) + banner ads (300 impressions/user/month × 7 DKK CPM) = **76.4 DKK** (≈12 USD)
+- Average income pr user pr year: 10% premium conversion × 70% net subscription revenue (after Apple's fee) + banner ads (300 impressions/user/month × 7 DKK CPM) = **69.6 DKK** (≈10 USD)
 
 Annual revenue:
-- Subscriptions: 5,670 Silver × 39 DKK × 12 + 2,835 Gold × 79 DKK × 12 + 945 Platinum × 139 DKK × 12 = **6,917,400 DKK**
-- Banner ads (bottom placement): 94,500 users × 300 impressions/user/month × 12 months ÷ 1,000 × 7 DKK ≈ **2,381,400 DKK**
-- **Total:** **9,298,800 DKK** (≈1.3M USD)
+- Subscriptions: 4,200 Silver × 39 DKK × 12 + 2,100 Gold × 79 DKK × 12 + 700 Platinum × 139 DKK × 12 = **5,124,000 DKK**
+- Banner ads (bottom placement): 70,000 users × 300 impressions/user/month × 12 months ÷ 1,000 × 7 DKK ≈ **1,764,000 DKK**
+- **Total:** **6,888,000 DKK** (≈0.99M USD)
 
 ## Cost Estimate
-- Infrastructure and support: **20 DKK** per user per year -> 94,500 × 20 = **1,890,000 DKK**
+- Infrastructure and support: **20 DKK** per user per year -> 70,000 × 20 = **1,400,000 DKK**
 - Marketing and user acquisition: **3,000,000 DKK**
 - Operational overhead (staff, legal, admin): **2,000,000 DKK**
-- Payment processing (Apple App Store 30% commission on subscriptions): **2,075,220 DKK**
+- Payment processing (Apple App Store 30% commission on subscriptions): **1,537,200 DKK**
 
-Total estimated annual cost: **8,965,220 DKK**
+Total estimated annual cost: **7,937,200 DKK**
 
 ## Break-even Analysis
-- Estimated annual profit: 9,298,800 − 8,965,220 = **333,580 DKK**
-- Break-even premium users: (6,890,000 − 2,381,400) ÷ (61 × 12 × 0.7) ≈ **8,800 paying users**
-- Break-even total users (at 10% premium conversion): **88,000 users**
+- Estimated annual profit: 6,888,000 − 7,937,200 = **−1,049,200 DKK**
+- Break-even premium users: (7,937,200 − 1,764,000) ÷ (61 × 12 × 0.7) ≈ **12,000 paying users**
+- Break-even total users (at 10% premium conversion): **120,000 users**
 
 ## First Three Years Outlook
 To reach the full penetration and conversion assumptions above, the first few years are expected to ramp up gradually.
 
 ### Year 1: Establish the product and gather feedback
-- **Penetration:** 2% of dating app users → **19,000 total users**
-- **Premium conversion:** 5% → **950 paying subscribers**
-- **Annual revenue:** 570 Silver, 285 Gold, 95 Platinum + banner ads (~478,800 DKK) → **1,174,200 DKK**
-- **Estimated costs:** infrastructure (380,000 DKK), marketing (1,000,000 DKK), overhead (1,500,000 DKK), Apple commission (208,620 DKK)
-- **Net result:** **−1,914,420 DKK** while investing in product-market fit
+- **Penetration:** 2% of dating app users → **14,000 total users**
+- **Premium conversion:** 5% → **700 paying subscribers**
+- **Annual revenue:** 420 Silver, 210 Gold, 70 Platinum + banner ads (~352,800 DKK) → **865,200 DKK**
+- **Estimated costs:** infrastructure (280,000 DKK), marketing (1,000,000 DKK), overhead (1,500,000 DKK), Apple commission (153,720 DKK)
+- **Net result:** **−2,068,520 DKK** while investing in product-market fit
 
 ### Year 2: Refine features and begin scaling
-- **Penetration:** 5% → **47,500 total users**
-- **Premium conversion:** 8% → **3,800 paying subscribers**
-- **Annual revenue:** 2,280 Silver, 1,140 Gold, 380 Platinum + banner ads (~1,197,000 DKK) → **3,978,600 DKK**
-- **Estimated costs:** infrastructure (950,000 DKK), marketing (2,000,000 DKK), overhead (1,800,000 DKK), Apple commission (834,480 DKK)
-- **Net result:** **−1,605,880 DKK**, moving toward break-even
+- **Penetration:** 5% → **35,000 total users**
+- **Premium conversion:** 8% → **2,800 paying subscribers**
+- **Annual revenue:** 1,680 Silver, 840 Gold, 280 Platinum + banner ads (~882,000 DKK) → **2,931,600 DKK**
+- **Estimated costs:** infrastructure (700,000 DKK), marketing (2,000,000 DKK), overhead (1,800,000 DKK), Apple commission (614,880 DKK)
+- **Net result:** **−2,183,280 DKK**, moving toward break-even
 
 ### Year 3: Expand reach and solidify monetization
-- **Penetration:** 8% → **76,000 total users**
-- **Premium conversion:** 9% → **6,840 paying subscribers**
-- **Annual revenue:** 4,104 Silver, 2,052 Gold, 684 Platinum + banner ads (~1,915,200 DKK) → **6,922,080 DKK**
-- **Estimated costs:** infrastructure (1,520,000 DKK), marketing (2,500,000 DKK), overhead (1,900,000 DKK), Apple commission (1,502,064 DKK)
-- **Net result:** **−499,984 DKK** as tiered pricing and ads drive profitability
+- **Penetration:** 8% → **56,000 total users**
+- **Premium conversion:** 9% → **5,040 paying subscribers**
+- **Annual revenue:** 3,024 Silver, 1,512 Gold, 504 Platinum + banner ads (~1,411,200 DKK) → **5,100,480 DKK**
+- **Estimated costs:** infrastructure (1,120,000 DKK), marketing (2,500,000 DKK), overhead (1,900,000 DKK), Apple commission (1,106,784 DKK)
+- **Net result:** **−1,526,304 DKK** as tiered pricing and ads drive profitability
 
 ## Strategic Considerations
 - High smartphone usage and a large single population support market entry


### PR DESCRIPTION
## Summary
- adjust Danish dating-app adoption estimate to 40% (~0.70M singles)
- recompute revenue, cost, and break-even figures using new base

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689ba24d136c832d92e4c0f40146a7ba