### PR TITLE
Remove expiry countdown text

### DIFF
--- a/src/components/DailyDiscovery.jsx
+++ b/src/components/DailyDiscovery.jsx
@@ -263,17 +263,14 @@ export default function DailyDiscovery({ userId, profiles = [], onSelectProfile,
       activeProfiles.length ? activeProfiles.map(p => {
         const prog = progresses.find(pr => pr.profileId === p.id);
         const stage = prog?.stage || 1;
-        const defaultDays = hasActiveSub(p) ? 10 : 5;
-        const daysLeft = prog?.daysLeft ?? defaultDays;
+        const isLastDay = prog?.daysLeft !== undefined && prog.daysLeft <= 0;
         return React.createElement('li', {
           key: p.id,
           className: 'p-4 bg-white rounded-lg cursor-pointer shadow-lg border border-gray-200 flex flex-col relative',
           onClick: () => onSelectProfile(p.id)
         },
           showLevels && React.createElement('span', { className:'absolute top-2 left-2 bg-pink-100 text-pink-600 text-xs font-semibold px-2 rounded' }, `Level ${stage}`),
-          React.createElement('span', { className:`absolute top-2 right-2 z-10 ${daysLeft <= 0 ? 'bg-red-100 text-red-600' : 'bg-yellow-100 text-yellow-600'} text-xs font-semibold px-2 rounded` },
-            daysLeft <= 0 ? t('lastDay') : t('expiresIn').replace('{days}', daysLeft)
-          ),
+          isLastDay && React.createElement('span', { className:'absolute top-2 right-2 z-10 bg-red-100 text-red-600 text-xs font-semibold px-2 rounded' }, t('lastDay')),
           React.createElement('div', { className: 'flex items-center gap-4 mb-2' },
             React.createElement('div', { className:'flex flex-col items-center' },
               (p.photoURL ?

--- a/src/components/ProfileEpisode.jsx
+++ b/src/components/ProfileEpisode.jsx
@@ -194,8 +194,8 @@ export default function ProfileEpisode({ userId, profileId, onBack }) {
     ),
     // The old level 2 intro box has been removed
     React.createElement(SectionTitle, { title: `${profile.name || ''}, ${profile.birthday ? getAge(profile.birthday) : profile.age || ''}${profile.city ? ', ' + profile.city : ''}` }),
-    React.createElement('p', { className:`text-left text-xs ${daysLeft <= 0 ? 'text-red-600' : 'text-yellow-600'} mb-2` },
-      daysLeft <= 0 ? t('lastDay') : t('expiresIn').replace('{days}', daysLeft)
+    daysLeft <= 0 && React.createElement('p', { className:'text-left text-xs text-red-600 mb-2' },
+      t('lastDay')
     ),
     React.createElement(SectionTitle, { title: t('episodeIntro') }),
     profile.clip && React.createElement('p', { className: 'mb-4' }, `"${profile.clip}"`),

--- a/src/i18n.js
+++ b/src/i18n.js
@@ -125,7 +125,6 @@ inviteAccepted:{ en:"Profile created", da:"Oprettet", sv:"Skapad", es:"Perfil cr
   episodeStageReflection:{ en:'Reflection', da:'Refleksion', sv:'Reflektion', es:'Reflexión', fr:'Réflexion', de:'Reflexion' },
   episodeStageReaction:{ en:'Reaction', da:'Reaktion', sv:'Reaktion', es:'Reacción', fr:'Réaction', de:'Reaktion' },
   episodeStageConnect:{ en:'Connect', da:'Forbind', sv:'Anslut', es:'Conectar', fr:'Connecter', de:'Verbinden' },
-  expiresIn:{ en:'Expires in {days} days', da:'Udl\u00f8ber om {days} dage', sv:'G\u00e5r ut om {days} dagar', es:'Expira en {days} d\u00edas', fr:'Expire dans {days} jours', de:'L\u00e4uft in {days} Tagen ab' },
   lastDay:{ en:'Last day', da:'Sidste dag', sv:'Sista dagen', es:'\u00daltimo d\u00eda', fr:'Dernier jour', de:'Letzter Tag' },
   missingFieldsTitle:{ en:'Missing information', da:'Mangler information', sv:'Saknar information', es:'Falta información', fr:'Informations manquantes', de:'Fehlende Angaben' },
   missingFieldsDesc:{ en:'Please fill out all required fields', da:'Udfyld venligst alle obligatoriske felter', sv:'Vänligen fyll i alla obligatoriska fält', es:'Por favor, completa todos los campos obligatorios', fr:'Veuillez remplir tous les champs obligatoires', de:'Bitte fülle alle Pflichtfelder aus' },


### PR DESCRIPTION
## Summary
- Remove "Expires in" countdown text from profile lists and episodes
- Cleanup translation strings to drop unused `expiresIn`

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a772574890832d9d6b168344bbb35d