### PR TITLE
feat: show subscription info in settings card

### DIFF
--- a/src/components/ProfileSettings.jsx
+++ b/src/components/ProfileSettings.jsx
@@ -639,29 +639,29 @@ export default function ProfileSettings({ userId, ageRange, onChangeAgeRange, pu
             action: publicView && !isOwnProfile && activeNow ? React.createElement('span', { className: 'text-sm text-green-600 font-medium' }, t('activeNow')) : null
           })
         ),
-      isOwnProfile && !publicView && !editInfo && profile.email && React.createElement('p', { className:'text-center text-sm text-gray-600 mt-1' }, profile.email),
-      !publicView && profile.subscriptionExpires && React.createElement('p', {
-        className: 'text-center text-sm mt-2 flex items-center justify-center gap-1 ' + (subscriptionActive ? 'text-green-600' : 'text-red-500')
-      },
-        !subscriptionActive && React.createElement(PremiumIcon, null),
-        (() => {
-          const tierLabel = {
-            silver: t('tierSilver'),
-            gold: t('tierGold'),
-            platinum: t('tierPlatinum')
-          }[profile.subscriptionTier] || 'Premium';
-          const date = new Date(profile.subscriptionExpires).toLocaleDateString('da-DK');
-          return subscriptionActive
-            ? `${tierLabel} abonnement aktivt til ${date}`
-            : `${tierLabel} abonnement udløb ${date}`;
-        })()
-      ),
-        !publicView && profile.subscriptionPurchased && React.createElement('p', {
-          className: 'text-center text-sm text-gray-500'
-        }, `Købt ${new Date(profile.subscriptionPurchased).toLocaleDateString('da-DK')}`)
-      ),
-      !publicView && React.createElement(Card, { className:'p-6 m-4 shadow-xl bg-white/90' },
+      isOwnProfile && !publicView && !editInfo && profile.email && React.createElement('p', { className:'text-center text-sm text-gray-600 mt-1' }, profile.email)
+    ),
+    !publicView && React.createElement(Card, { className:'p-6 m-4 shadow-xl bg-white/90' },
         React.createElement(SectionTitle, { title: t('settings') }),
+        profile.subscriptionExpires && React.createElement('p', {
+          className: 'text-center text-sm mt-2 flex items-center justify-center gap-1 ' + (subscriptionActive ? 'text-green-600' : 'text-red-500')
+        },
+          !subscriptionActive && React.createElement(PremiumIcon, null),
+          (() => {
+            const tierLabel = {
+              silver: t('tierSilver'),
+              gold: t('tierGold'),
+              platinum: t('tierPlatinum')
+            }[profile.subscriptionTier] || 'Premium';
+            const date = new Date(profile.subscriptionExpires).toLocaleDateString('da-DK');
+            return subscriptionActive
+              ? `${tierLabel} abonnement aktivt til ${date}`
+              : `${tierLabel} abonnement udløb ${date}`;
+          })()
+        ),
+        profile.subscriptionPurchased && React.createElement('p', {
+          className: 'text-center text-sm text-gray-500'
+        }, `Købt ${new Date(profile.subscriptionPurchased).toLocaleDateString('da-DK')}`),
         subscriptionActive && profile.subscriptionTier === 'platinum' && React.createElement('label', { className:'flex items-center gap-2 mt-2' },
           React.createElement('input', { type:'checkbox', checked: profile.incognito || false, onChange: async e => { const checked = e.target.checked; await updateDoc(doc(db,'profiles', userId), { incognito: checked }); setProfile({ ...profile, incognito: checked }); } }),
           t('incognitoMode')


### PR DESCRIPTION
## Summary
- move subscription details into settings card on profile page

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689f2d9affd8832da8159cc32a8df7e4