### PR TITLE
Sequential puzzle reveal for profile images

### DIFF
--- a/src/components/RevealTestScreen.jsx
+++ b/src/components/RevealTestScreen.jsx
@@ -2,23 +2,27 @@ import React, { useState } from 'react';
 import { Card } from './ui/card.js';
 import { Button } from './ui/button.js';
 import SectionTitle from './SectionTitle.jsx';
-import PuzzleReveal from './PuzzleReveal.jsx';
 import { useDoc } from '../firebase.js';
 import { useT } from '../i18n.js';
 
 export default function RevealTestScreen({ onBack }) {
   const profile = useDoc('profiles', '101');
-  const [showReveal, setShowReveal] = useState(false);
   const [revealStep, setRevealStep] = useState(0);
+  const [animatingPiece, setAnimatingPiece] = useState(null);
   const t = useT();
 
+  const pieces = ['tl', 'tr', 'bl', 'br', 'center'];
+
   const nextStep = () => {
-    if (revealStep >= 5 || showReveal) return;
-    setRevealStep(s => s + 1);
-    setShowReveal(true);
+    if (revealStep >= pieces.length || animatingPiece !== null) return;
+    const current = pieces[revealStep];
+    setAnimatingPiece(current);
     const audio = new Audio('/reveal.mp3');
     audio.play().catch(err => console.error('Failed to play reveal sound', err));
-    setTimeout(() => setShowReveal(false), 1000);
+    setTimeout(() => {
+      setRevealStep(s => s + 1);
+      setAnimatingPiece(null);
+    }, 1000);
   };
 
   if (!profile) {
@@ -30,11 +34,11 @@ export default function RevealTestScreen({ onBack }) {
 
   const photoURL = profile.photoURL || '';
 
-  const overlays = Array.from({ length: 5 }).map((_, i) =>
-    revealStep <= i && React.createElement('div', {
-      key: i,
-      className: 'absolute top-0 h-full',
-      style: { left: `${i * 20}%`, width: '20%', backgroundColor: '#ccc' }
+  const overlays = pieces.map((p, i) =>
+    (i >= revealStep || animatingPiece === p) && React.createElement('div', {
+      key: p,
+      className: `piece ${p}${animatingPiece === p ? ' reveal-animation' : ''}`,
+      style: { animationDelay: '0s' }
     })
   );
 
@@ -46,12 +50,8 @@ export default function RevealTestScreen({ onBack }) {
         alt: profile.name || '',
         className: 'w-full rounded object-cover'
       }),
-      overlays,
-      revealStep < 5 && !showReveal && React.createElement('div', { className: 'absolute inset-0 flex items-center justify-center rounded text-center px-2 bg-black/80' },
-        React.createElement('span', { className: 'text-pink-500 text-xs font-semibold' }, t('dayLabel').replace('{day}', 1))
-      ),
-      showReveal && React.createElement(PuzzleReveal, { label: t('dayLabel').replace('{day}', 1) })
+      React.createElement('div', { className: 'puzzle-reveal absolute inset-0 rounded overflow-hidden pointer-events-none' }, overlays)
     ),
-    revealStep < 5 && React.createElement(Button, { className: 'bg-blue-500 text-white px-4 py-2 rounded', onClick: nextStep, disabled: showReveal }, t('next'))
+    revealStep < pieces.length && React.createElement(Button, { className: 'bg-blue-500 text-white px-4 py-2 rounded', onClick: nextStep, disabled: animatingPiece !== null }, t('next'))
   );
 }


### PR DESCRIPTION
## Summary
- Replace vertical-strip reveal test with stepwise puzzle piece reveal
- Play reveal sound and animate each tile individually on click

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a6b7dba64c832d8c89101998adf4b0