### PR TITLE
Store timestamps for videos and display with clips

### DIFF
--- a/src/components/AdminScreen.jsx
+++ b/src/components/AdminScreen.jsx
@@ -71,7 +71,8 @@ export default function AdminScreen({ onOpenStats, onOpenBugReports, onOpenMatch
         }
       } else if (name.startsWith('videoClips-')) {
         if (!videoClips.some(v => v.url === url)) {
-          videoClips.push({ url, lang: language, uploadedAt: new Date().toISOString() });
+          const recordedAt = new Date().toISOString();
+          videoClips.push({ url, lang: language, recordedAt, uploadedAt: recordedAt });
           updates.videoClips = videoClips;
         }
       }

--- a/src/components/ProfileEpisode.jsx
+++ b/src/components/ProfileEpisode.jsx
@@ -206,7 +206,11 @@ export default function ProfileEpisode({ userId, profileId, onBack }) {
         const locked = i >= stage;
         const classes = `w-[30%] flex flex-col items-center justify-end min-h-[160px] relative ${locked ? 'pointer-events-none' : ''}`;
         return React.createElement('div', { key: i, className: classes },
-          url && React.createElement(VideoPreview, { src: url, onEnded: () => handleClipEnd(i) }),
+          url && React.createElement(VideoPreview, {
+            src: url,
+            timestamp: clip && (clip.recordedAt || clip.uploadedAt),
+            onEnded: () => handleClipEnd(i)
+          }),
           url && !locked && React.createElement(VideoLikeButton, { userId, videoId: `${profileId}-clip-${i}` }),
           !locked && i === stage - 1 && React.createElement('span', { className:'absolute top-1 right-1 bg-green-100 text-green-600 text-xs font-semibold px-1 rounded' }, t('dayLabel').replace('{day}', i + 1)),
           (locked || (showReveal && i === stage - 1)) && React.createElement('div', { className:`absolute inset-0 bg-black/80 flex items-center justify-center rounded text-center px-2 ${showReveal && i === stage - 1 ? 'reveal-animation' : ''}` },

--- a/src/components/ProfileSettings.jsx
+++ b/src/components/ProfileSettings.jsx
@@ -271,7 +271,8 @@ export default function ProfileSettings({ userId, ageRange, onChangeAgeRange, pu
       const storageRef = ref(storage, `profiles/${userId}/${field}-${Date.now()}-${file.name}`);
       await uploadBytes(storageRef, file);
       const url = await getDownloadURL(storageRef);
-      const clip = { url, lang: profile.language || 'en', uploadedAt: new Date().toISOString() };
+      const recordedAt = new Date().toISOString();
+      const clip = { url, lang: profile.language || 'en', recordedAt, uploadedAt: recordedAt };
       if(music){
         const musicRef = ref(storage, `profiles/${userId}/${field}-music-${Date.now()}-${music.name}`);
         await uploadBytes(musicRef, music);
@@ -479,7 +480,10 @@ export default function ProfileSettings({ userId, ageRange, onChangeAgeRange, pu
         const locked = i >= stage;
         return React.createElement('div', { key: i, className: `w-[30%] flex flex-col items-center justify-end min-h-[160px] relative ${locked ? 'pointer-events-none' : ''} ${ (i===0 && highlightVideo1) || (i===1 && highlightVideo2) ? 'ring-4 ring-green-500' : ''}` },
           url
-            ? React.createElement(VideoPreview, { src: url })
+            ? React.createElement(VideoPreview, {
+                src: url,
+                timestamp: clip && (clip.recordedAt || clip.uploadedAt)
+              })
             : React.createElement('div', { className:'flex flex-col items-center' },
                 React.createElement(CameraIcon, {
                   className: `w-10 h-10 text-gray-400 ${!publicView ? 'cursor-pointer' : ''}`,

--- a/src/components/RevealTestScreen.jsx
+++ b/src/components/RevealTestScreen.jsx
@@ -34,7 +34,10 @@ export default function RevealTestScreen({ onBack }) {
   return React.createElement(Card, { className: 'p-6 m-4 shadow-xl bg-white/90' },
     React.createElement(SectionTitle, { title: t('revealTestTitle'), colorClass: 'text-blue-600', action: React.createElement(Button, { className: 'bg-blue-500 text-white px-4 py-2 rounded', onClick: onBack }, t('back')) }),
     videoURL && React.createElement('div', { className: 'mb-4 relative' },
-      React.createElement(VideoPreview, { src: videoURL }),
+      React.createElement(VideoPreview, {
+        src: videoURL,
+        timestamp: profile.videoClips?.[0]?.recordedAt || profile.videoClips?.[0]?.uploadedAt
+      }),
       overlay
     ),
     React.createElement(Button, { className: 'bg-blue-500 text-white px-4 py-2 rounded', onClick: runTest }, 'Test reveal')

--- a/src/components/VideoPreview.jsx
+++ b/src/components/VideoPreview.jsx
@@ -1,15 +1,21 @@
 import React from 'react';
 
-export default function VideoPreview({ src, onEnded }) {
-  return React.createElement('video', {
-    src,
-    controls: true,
-    controlsList: 'nodownload noplaybackrate',
-    disablePictureInPicture: true,
-    onRateChange: e => {
-      e.currentTarget.playbackRate = 1;
-    },
-    className: 'w-full rounded',
-    onEnded
-  });
+export default function VideoPreview({ src, timestamp, onEnded }) {
+  const formatted = timestamp ? new Date(timestamp).toLocaleString() : '';
+  return React.createElement('div', { className: 'relative w-full' },
+    React.createElement('video', {
+      src,
+      controls: true,
+      controlsList: 'nodownload noplaybackrate',
+      disablePictureInPicture: true,
+      onRateChange: e => {
+        e.currentTarget.playbackRate = 1;
+      },
+      className: 'w-full rounded',
+      onEnded
+    }),
+    formatted && React.createElement('span', {
+      className: 'absolute bottom-1 left-1 bg-black/60 text-white text-xs px-1 rounded'
+    }, formatted)
+  );
 }


### PR DESCRIPTION
## Summary
- Save recording timestamp for uploaded video clips
- Overlay formatted date/time on video previews
- Pass clip timestamps through profile and test screens

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a319eb55d8832d829f30a61fe02ac4