### PR TITLE
feat: open app on discovery tab by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,7 +98,7 @@ This approach keeps the codebase unified while still allowing environment‑spec
 
 ## Manual Function Testing
 
-The admin page contains a dedicated function test screen. Tests are organized in modules so each area can be completed separately. See [docs/developers/function-test-modules.md](docs/developers/function-test-modules.md) for an overview of the modules and how to submit results.
+The admin page contains a dedicated function test screen. Tests are organized in modules so each area can be completed separately. To access the admin interface, open the app with `?tab=admin` in the URL. See [docs/developers/function-test-modules.md](docs/developers/function-test-modules.md) for an overview of the modules and how to submit results.
 
 ## Automated Screenshots
 

--- a/src/VideotpushApp.jsx
+++ b/src/VideotpushApp.jsx
@@ -71,7 +71,7 @@ export default function VideotpushApp() {
   });
   const [ageRange,setAgeRange]=useState([35,55]);
   const params = new URLSearchParams(window.location.search);
-  const initialTab = params.get('tab') || 'admin';
+  const initialTab = params.get('tab') || 'discovery';
   const [tab,setTab]=useState(initialTab);
   const [viewProfile,setViewProfile]=useState(null);
   const [returnTab,setReturnTab]=useState('discovery');


### PR DESCRIPTION
## Summary
- default to opening the discovery tab when no tab query parameter is provided
- document how to access admin interface via `?tab=admin`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689f2c638508832daf907dc5a2d21f20