### PR TITLE
Handle Google sign-in popup errors by using existing user

### DIFF
--- a/src/firebase.js
+++ b/src/firebase.js
@@ -149,6 +149,10 @@ export async function signInWithGoogle() {
   } catch (err) {
     await logEvent('signInWithGoogle error', { error: err.message });
     console.error('Google sign-in failed', err);
+    if (auth.currentUser) {
+      await logEvent('signInWithGoogle recovered', { uid: auth.currentUser.uid });
+      return { user: auth.currentUser };
+    }
     throw err;
   }
 }


### PR DESCRIPTION
## Summary
- Allow Google sign-in to succeed if authentication completes but popup reports an error

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689ec5789f58832d99875a861dd333e5