### PR TITLE
feat: use 'Forbind' for Realetten ad button

### DIFF
--- a/src/components/AdBanner.test.jsx
+++ b/src/components/AdBanner.test.jsx
@@ -11,7 +11,7 @@ jest.mock('../i18n.js', () => ({
       adInviteText: 'Invite a friend',
       adInviteButton: 'Invite',
       adRealettenText: 'Try Realetten',
-      adRealettenButton: 'Play',
+      adRealettenButton: 'Connect',
       tierSilver: 'Silver'
     };
     return map[key] || key;

--- a/src/i18n.js
+++ b/src/i18n.js
@@ -59,7 +59,7 @@ export const messages = {
   adInviteText:{ en:'Invite a friend to RealDate', da:'Inviter en ven til RealDate' },
   adInviteButton:{ en:'Invite', da:'Inviter' },
   adRealettenText:{ en:'Meet new people - video call up to 4 people', da:'Mød nye mennesker - videokald op til 4 personer' },
-  adRealettenButton:{ en:'Play', da:'Spil' },
+  adRealettenButton:{ en:'Connect', da:'Forbind' },
   tierSilver:{ en:'Silver', da:'Sølv' },
   tierGold:{ en:'Gold', da:'Guld' },
   tierPlatinum:{ en:'Platinum', da:'Platin' },


### PR DESCRIPTION
## Summary
- switch Realetten advertisement button label to "Forbind" / "Connect"
- align unit test mock with new translation

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689dc758edfc832dae28c137ff0b51a8