### PR TITLE
feat: allow liking videos

### DIFF
--- a/src/components/LikesScreen.jsx
+++ b/src/components/LikesScreen.jsx
@@ -34,7 +34,7 @@ export default function LikesScreen({ userId, onSelectProfile, onBack }) {
     platinum: t('tierPlatinum')
   }[tier] || 'Premium';
 
-  const [activeVideo, setActiveVideo] = useState(null);
+  const [activeProfile, setActiveProfile] = useState(null);
   const [matchedProfile, setMatchedProfile] = useState(null);
   const toggleLike = async profileId => {
     const likeId = `${userId}-${profileId}`;
@@ -126,7 +126,7 @@ export default function LikesScreen({ userId, onSelectProfile, onBack }) {
               )
             ),
             React.createElement('div',{className:'flex gap-2 mt-2'},
-              React.createElement(Button,{size:'sm',variant:'outline',className:'flex items-center gap-1',onClick:e=>{e.stopPropagation();const url=(p.videoClips&&p.videoClips[0])?(p.videoClips[0].url||p.videoClips[0]):null;if(url)setActiveVideo(url);}},
+              React.createElement(Button,{size:'sm',variant:'outline',className:'flex items-center gap-1',onClick:e=>{e.stopPropagation();const url=(p.videoClips&&p.videoClips[0])?(p.videoClips[0].url||p.videoClips[0]):null;if(url)setActiveProfile({id:p.id,url});}},
                 React.createElement(PlayCircle,{className:'w-5 h-5'}),'Afspil'
               )
             )
@@ -139,6 +139,12 @@ export default function LikesScreen({ userId, onSelectProfile, onBack }) {
     !canSeeLikes && likedProfiles.length > 0 && React.createElement(Button,{className:'mt-4 w-full bg-yellow-500 text-white',onClick:()=>setShowPurchase(true)},'Køb Guld eller Platin (gratis nu - betaling ikke implementeret)'),
     showPurchase && React.createElement(SubscriptionOverlay,{onClose:()=>setShowPurchase(false), onBuy:handlePurchase}),
     matchedProfile && React.createElement(MatchOverlay,{name:matchedProfile.name,onClose:()=>setMatchedProfile(null)}),
-    activeVideo && React.createElement(VideoOverlay,{src:activeVideo,onClose:()=>setActiveVideo(null)})
+    activeProfile && React.createElement(VideoOverlay,{
+      src:activeProfile.url,
+      profileId:activeProfile.id,
+      liked:likes.some(l=>l.profileId===activeProfile.id),
+      onLike:()=>toggleLike(activeProfile.id),
+      onClose:()=>setActiveProfile(null)
+    })
   );
 }

--- a/src/components/VideoOverlay.jsx
+++ b/src/components/VideoOverlay.jsx
@@ -1,8 +1,8 @@
 import React, { useRef } from 'react';
-import { X } from 'lucide-react';
+import { X, Heart } from 'lucide-react';
 import { db, doc, updateDoc, increment } from '../firebase.js';
 
-export default function VideoOverlay({ src, profileId, onClose }) {
+export default function VideoOverlay({ src, profileId, liked = false, onLike, onClose }) {
   const watched = useRef(0);
   const handleTime = e => { watched.current = e.currentTarget.currentTime; };
   const handleClose = () => {
@@ -22,6 +22,12 @@ export default function VideoOverlay({ src, profileId, onClose }) {
         onTimeUpdate:handleTime,
         className:'w-full rounded'
       }),
+      onLike && React.createElement('button', {
+        onClick:onLike,
+        className:`absolute top-2 left-2 rounded-full p-1 ${liked ? 'bg-pink-500 text-white' : 'bg-white text-pink-500 border border-pink-500'}`
+      },
+        React.createElement(Heart,{className:'w-6 h-6'})
+      ),
       React.createElement('button', { onClick:handleClose, className:'absolute top-2 right-2 text-white bg-black/40 rounded-full p-1' },
         React.createElement(X,{className:'w-6 h-6'})
       )


### PR DESCRIPTION
## Summary
- add heart button to video overlay for reacting to clips
- wire LikesScreen to control and toggle likes while watching videos

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a06790e47c832d8cccf579b99bc06d