### PR TITLE
Use i18n for verification badge

### DIFF
--- a/src/components/VerificationBadge.jsx
+++ b/src/components/VerificationBadge.jsx
@@ -1,9 +1,11 @@
 import React from 'react';
 import { CheckCircle } from 'lucide-react';
+import { useT } from '../i18n.js';
 
 export default function VerificationBadge(){
+  const t = useT();
   return React.createElement('span', { className:'flex items-center gap-1 text-green-600 text-xs' },
     React.createElement(CheckCircle, { className:'w-4 h-4' }),
-    'Verified'
+    t('verified')
   );
 }

--- a/src/i18n.js
+++ b/src/i18n.js
@@ -18,6 +18,7 @@ export const messages = {
   chatIntroText:{ en:'Chats appear when profiles match. Enable notifications to get alerted when there is a match.', da:'Chats vises, når profiler matcher. Aktiver notifikationer for at få besked, når der er et match.', sv:'Chattar visas när profiler matchar. Aktivera aviseringar för att få en notis när du får en match.', es:'Los chats aparecen cuando los perfiles coinciden. Activa las notificaciones para recibir un aviso cuando haya un match.', fr:'Les discussions apparaissent lorsque les profils correspondent. Activez les notifications pour être alerté en cas de match.', de:'Chats erscheinen, wenn Profile übereinstimmen. Aktiviere Benachrichtigungen, um bei einem Match benachrichtigt zu werden.' },
   enableNotifications:{ en:'Enable notifications', da:'Aktiver notifikationer', sv:'Aktivera aviseringar', es:'Activar notificaciones', fr:'Activer les notifications', de:'Benachrichtigungen aktivieren' },
   seen: { en:'Seen', da:'Set', sv:'Sett', es:'Visto', fr:'Vu', de:'Gesehen' },
+  verified: { en:'Verified', da:'Bekræftet', sv:'Verifierad', es:'Verificado', fr:'Vérifié', de:'Verifiziert' },
   checkInTitle:{ en:'Daily reflection', da:'Dagens refleksion', sv:'Dagens reflektion', es:'Reflexión diaria', fr:'Réflexion du jour', de:'Tägliche Reflexion' },
   profile:{ en:'Profile', da:'Profil', sv:'Profil', es:'Perfil', fr:'Profil', de:'Profil' },
   about:{ en:'About RealDate', da:'Om RealDate', sv:'Om RealDate', es:'Acerca de RealDate', fr:'À propos de RealDate', de:'Über RealDate' },


### PR DESCRIPTION
## Summary
- translate verification badge using the shared i18n messages
- add "Bekræftet" Danish string and equivalents for other languages

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689ec71c9aa8832db7077a8a83858709