### PR TITLE
Remove verification and messaging features from pricing

### DIFF
--- a/public/pricing.html
+++ b/public/pricing.html
@@ -113,20 +113,6 @@
         <td>&#10003; (priority)</td>
       </tr>
       <tr>
-        <td>Profile verification badge</td>
-        <td>&#10060;</td>
-        <td>&#10060;</td>
-        <td>&#10003;</td>
-        <td>&#10003;</td>
-      </tr>
-      <tr>
-        <td>Read receipts & typing indicators</td>
-        <td>&#10060;</td>
-        <td>&#10060;</td>
-        <td>&#10003;</td>
-        <td>&#10003;</td>
-      </tr>
-      <tr>
         <td><strong>Price (DKK/month)</strong></td>
         <td><strong>Free</strong></td>
         <td><strong>39</strong></td>


### PR DESCRIPTION
## Summary
- drop profile verification badge and read receipts & typing indicators from pricing table

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a770a29da0832db4fa6bb10df2b588