### PR TITLE
Add greeting with newline to invite message

### DIFF
--- a/public/invite.html
+++ b/public/invite.html
@@ -13,7 +13,7 @@
     <h1 class="text-3xl font-bold text-pink-600 text-center mb-4">RealDate</h1>
     <div class="flex items-center mb-4">
       <div id="profile-pic" class="mr-4"></div>
-      <h2 id="invite-text" class="text-xl font-bold text-pink-600"></h2>
+      <h2 id="invite-text" class="text-xl font-bold text-pink-600 whitespace-pre-line"></h2>
     </div>
     <p class="mb-4">Få 3 måneders <strong>gratis</strong> premium adgang med disse fordele:</p>
     <ul class="list-disc list-inside text-left mb-6 space-y-1">

--- a/src/invite.js
+++ b/src/invite.js
@@ -12,7 +12,7 @@ async function loadInvite() {
     if (!snap.exists()) return;
     const profile = snap.data();
     const inviteText = document.getElementById('invite-text');
-    const greeting = recipient ? `${recipient}, ` : '';
+    const greeting = recipient ? `Hej ${recipient},\n` : '';
     inviteText.textContent = gift
       ? `${greeting}${profile.name} giver dig gratis premium i 3 måneder`
       : `${greeting}${profile.name} inviterer dig til RealDate`;


### PR DESCRIPTION
## Summary
- greet invite recipients with "Hej <name>" and line break before invite message
- preserve newline in invite text via Tailwind `whitespace-pre-line`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689dff1a406c832d9d8595b0a69a864d