### PR TITLE
Fix FAQ link path in profile settings

### DIFF
--- a/src/components/ProfileSettings.jsx
+++ b/src/components/ProfileSettings.jsx
@@ -763,7 +763,7 @@ export default function ProfileSettings({ userId, ageRange, onChangeAgeRange, pu
         React.createElement(Button, {
           className: 'mt-2 w-full bg-indigo-500 text-white',
           onClick: () => {
-            window.location.href = '/faq.html';
+            window.location.href = 'faq.html';
           }
         }, t('faq'))
       ),


### PR DESCRIPTION
## Summary
- Fix broken FAQ link by removing leading slash in profile settings

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a078d25010832d8c489696dbe44b35