### PR TITLE
Fix syntax error in AdminScreen overlay rendering

### DIFF
--- a/src/components/AdminScreen.jsx
+++ b/src/components/AdminScreen.jsx
@@ -339,6 +339,6 @@ export default function AdminScreen({ onOpenStats, onOpenBugReports, onOpenMatch
     )
   ),
     showBugReport && React.createElement(BugReportOverlay, { onClose: () => setShowBugReport(false) }),
-    showHelp && React.createElement(AdminHelpOverlay, { onClose: () => setShowHelp(false) })
-  );
+    showHelp && React.createElement(AdminHelpOverlay, { onClose: () => setShowHelp(false) }),
+  ));
 }


### PR DESCRIPTION
## Summary
- close unmatched parenthesis in AdminScreen to allow Parcel build

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a6bc277200832dacb708fba094fdc9