### PR TITLE
Translate testers guide to Danish

### DIFF
--- a/public/testers.html
+++ b/public/testers.html
@@ -5,28 +5,28 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover" />
   <meta name="theme-color" content="#ff4957" />
   <script src="https://cdn.tailwindcss.com"></script>
-  <title>RealDate Tester Guide</title>
+  <title>RealDate Testerguide</title>
   <link rel="stylesheet" href="../src/style.css" />
 </head>
 <body class="bg-gradient-to-br from-pink-100 to-white min-h-screen flex items-center justify-center p-4">
   <div class="bg-white/90 p-6 rounded-lg shadow-xl max-w-md w-full">
-    <h1 class="text-3xl font-bold text-pink-600 text-center mb-4">Tester Guide</h1>
-    <p class="mb-4 text-gray-700">Install RealDate on your phone for the best experience.</p>
-    <h2 class="text-xl font-semibold text-pink-600 mt-4 mb-2">Add to Home Screen</h2>
+    <h1 class="text-3xl font-bold text-pink-600 text-center mb-4">Testerguide</h1>
+    <p class="mb-4 text-gray-700">Installér RealDate på din telefon for den bedste oplevelse.</p>
+    <h2 class="text-xl font-semibold text-pink-600 mt-4 mb-2">Tilføj til hjemmeskærm</h2>
     <ol class="list-decimal list-inside text-left mb-4 space-y-1 text-gray-700">
-      <li>Open RealDate in your browser.</li>
-      <li>Tap the menu and choose <strong>Add to Home Screen</strong> or <strong>Install App</strong>.</li>
-      <li>Confirm the installation.</li>
+      <li>Åbn RealDate i din browser.</li>
+      <li>Tryk på menuen og vælg <strong>Tilføj til hjemmeskærm</strong> eller <strong>Installer app</strong>.</li>
+      <li>Bekræft installationen.</li>
     </ol>
-    <p class="mb-4 text-gray-700">When you open the installed app allow notifications to get updates and matches.</p>
-    <h2 class="text-xl font-semibold text-pink-600 mt-4 mb-2">Offline Test</h2>
+    <p class="mb-4 text-gray-700">Når du åbner den installerede app, skal du tillade notifikationer for at få opdateringer og matches.</p>
+    <h2 class="text-xl font-semibold text-pink-600 mt-4 mb-2">Offline test</h2>
     <ol class="list-decimal list-inside text-left mb-4 space-y-1 text-gray-700">
-      <li>Open a profile while online so the clips are cached.</li>
-      <li>Enable airplane mode and reopen the app from your home screen.</li>
-      <li>Verify that the previously viewed clips still play.</li>
-      <li>Disable airplane mode and send a chat message to confirm the app reconnects.</li>
+      <li>Åbn en profil, mens du er online, så klippene gemmes i cache.</li>
+      <li>Aktivér flytilstand og genåbn appen fra din startskærm.</li>
+      <li>Bekræft, at de tidligere viste klip stadig afspilles.</li>
+      <li>Deaktiver flytilstand og send en chatbesked for at bekræfte, at appen opretter forbindelse igen.</li>
     </ol>
-    <a href="./index.html" class="block bg-pink-500 text-white py-3 rounded-lg font-bold text-center">Back to RealDate</a>
+    <a href="./index.html" class="block bg-pink-500 text-white py-3 rounded-lg font-bold text-center">Tilbage til RealDate</a>
   </div>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- localize tester instructions page to Danish so participants can read the guide in their native language

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689dfe6c66d8832dbec5b3caa04d367f