### PR TITLE
feat: add offline fallback for PWA

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "start": "npx serve .",
     "dev": "parcel public/index.html",
     "prebuild": "node scripts/bump-version.js",
-    "build": "parcel build public/index.html public/invite.html public/commercial.html public/faq.html public/pricing.html public/test-webpush.html --dist-dir dist --no-source-maps --public-url ./ && cp public/service-worker.js dist/ && cp public/*.mp3 dist/",
+    "build": "parcel build public/index.html public/invite.html public/commercial.html public/faq.html public/pricing.html public/test-webpush.html public/offline.html --dist-dir dist --no-source-maps --public-url ./ && cp public/service-worker.js dist/ && cp public/*.mp3 dist/",
     "test": "jest",
     "screenshots": "node scripts/capture-screens.js"
   },

--- a/public/offline.html
+++ b/public/offline.html
@@ -1,0 +1,21 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Offline</title>
+  <meta name="theme-color" content="#ff4957" />
+  <link rel="manifest" href="manifest.json" />
+  <link rel="icon" href="icon-512.png" />
+</head>
+<body style="padding:1rem;background-color:#fff;color:#000;">
+  <h1 style="margin-bottom:1rem;">You are offline</h1>
+  <p style="margin-bottom:1rem;">This app requires an internet connection. Please check your connection and try again.</p>
+  <button id="reload-btn" style="padding:0.5rem 1rem;background-color:#6b7280;color:#fff;">Reload</button>
+  <script>
+    document.getElementById('reload-btn').addEventListener('click', () => {
+      window.location.reload();
+    });
+  </script>
+</body>
+</html>

--- a/public/service-worker.js
+++ b/public/service-worker.js
@@ -1,6 +1,6 @@
 // Bump the cache name whenever cached files change to ensure
 // clients receive the latest versions.
-const CACHE_NAME = 'VideoTinder-cache-v6';
+const CACHE_NAME = 'VideoTinder-cache-v7';
 console.log('ServiceWorker script loaded', CACHE_NAME);
 // Cache for images and video so large media files work offline
 const MEDIA_CACHE = 'media-cache-v1';
@@ -8,6 +8,10 @@ const rel = (p) => new URL(p, self.registration.scope).href;
 const URLS_TO_CACHE = [
   rel(''),
   rel('index.html'),
+  rel('offline.html'),
+  rel('manifest.json'),
+  rel('icon-192.png'),
+  rel('icon-512.png'),
 ];
 
 self.addEventListener('install', event => {
@@ -75,6 +79,12 @@ self.addEventListener('push', event => {
 self.addEventListener('fetch', event => {
   console.log('ServiceWorker fetch', event.request.url);
   const dest = event.request.destination;
+  if (event.request.mode === 'navigate') {
+    event.respondWith(
+      fetch(event.request).catch(() => caches.match(rel('offline.html')))
+    );
+    return;
+  }
   if (['image', 'video'].includes(dest)) {
     event.respondWith(
       caches.open(MEDIA_CACHE).then(cache =>


### PR DESCRIPTION
## Summary
- cache core assets and offline page in service worker
- serve new offline fallback page when navigation fails
- include offline page in build pipeline

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a7363009c4832da315e4aa50ca177a