### PR TITLE
Turn commercial CTA into pulsing button

### DIFF
--- a/public/commercial.html
+++ b/public/commercial.html
@@ -27,6 +27,7 @@
       text-decoration: none;
       padding: 0.75rem 1.5rem;
       font-size: 1.2rem;
+      border: none;
       border-radius: 4px;
       cursor: pointer;
       transition: transform 0.2s, box-shadow 0.2s;
@@ -66,7 +67,7 @@
   <header>
     <h1>Velkommen til RealDate</h1>
     <p>Fordi ægte forbindelser ikke kan forhastes.</p>
-    <a class="cta" href="https://nyhave.github.io/VideoTinder/">Prøv RealDate i dag</a>
+    <button class="cta" onclick="window.location.href='https://nyhave.github.io/VideoTinder/'">Prøv RealDate i dag</button>
   </header>
   <section>
     <h2>Hvorfor RealDate?</h2>


### PR DESCRIPTION
## Summary
- Convert "Prøv RealDate i dag" link to a button that redirects to the app
- Style CTA button to remove default borders while retaining pulse animation

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689e17dbc920832dab21f0d7a8f7cc4d