### PR TITLE
Remove advanced subscription features from pricing page

### DIFF
--- a/public/pricing.html
+++ b/public/pricing.html
@@ -92,13 +92,6 @@
         <td>&#10003;</td>
       </tr>
       <tr>
-        <td>Undo removes</td>
-        <td>&#10060;</td>
-        <td>last</td>
-        <td>&#10003;</td>
-        <td>&#10003;</td>
-      </tr>
-      <tr>
         <td>Super like per week</td>
         <td>&#10060;</td>
         <td>1</td>
@@ -111,34 +104,6 @@
         <td>1/month</td>
         <td>2/month</td>
         <td>4/month</td>
-      </tr>
-      <tr>
-        <td>Advanced filters (gender, age, etc.)</td>
-        <td>gender, age</td>
-        <td>gender, age</td>
-        <td>Full</td>
-        <td>Full</td>
-      </tr>
-      <tr>
-        <td>Incognito mode</td>
-        <td>&#10060;</td>
-        <td>&#10060;</td>
-        <td>&#10060;</td>
-        <td>&#10003;</td>
-      </tr>
-      <tr>
-        <td>Video creation tools (music)</td>
-        <td>&#10060;</td>
-        <td>&#10060;</td>
-        <td>&#10003;</td>
-        <td>&#10003;</td>
-      </tr>
-      <tr>
-        <td>Longer videos</td>
-        <td>&#10060;</td>
-        <td>&#10060;</td>
-        <td>15 sec</td>
-        <td>25 sec</td>
       </tr>
       <tr>
         <td>Ad-free experience</td>
@@ -160,13 +125,6 @@
         <td>&#10060;</td>
         <td>&#10003;</td>
         <td>&#10003;</td>
-      </tr>
-      <tr>
-        <td>Advanced profile analytics</td>
-        <td>&#10060;</td>
-        <td>&#10060;</td>
-        <td>&#10003; (basic)</td>
-        <td>&#10003; (advanced)</td>
       </tr>
       <tr>
         <td><strong>Price (DKK/month)</strong></td>


### PR DESCRIPTION
## Summary
- drop advanced features from pricing page (undo removes, filters, incognito mode, creation tools, longer videos, profile analytics)

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a76e2af0bc832d99486c22a008680d