### PR TITLE
Use iPhone 15 ringtone for chat call alerts

### DIFF
--- a/src/components/AdminScreen.jsx
+++ b/src/components/AdminScreen.jsx
@@ -189,7 +189,7 @@ export default function AdminScreen({ onOpenStats, onOpenBugReports, onOpenMatch
   };
 
   const testRingtone = () => {
-    const audio = new Audio('/reveal.mp3');
+    const audio = new Audio('/iphone_15.mp3');
     audio.play().catch(() => {});
   };
 

--- a/src/components/ChatScreen.jsx
+++ b/src/components/ChatScreen.jsx
@@ -71,7 +71,7 @@ export default function ChatScreen({ userId, onStartCall }) {
 
   useEffect(() => {
     if (!ringAudioRef.current) {
-      ringAudioRef.current = new Audio('/reveal.mp3');
+      ringAudioRef.current = new Audio('/iphone_15.mp3');
       ringAudioRef.current.loop = true;
     }
     const audio = ringAudioRef.current;


### PR DESCRIPTION
## Summary
- Ring incoming video calls in chat with new `iphone_15.mp3`
- Update admin ringtone test to play the same audio clip

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689f85a8e994832d8d3d5075cc8b1864