### PR TITLE
Remove recording titles and add retake reminder

### DIFF
--- a/src/components/ProfileSettings.jsx
+++ b/src/components/ProfileSettings.jsx
@@ -495,8 +495,7 @@ export default function ProfileSettings({ userId, ageRange, onChangeAgeRange, pu
           url && publicView && reportMode && React.createElement(Flag, {
             className: 'w-5 h-5 text-red-500 absolute top-1 right-1 cursor-pointer',
             onClick: () => setReportItem({ clipURL: url })
-          }),
-          React.createElement('p', { className:'mt-1 text-xs text-center' }, t(`clip${i+1}`))
+          })
         );
       })
     ),

--- a/src/components/SnapVideoRecorder.jsx
+++ b/src/components/SnapVideoRecorder.jsx
@@ -112,11 +112,9 @@ export default function SnapVideoRecorder({ onCancel, onRecorded, maxDuration = 
   const remainingSeconds = remaining;
 
   if(stage === 'intro'){
-    const clipLabel = clipIndex != null ? t(`clip${clipIndex+1}`) : '';
-    const seconds = Math.round(maxDuration/1000);
     return React.createElement('div', { className:'fixed inset-0 z-50 flex items-center justify-center bg-black/60' },
       React.createElement('div', { className:'bg-white p-4 rounded max-w-sm text-center' },
-        React.createElement('p', { className:'mb-4' }, t('recordIntro').replace('{clip}', clipLabel).replace('{seconds}', seconds)),
+        React.createElement('p', { className:'mb-4' }, t('recordIntro')),
         React.createElement('div', { className:'flex justify-center gap-2' },
           React.createElement('button', { onClick: startCountdown, className:'bg-pink-500 text-white px-4 py-2 rounded' }, t('ok')),
           React.createElement('button', { onClick: cancel, className:'bg-gray-200 text-gray-700 px-4 py-2 rounded' }, t('cancel'))

--- a/src/i18n.js
+++ b/src/i18n.js
@@ -94,16 +94,13 @@ export const messages = {
   registerCtaDesc:{ en:"Create a profile to get started", da:"Opret en profil for at komme i gang", sv:"Skapa en profil för att komme igång", es:"Crea un perfil para comenzar", fr:"Créez un profil pour commencer", de:"Erstelle ein Profil, um zu starten" },
   videoCtaTitle:{ en:'Add video clips', da:'Tilføj videoer', sv:'Lägg till videoklipp', es:'Añadir videoclips', fr:'Ajouter des clips vidéo', de:'Videoclips hinzufügen' },
   videoCtaDesc:{ en:'Upload short clips to showcase yourself', da:'Upload korte videoklip for at vise dig frem', sv:'Ladda upp korta klipp för att visa dig', es:'Sube clips cortos para mostrarte', fr:'Téléchargez de courts clips pour vous présenter', de:'Lade kurze Clips hoch, um dich zu zeigen' },
-  clip1:{ en:'Introduction', da:'Introduktion', sv:'Introduktion', es:'Introducción', fr:'Introduction', de:'Einführung' },
-  clip2:{ en:'Biggest interest', da:'Største interesse', sv:'Största intresse', es:'Mayor interés', fr:'Plus grand intérêt', de:'Größtes Interesse' },
-  clip3:{ en:'Free', da:'Fri', sv:'Fritt', es:'Libre', fr:'Libre', de:'Frei' },
   recordIntro:{
-    en:'You are about to record {clip}. You have {seconds} seconds. A countdown will appear before recording starts.',
-    da:'Du skal til at optage {clip}. Du har {seconds} sekunder. Der kommer en nedtælling før optagelsen starter.',
-    sv:'Du ska spela in {clip}. Du har {seconds} sekunder. En nedräkning visas innan inspelningen startar.',
-    es:'Vas a grabar {clip}. Tienes {seconds} segundos. Aparecerá una cuenta regresiva antes de que comience la grabación.',
-    fr:'Vous allez enregistrer {clip}. Vous avez {seconds} secondes. Un compte à rebours apparaîtra avant que l\'enregistrement ne commence.',
-    de:'Du wirst {clip} aufnehmen. Du hast {seconds} Sekunden. Ein Countdown erscheint, bevor die Aufnahme startet.'
+    en:'You can retake the video as many times as you want.',
+    da:'Du kan tage videoen om lige så mange gange du vil.',
+    sv:'Du kan ta om videon så många gånger du vill.',
+    es:'Puede volver a tomar el video tantas veces como desee.',
+    fr:'Vous pouvez reprendre la vidéo autant de fois que vous le souhaitez.',
+    de:'Sie können das Video so oft wiederholen, wie Sie möchten.'
   },
 inviteFriend:{ en:'Invite a friend', da:'Inviter en ven', sv:'Bjud in en vän', es:'Invitar a un amigo', fr:'Inviter un ami', de:'Einen Freund einladen' },
 inviteDesc:{ en:'Share the link below to invite others to RealDate', da:'Del linket nedenfor for at invitere andre til RealDate', sv:'Dela länken nedan för at bjuda in andra til RealDate', es:'Comparte el enlace de abajo para invitar a otros a RealDate', fr:"Partagez le lien ci-dessous pour inviter d'autres sur RealDate", de:'Teile den Link unten, um andere zu RealDate einzuladen' },


### PR DESCRIPTION
## Summary
- Remove clip titles from profile settings and recording flow
- Replace recording intro with message about unlimited retakes
- Update translations for new recording popup

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689ec31263d4832da68b7214c2bbb611