### PR TITLE
Fix quiet video call ringtone

### DIFF
--- a/src/components/ChatScreen.jsx
+++ b/src/components/ChatScreen.jsx
@@ -79,7 +79,8 @@ export default function ChatScreen({ userId, onStartCall }) {
     volumeTimeouts.current.forEach(clearTimeout);
     volumeTimeouts.current = [];
     if (incomingCall) {
-      const steps = [0.5, 0.6, 0.7, 0.8, 0.7, 1];
+      const steps = [0.8, 0.9, 1];
+      audio.currentTime = 0;
       audio.volume = steps[0];
       audio.play().catch(() => {});
       steps.slice(1).forEach((v, i) => {


### PR DESCRIPTION
## Summary
- Increase starting volume for incoming call ringtone and reset playback time so the ringtone plays reliably

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a032802884832d9ccc6ee9b0aada6b