### PR TITLE
Replace call button with video call on chat screen

### DIFF
--- a/src/components/ChatScreen.jsx
+++ b/src/components/ChatScreen.jsx
@@ -207,7 +207,7 @@ export default function ChatScreen({ userId, onStartCall }) {
           React.createElement(Button, {
             className: 'bg-pink-500 text-white',
             onClick: () => onStartCall && onStartCall([userId, active.profileId].sort().join('-'))
-          }, incomingCall ? 'Deltag i opkald' : 'Foretag opkald')
+          }, incomingCall ? 'Deltag i opkald' : 'Foretag videoopkald')
         )
       )
     ) : (


### PR DESCRIPTION
## Summary
- update chat screen button label to "Foretag videoopkald"

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689c236dc090832db693edd9d201fade