### PR TITLE
Add FAQ screen and profile link

### DIFF
--- a/src/VideotpushApp.jsx
+++ b/src/VideotpushApp.jsx
@@ -18,6 +18,7 @@ import ActiveCallsScreen from './components/ActiveCallsScreen.jsx';
 import ActiveGroupCallsScreen from './components/ActiveGroupCallsScreen.jsx';
 import ReportedContentScreen from './components/ReportedContentScreen.jsx';
 import AboutScreen from './components/AboutScreen.jsx';
+import FaqScreen from './components/FaqScreen.jsx';
 import FunctionTestScreen from './components/FunctionTestScreen.jsx';
 import RevealTestScreen from './components/RevealTestScreen.jsx';
 import TextLogScreen from './components/TextLogScreen.jsx';
@@ -566,6 +567,7 @@ export default function VideotpushApp() {
             onChangeAgeRange: setAgeRange,
             onViewPublicProfile: viewOwnPublicProfile,
             onOpenAbout: ()=>setTab('about'),
+            onOpenFaq: ()=>setTab('faq'),
             onLogout: logout,
             activeTask,
             taskTrigger: taskClicks
@@ -587,7 +589,8 @@ export default function VideotpushApp() {
           tab==='recentlogins' && React.createElement(RecentLoginsScreen, { onBack: ()=>setTab('admin') }),
           tab==='graphics' && React.createElement(GraphicsElementsScreen, { onBack: ()=>setTab('admin') }),
           tab==='notifications' && React.createElement(NotificationsScreen, { notifications, onBack: ()=>setTab(returnTab) }),
-          tab==='about' && React.createElement(AboutScreen, { userId })
+          tab==='about' && React.createElement(AboutScreen, { userId }),
+          tab==='faq' && React.createElement(FaqScreen, { onBack: ()=>setTab('profile') })
         )
     ),
     React.createElement('div', {

--- a/src/components/FaqScreen.jsx
+++ b/src/components/FaqScreen.jsx
@@ -1,0 +1,20 @@
+import React from 'react';
+import { Card } from './ui/card.js';
+import { Button } from './ui/button.js';
+import SectionTitle from './SectionTitle.jsx';
+import { ArrowLeft } from 'lucide-react';
+import { useT } from '../i18n.js';
+
+export default function FaqScreen({ onBack }) {
+  const t = useT();
+  const action = React.createElement(Button, { className: 'flex items-center gap-1', onClick: onBack },
+    React.createElement(ArrowLeft, { className: 'w-4 h-4' }), t('back'));
+  return React.createElement(Card, { className: 'p-6 m-4 shadow-xl bg-white/90' },
+    React.createElement(SectionTitle, { title: t('faq'), action }),
+    React.createElement('p', { className: 'mb-4 text-gray-700' }, t('faqIntro')),
+    React.createElement('ul', { className: 'list-disc pl-5 text-gray-700' },
+      React.createElement('li', null, 'Hvordan fungerer RealDate? RealDate bruger korte videoklip til at vise energi og personlighed.'),
+      React.createElement('li', null, 'Hvordan kontakter jeg support? Brug knappen "Fejlmeld" på Om RealDate-siden.')
+    )
+  );
+}

--- a/src/components/ProfileSettings.jsx
+++ b/src/components/ProfileSettings.jsx
@@ -24,7 +24,7 @@ import VerificationBadge from './VerificationBadge.jsx';
 import { showLocalNotification, sendWebPushToProfile } from '../notifications.js';
 import InfoOverlay from './InfoOverlay.jsx';
 
-export default function ProfileSettings({ userId, ageRange, onChangeAgeRange, publicView = false, onViewPublicProfile = () => {}, onOpenAbout = () => {}, onLogout = null, viewerId = userId, onBack, activeTask, taskTrigger = 0 }) {
+export default function ProfileSettings({ userId, ageRange, onChangeAgeRange, publicView = false, onViewPublicProfile = () => {}, onOpenAbout = () => {}, onOpenFaq = () => {}, onLogout = null, viewerId = userId, onBack, activeTask, taskTrigger = 0 }) {
   const [profile,setProfile]=useState(null);
   const t = useT();
   const photoRef = useRef();
@@ -759,7 +759,11 @@ export default function ProfileSettings({ userId, ageRange, onChangeAgeRange, pu
         React.createElement(Button, {
           className: 'mt-4 w-full bg-pink-500 text-white',
           onClick: onOpenAbout
-        }, t('about'))
+        }, t('about')),
+        React.createElement(Button, {
+          className: 'mt-2 w-full bg-indigo-500 text-white',
+          onClick: onOpenFaq
+        }, t('faq'))
       ),
     !publicView && React.createElement(Button, {
         className: 'mt-6 w-full bg-red-500 text-white',

--- a/src/i18n.js
+++ b/src/i18n.js
@@ -22,6 +22,8 @@ export const messages = {
   checkInTitle:{ en:'Daily reflection', da:'Dagens refleksion', sv:'Dagens reflektion', es:'Reflexión diaria', fr:'Réflexion du jour', de:'Tägliche Reflexion' },
   profile:{ en:'Profile', da:'Profil', sv:'Profil', es:'Perfil', fr:'Profil', de:'Profil' },
   about:{ en:'About RealDate', da:'Om RealDate', sv:'Om RealDate', es:'Acerca de RealDate', fr:'À propos de RealDate', de:'Über RealDate' },
+  faq:{ en:'FAQ', da:'Hyppige spørgsmål' },
+  faqIntro:{ en:'Find answers to common questions about RealDate.', da:'Find svar på de mest hyppige spørgsmål om RealDate.' },
   loadMore:{ en:'Load more', da:'Hent flere...', sv:'Hämta fler...', es:'Cargar más', fr:'Charger plus', de:'Mehr laden' },
   noProfiles:{ en:'No profiles found', da:'Ingen profiler fundet', sv:'Inga profiler', es:'No hay perfiles', fr:'Aucun profil', de:'Keine Profile gefunden'},
   ok:{ en:'OK', da:'OK', sv:'OK', es:'OK', fr:'OK', de:'OK' },


### PR DESCRIPTION
## Summary
- Add a new FAQ screen with basic common questions and back navigation
- Include FAQ button in profile settings to open the FAQ page
- Localize FAQ strings in i18n and wire up new tab

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a01fbbc078832d8bf4967100b1db03