### PR TITLE
Avoid flicker for profile task button

### DIFF
--- a/src/components/TaskButton.jsx
+++ b/src/components/TaskButton.jsx
@@ -4,7 +4,8 @@ import { useT } from '../i18n.js';
 
 export default function TaskButton({ profile, cachedPhotoURL, onClick }) {
   const t = useT();
-  const prof = { ...(profile || {}) };
+  if (!profile?.id) return null;
+  const prof = { ...profile };
   if (!prof.photoURL && cachedPhotoURL) prof.photoURL = cachedPhotoURL;
   const task = getNextTask(prof);
   if (!task) return null;

--- a/src/components/TaskButton.test.jsx
+++ b/src/components/TaskButton.test.jsx
@@ -26,7 +26,7 @@ describe('TaskButton', () => {
     getNextTask.mockReturnValue({ labelKey: 'taskAddProfilePicture' });
     ReactDOM.render(
       <LanguageProvider value={{ lang: 'en', setLang: () => {} }}>
-        <TaskButton profile={{}} onClick={() => {}} />
+        <TaskButton profile={{ id: 'p1' }} onClick={() => {}} />
       </LanguageProvider>,
       container
     );
@@ -40,7 +40,7 @@ describe('TaskButton', () => {
     const handleClick = jest.fn();
     ReactDOM.render(
       <LanguageProvider value={{ lang: 'en', setLang: () => {} }}>
-        <TaskButton profile={{}} onClick={handleClick} />
+        <TaskButton profile={{ id: 'p1' }} onClick={handleClick} />
       </LanguageProvider>,
       container
     );
@@ -53,7 +53,7 @@ describe('TaskButton', () => {
     getNextTask.mockReturnValue(null);
     ReactDOM.render(
       <LanguageProvider value={{ lang: 'en', setLang: () => {} }}>
-        <TaskButton profile={{}} onClick={() => {}} />
+        <TaskButton profile={{ id: 'p1' }} onClick={() => {}} />
       </LanguageProvider>,
       container
     );
@@ -64,10 +64,22 @@ describe('TaskButton', () => {
     getNextTask.mockReturnValue(null);
     ReactDOM.render(
       <LanguageProvider value={{ lang: 'en', setLang: () => {} }}>
-        <TaskButton profile={{}} cachedPhotoURL="url123" onClick={() => {}} />
+        <TaskButton profile={{ id: 'p1' }} cachedPhotoURL="url123" onClick={() => {}} />
       </LanguageProvider>,
       container
     );
-    expect(getNextTask).toHaveBeenCalledWith({ photoURL: 'url123' });
+    expect(getNextTask).toHaveBeenCalledWith({ id: 'p1', photoURL: 'url123' });
+  });
+
+  test('renders nothing when profile id missing', () => {
+    getNextTask.mockReturnValue({ labelKey: 'taskAddProfilePicture' });
+    ReactDOM.render(
+      <LanguageProvider value={{ lang: 'en', setLang: () => {} }}>
+        <TaskButton profile={{}} onClick={() => {}} />
+      </LanguageProvider>,
+      container
+    );
+    expect(getNextTask).not.toHaveBeenCalled();
+    expect(container.innerHTML).toBe('');
   });
 });


### PR DESCRIPTION
## Summary
- Skip rendering TaskButton until a profile id is available to prevent showing the green "add profile picture" task before data loads
- Update TaskButton tests to include profile ids and cover missing-id behavior

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689d7846ae08832db15a45acce0831cc