### PR TITLE
Add thumb and heart video reactions

### DIFF
--- a/docs/developers/video-reactions.md
+++ b/docs/developers/video-reactions.md
@@ -1,0 +1,21 @@
+# Video Reactions
+
+Users can react to individual video clips with either a thumb or a heart.
+
+## Data model
+Reactions are stored in the `videoReactions` Firestore collection with the following fields:
+
+- `id`: `${userId}-${videoId}`
+- `userId`: identifier of the reacting user
+- `videoId`: identifier of the video clip
+- `type`: `"thumb"` or `"heart"`
+
+Selecting the same reaction again clears it. Switching between reactions updates the stored `type`.
+
+## UI
+The `VideoLikeButton` component renders two buttons below each video:
+
+- **Thumbs up** – blue background when selected
+- **Heart** – pink background when selected
+
+Both buttons explicitly set text colors to maintain contrast against their backgrounds.

--- a/src/components/VideoLikeButton.jsx
+++ b/src/components/VideoLikeButton.jsx
@@ -1,24 +1,32 @@
 import React from 'react';
 import { useDoc, db, doc, setDoc, deleteDoc } from '../firebase.js';
 import { Button } from './ui/button.js';
+import { ThumbsUp, Heart } from 'lucide-react';
 
 export default function VideoLikeButton({ userId, videoId }) {
-  const likeId = `${userId}-${videoId}`;
-  const like = useDoc('videoLikes', likeId);
-  const liked = !!like;
+  const reactionId = `${userId}-${videoId}`;
+  const reaction = useDoc('videoReactions', reactionId);
 
-  const toggleLike = async e => {
+  const setReaction = async (type, e) => {
     e.stopPropagation();
-    const ref = doc(db, 'videoLikes', likeId);
-    if (liked) {
+    const ref = doc(db, 'videoReactions', reactionId);
+    if (reaction?.type === type) {
       await deleteDoc(ref);
     } else {
-      await setDoc(ref, { id: likeId, userId, videoId });
+      await setDoc(ref, { id: reactionId, userId, videoId, type });
     }
   };
 
-  return React.createElement(Button, {
-    className: `mt-2 w-full ${liked ? 'bg-pink-500 text-white' : 'bg-gray-200 text-black'}`,
-    onClick: toggleLike
-  }, liked ? 'Unlike' : 'Like');
+  return React.createElement('div', { className: 'flex gap-2 mt-2 w-full' },
+    React.createElement(Button, {
+      className: `flex-1 ${reaction?.type === 'thumb' ? 'bg-blue-500 text-white' : 'bg-gray-200 text-black'}`,
+      onClick: e => setReaction('thumb', e),
+      'aria-label': 'Thumb reaction'
+    }, React.createElement(ThumbsUp, { className: 'w-4 h-4' })),
+    React.createElement(Button, {
+      className: `flex-1 ${reaction?.type === 'heart' ? 'bg-pink-500 text-white' : 'bg-gray-200 text-black'}`,
+      onClick: e => setReaction('heart', e),
+      'aria-label': 'Heart reaction'
+    }, React.createElement(Heart, { className: 'w-4 h-4' }))
+  );
 }


### PR DESCRIPTION
## Summary
- Replace Like button with thumb and heart reaction buttons on videos
- Document video reaction storage in Firestore

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a09d2fbdfc832d98054ad5ff3b08ec