### PR TITLE
Redirect Realetten ad to Interest Chat

### DIFF
--- a/src/VideotpushApp.jsx
+++ b/src/VideotpushApp.jsx
@@ -453,6 +453,12 @@ export default function VideotpushApp() {
     return () => window.removeEventListener('showRealetten', handler);
   }, []);
 
+  useEffect(() => {
+    const handler = () => setTab('interestchat');
+    window.addEventListener('showInterestChat', handler);
+    return () => window.removeEventListener('showInterestChat', handler);
+  }, []);
+
 
   if(!loggedIn) return React.createElement(LanguageProvider, { value:{lang,setLang} },
     React.createElement(WelcomeScreen, { onLogin: (id, method = 'password') => {

--- a/src/components/AdBanner.jsx
+++ b/src/components/AdBanner.jsx
@@ -22,7 +22,7 @@ export default function AdBanner({ user }){
     {
       text: t('adRealettenText'),
       button: t('adRealettenButton'),
-      onClick: () => window.dispatchEvent(new CustomEvent('showRealetten'))
+      onClick: () => window.dispatchEvent(new CustomEvent('showInterestChat'))
     }
   ];
   const [idx, setIdx] = useState(0);

--- a/src/components/AdBanner.test.jsx
+++ b/src/components/AdBanner.test.jsx
@@ -56,5 +56,19 @@ describe('AdBanner', () => {
     ReactDOM.render(<AdBanner user={{ subscriptionTier: 'platinum' }} />, container);
     expect(container.innerHTML).toBe('');
   });
+
+  test('Realetten ad redirects to interest chat', () => {
+    act(() => { ReactDOM.render(<AdBanner user={{ subscriptionTier: 'free' }} />, container); });
+    act(() => { jest.advanceTimersByTime(10000); });
+    expect(container.textContent).toContain('Try Realetten');
+    const handler = jest.fn();
+    window.addEventListener('showInterestChat', handler);
+    const button = container.querySelector('button');
+    act(() => {
+      button.click();
+    });
+    expect(handler).toHaveBeenCalled();
+    window.removeEventListener('showInterestChat', handler);
+  });
 });
 


### PR DESCRIPTION
## Summary
- send Realetten ad clicks to the Interest Chat screen via new `showInterestChat` event
- handle the new event in `VideotpushApp`
- test that the Realetten ad opens Interest Chat

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689da422a584832daa225ef8ecb1265a