### PR TITLE
Move back button above public profile title

### DIFF
--- a/src/components/ProfileSettings.jsx
+++ b/src/components/ProfileSettings.jsx
@@ -517,6 +517,7 @@ export default function ProfileSettings({ userId, ageRange, onChangeAgeRange, pu
             onClick: onLogout
           }, t('logout'))
         ),
+        publicView && onBack && React.createElement(Button, { className: 'mb-4 bg-pink-500 text-white', onClick: onBack }, 'Tilbage'),
         React.createElement(SectionTitle, { title: t('yourProfileTitle'), action:
           React.createElement('div', { className:'flex items-center gap-2' },
             React.createElement('span', { className:'text-sm text-blue-500 underline cursor-pointer', onClick: () => setShowHelp(true) }, t('dailyHelpLabel')),
@@ -526,8 +527,7 @@ export default function ProfileSettings({ userId, ageRange, onChangeAgeRange, pu
             })
           )
         }),
-      publicView && onBack && React.createElement(Button, { className: 'mb-4 bg-pink-500 text-white', onClick: onBack }, 'Tilbage'),
-      React.createElement('div', { className:'flex items-center mb-4 gap-4' },
+        React.createElement('div', { className:'flex items-center mb-4 gap-4' },
         React.createElement('div', { className:`flex flex-col items-center ${highlightPhoto ? 'ring-4 ring-green-500' : ''}` },
           profile.photoURL ?
             React.createElement('img', {


### PR DESCRIPTION
## Summary
- Reposition back button above title when viewing public profile

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689fb24d92a0832dac225c738daccc0b