### PR TITLE
Add like button for video clips

### DIFF
--- a/src/components/ProfileEpisode.jsx
+++ b/src/components/ProfileEpisode.jsx
@@ -8,6 +8,7 @@ import SectionTitle from './SectionTitle.jsx';
 import { useT } from '../i18n.js';
 import ProfileSettings from './ProfileSettings.jsx';
 import VideoPreview from './VideoPreview.jsx';
+import VideoLikeButton from './VideoLikeButton.jsx';
 import { Star } from 'lucide-react';
 import InfoOverlay from './InfoOverlay.jsx';
 import useDayOffset from '../useDayOffset.js';
@@ -206,6 +207,7 @@ export default function ProfileEpisode({ userId, profileId, onBack }) {
         const classes = `w-[30%] flex flex-col items-center justify-end min-h-[160px] relative ${locked ? 'pointer-events-none' : ''}`;
         return React.createElement('div', { key: i, className: classes },
           url && React.createElement(VideoPreview, { src: url, onEnded: () => handleClipEnd(i) }),
+          url && !locked && React.createElement(VideoLikeButton, { userId, videoId: `${profileId}-clip-${i}` }),
           !locked && i === stage - 1 && React.createElement('span', { className:'absolute top-1 right-1 bg-green-100 text-green-600 text-xs font-semibold px-1 rounded' }, t('dayLabel').replace('{day}', i + 1)),
           (locked || (showReveal && i === stage - 1)) && React.createElement('div', { className:`absolute inset-0 bg-black/80 flex items-center justify-center rounded text-center px-2 ${showReveal && i === stage - 1 ? 'reveal-animation' : ''}` },
             React.createElement('span', { className:'text-pink-500 text-xs font-semibold' }, t('dayLabel').replace('{day}', i + 1))

--- a/src/components/VideoLikeButton.jsx
+++ b/src/components/VideoLikeButton.jsx
@@ -1,0 +1,24 @@
+import React from 'react';
+import { useDoc, db, doc, setDoc, deleteDoc } from '../firebase.js';
+import { Button } from './ui/button.js';
+
+export default function VideoLikeButton({ userId, videoId }) {
+  const likeId = `${userId}-${videoId}`;
+  const like = useDoc('videoLikes', likeId);
+  const liked = !!like;
+
+  const toggleLike = async e => {
+    e.stopPropagation();
+    const ref = doc(db, 'videoLikes', likeId);
+    if (liked) {
+      await deleteDoc(ref);
+    } else {
+      await setDoc(ref, { id: likeId, userId, videoId });
+    }
+  };
+
+  return React.createElement(Button, {
+    className: `mt-2 w-full ${liked ? 'bg-pink-500 text-white' : 'bg-gray-200 text-black'}`,
+    onClick: toggleLike
+  }, liked ? 'Unlike' : 'Like');
+}


### PR DESCRIPTION
## Summary
- add `VideoLikeButton` component storing likes in `videoLikes`
- show like button for each unlocked clip in profile episodes

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a07c920dfc832d9635170d1c612e55