### PR TITLE
Add profile picture puzzle reveal to admin page

### DIFF
--- a/src/components/AdminScreen.jsx
+++ b/src/components/AdminScreen.jsx
@@ -23,6 +23,8 @@ export default function AdminScreen({ onOpenStats, onOpenBugReports, onOpenMatch
   const config = useDoc('config', 'app') || {};
   const invitesEnabled = config.premiumInvitesEnabled !== false;
   const showLevels = config.showLevels !== false;
+  const [revealStep, setRevealStep] = useState(0);
+  const photoURL = (profiles.find(p => p.id === userId) || {}).photoURL;
 
   const toggleLog = () => {
     const val = !logEnabled;
@@ -247,6 +249,26 @@ export default function AdminScreen({ onOpenStats, onOpenBugReports, onOpenMatch
       className: 'bg-red-500 text-white px-4 py-2 rounded',
       onClick: deleteUser
     }, 'Delete user')
+  ),
+  photoURL && React.createElement('div', { className: 'mt-4' },
+    React.createElement(Button, {
+      className: 'bg-blue-500 text-white px-4 py-2 rounded mb-2',
+      onClick: () => setRevealStep(s => Math.min(5, s + 1))
+    }, 'Vis profilbillede'),
+    React.createElement('div', { className: 'relative w-48 h-48 border' },
+      React.createElement('img', {
+        src: photoURL,
+        alt: 'Profil',
+        className: 'w-full h-full object-cover'
+      }),
+      Array.from({ length: 5 }).map((_, i) =>
+        revealStep <= i && React.createElement('div', {
+          key: i,
+          className: 'absolute top-0 h-full',
+          style: { left: `${i * 20}%`, width: '20%', backgroundColor: '#ccc' }
+        })
+      )
+    )
   )
   ),
 


### PR DESCRIPTION
## Summary
- Add puzzle-based profile photo reveal to admin page
- Track reveal progress with state and show image pieces on each click

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a6a58fd304832dbb0564ae39891d9e