### PR TITLE
Ensure ringtone audio copied to build output

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "start": "npx serve .",
     "dev": "parcel public/index.html",
     "prebuild": "node scripts/bump-version.js",
-    "build": "parcel build public/index.html public/invite.html public/testers.html public/commercial.html --dist-dir dist --no-source-maps --public-url ./ && cp public/service-worker.js dist/",
+    "build": "parcel build public/index.html public/invite.html public/testers.html public/commercial.html --dist-dir dist --no-source-maps --public-url ./ && cp public/service-worker.js dist/ && cp public/*.mp3 dist/",
     "test": "jest",
     "screenshots": "node scripts/capture-screens.js"
   },


### PR DESCRIPTION
## Summary
- Include mp3 ringtone files in parcel build output by copying public/*.mp3 to dist

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689f87ae3030832d884f40886dc6200f