### PR TITLE
Translate commercial page to Danish

### DIFF
--- a/public/commercial.html
+++ b/public/commercial.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>RealDate - Experience Real Connections</title>
+  <title>RealDate - Oplev ægte forbindelser</title>
   <style>
     body {
       font-family: Arial, sans-serif;
@@ -64,25 +64,25 @@
 </head>
 <body>
   <header>
-    <h1>Welcome to RealDate</h1>
-    <p>Because genuine connections can't be rushed.</p>
-    <a class="cta" href="https://nyhave.github.io/VideoTinder/">Try RealDate today</a>
+    <h1>Velkommen til RealDate</h1>
+    <p>Fordi ægte forbindelser ikke kan forhastes.</p>
+    <a class="cta" href="https://nyhave.github.io/VideoTinder/">Prøv RealDate i dag</a>
   </header>
   <section>
-    <h2>Why RealDate?</h2>
-    <p>RealDate introduces a slower, more thoughtful approach to online dating. Instead of endless swiping, we give you space to reflect and truly connect.</p>
+    <h2>Hvorfor RealDate?</h2>
+    <p>RealDate introducerer en langsommere og mere eftertænksom tilgang til online dating. I stedet for at swipe uendeligt giver vi dig plads til at reflektere og skabe ægte forbindelser.</p>
     <div class="features">
       <div class="feature">
-        <h3>Daily Profiles</h3>
-        <p>Meet a handful of curated profiles every day to keep dating meaningful.</p>
+        <h3>Daglige profiler</h3>
+        <p>Mød en håndfuld udvalgte profiler hver dag for at gøre dating meningsfuld.</p>
       </div>
       <div class="feature">
-        <h3>Reflection Notes</h3>
-        <p>Record your impressions and feelings after each video interaction.</p>
+        <h3>Refleksionsnotater</h3>
+        <p>Nedskriv dine indtryk og følelser efter hver videointeraktion.</p>
       </div>
       <div class="feature">
-        <h3>Build Real Relationships</h3>
-        <p>Our matching fosters genuine, lasting connections and reduces loneliness.</p>
+        <h3>Opbyg ægte relationer</h3>
+        <p>Vores matchning fremmer ægte, varige forbindelser og mindsker ensomhed.</p>
       </div>
     </div>
   </section>


### PR DESCRIPTION
## Summary
- translate commercial landing page text into Danish for localized experience

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689e0636e7f4832db6eb11ab9dfd4488