### PR TITLE
Show reaction counts for each video

### DIFF
--- a/docs/developers/video-reactions.md
+++ b/docs/developers/video-reactions.md
@@ -17,5 +17,6 @@ The `VideoLikeButton` component renders two buttons below each video:
 
 - **Thumbs up** – blue background when selected
 - **Heart** – pink background when selected
+Each button displays the count of its respective reactions.
 
 Both buttons explicitly set text colors to maintain contrast against their backgrounds.

--- a/src/components/VideoLikeButton.jsx
+++ b/src/components/VideoLikeButton.jsx
@@ -1,11 +1,14 @@
 import React from 'react';
-import { useDoc, db, doc, setDoc, deleteDoc } from '../firebase.js';
+import { useDoc, useCollection, db, doc, setDoc, deleteDoc } from '../firebase.js';
 import { Button } from './ui/button.js';
 import { ThumbsUp, Heart } from 'lucide-react';
 
 export default function VideoLikeButton({ userId, videoId }) {
   const reactionId = `${userId}-${videoId}`;
   const reaction = useDoc('videoReactions', reactionId);
+  const reactions = useCollection('videoReactions', 'videoId', videoId);
+  const thumbCount = reactions.filter(r => r.type === 'thumb').length;
+  const heartCount = reactions.filter(r => r.type === 'heart').length;
 
   const setReaction = async (type, e) => {
     e.stopPropagation();
@@ -22,11 +25,17 @@ export default function VideoLikeButton({ userId, videoId }) {
       className: `flex-1 ${reaction?.type === 'thumb' ? 'bg-blue-500 text-white' : 'bg-gray-200 text-black'}`,
       onClick: e => setReaction('thumb', e),
       'aria-label': 'Thumb reaction'
-    }, React.createElement(ThumbsUp, { className: 'w-4 h-4' })),
+    },
+      React.createElement(ThumbsUp, { className: 'w-4 h-4' }),
+      React.createElement('span', { className: 'ml-1' }, thumbCount)
+    ),
     React.createElement(Button, {
       className: `flex-1 ${reaction?.type === 'heart' ? 'bg-pink-500 text-white' : 'bg-gray-200 text-black'}`,
       onClick: e => setReaction('heart', e),
       'aria-label': 'Heart reaction'
-    }, React.createElement(Heart, { className: 'w-4 h-4' }))
+    },
+      React.createElement(Heart, { className: 'w-4 h-4' }),
+      React.createElement('span', { className: 'ml-1' }, heartCount)
+    )
   );
 }


### PR DESCRIPTION
## Summary
- display real-time counts of thumbs and hearts under each video
- document reaction count behavior for VideoLikeButton

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a0a12966e4832da6b61dd04d2400ab