### PR TITLE
Implement puzzle-style profile reveal animation

### DIFF
--- a/src/components/ProfileEpisode.jsx
+++ b/src/components/ProfileEpisode.jsx
@@ -9,6 +9,7 @@ import { useT } from '../i18n.js';
 import ProfileSettings from './ProfileSettings.jsx';
 import VideoPreview from './VideoPreview.jsx';
 import VideoLikeButton from './VideoLikeButton.jsx';
+import PuzzleReveal from './PuzzleReveal.jsx';
 import { Star } from 'lucide-react';
 import InfoOverlay from './InfoOverlay.jsx';
 import useDayOffset from '../useDayOffset.js';
@@ -213,9 +214,10 @@ export default function ProfileEpisode({ userId, profileId, onBack }) {
           }),
           url && !locked && React.createElement(VideoLikeButton, { userId, videoId: `${profileId}-clip-${i}` }),
           !locked && i === stage - 1 && React.createElement('span', { className:'absolute top-1 right-1 bg-green-100 text-green-600 text-xs font-semibold px-1 rounded' }, t('dayLabel').replace('{day}', i + 1)),
-          (locked || (showReveal && i === stage - 1)) && React.createElement('div', { className:`absolute inset-0 bg-black/80 flex items-center justify-center rounded text-center px-2 ${showReveal && i === stage - 1 ? 'reveal-animation' : ''}` },
+          locked && React.createElement('div', { className:'absolute inset-0 bg-black/80 flex items-center justify-center rounded text-center px-2' },
             React.createElement('span', { className:'text-pink-500 text-xs font-semibold' }, t('dayLabel').replace('{day}', i + 1))
-          )
+          ),
+          showReveal && i === stage - 1 && React.createElement(PuzzleReveal, { label: t('dayLabel').replace('{day}', i + 1) })
         );
       })
     ),

--- a/src/components/PuzzleReveal.jsx
+++ b/src/components/PuzzleReveal.jsx
@@ -1,0 +1,13 @@
+import React from 'react';
+
+export default function PuzzleReveal({ label }) {
+  return React.createElement('div', { className: 'puzzle-reveal absolute inset-0 rounded overflow-hidden pointer-events-none' },
+    React.createElement('div', { className: 'piece tl' }),
+    React.createElement('div', { className: 'piece tr' }),
+    React.createElement('div', { className: 'piece bl' }),
+    React.createElement('div', { className: 'piece br' }),
+    React.createElement('div', { className: 'piece center flex items-center justify-center' },
+      React.createElement('span', { className: 'text-pink-500 text-xs font-semibold' }, label)
+    )
+  );
+}

--- a/src/components/RevealTestScreen.jsx
+++ b/src/components/RevealTestScreen.jsx
@@ -3,6 +3,7 @@ import { Card } from './ui/card.js';
 import { Button } from './ui/button.js';
 import SectionTitle from './SectionTitle.jsx';
 import VideoPreview from './VideoPreview.jsx';
+import PuzzleReveal from './PuzzleReveal.jsx';
 import { useDoc } from '../firebase.js';
 import { useT } from '../i18n.js';
 
@@ -27,9 +28,11 @@ export default function RevealTestScreen({ onBack }) {
 
   const videoURL = profile.videoClips?.[0]?.url || profile.videoClips?.[0] || '';
 
-  const overlay = React.createElement('div', { className:`absolute inset-0 bg-black/80 flex items-center justify-center rounded text-center px-2 ${showReveal ? 'reveal-animation pointer-events-none' : ''}` },
-    React.createElement('span', { className:'text-pink-500 text-xs font-semibold' }, t('dayLabel').replace('{day}', 1))
-  );
+  const overlay = showReveal
+    ? React.createElement(PuzzleReveal, { label: t('dayLabel').replace('{day}', 1) })
+    : React.createElement('div', { className:'absolute inset-0 bg-black/80 flex items-center justify-center rounded text-center px-2' },
+      React.createElement('span', { className:'text-pink-500 text-xs font-semibold' }, t('dayLabel').replace('{day}', 1))
+    );
 
   return React.createElement(Card, { className: 'p-6 m-4 shadow-xl bg-white/90' },
     React.createElement(SectionTitle, { title: t('revealTestTitle'), colorClass: 'text-blue-600', action: React.createElement(Button, { className: 'bg-blue-500 text-white px-4 py-2 rounded', onClick: onBack }, t('back')) }),

--- a/src/style.css
+++ b/src/style.css
@@ -116,3 +116,15 @@ button.btn-outline-red {
   from { opacity: 1; }
   to { opacity: 0; }
 }
+
+/* Puzzle reveal overlay */
+.puzzle-reveal .piece {
+  position: absolute;
+  background: rgba(0,0,0,0.8);
+  animation: overlay-fade 0.8s ease-out forwards;
+}
+.puzzle-reveal .piece.tl { top:0; left:0; width:50%; height:50%; animation-delay:0s; }
+.puzzle-reveal .piece.tr { top:0; right:0; width:50%; height:50%; animation-delay:0.15s; }
+.puzzle-reveal .piece.bl { bottom:0; left:0; width:50%; height:50%; animation-delay:0.3s; }
+.puzzle-reveal .piece.br { bottom:0; right:0; width:50%; height:50%; animation-delay:0.45s; }
+.puzzle-reveal .piece.center { top:25%; left:25%; width:50%; height:50%; animation-delay:0.6s; display:flex; align-items:center; justify-content:center; }


### PR DESCRIPTION
## Summary
- Introduce `PuzzleReveal` component to animate profile picture reveal in five puzzle-like steps
- Integrate puzzle reveal into profile episodes and reveal test screen
- Add corresponding CSS for sequential corner-to-center fade out

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a6a74099f0832d9b07a90aa0717586