### PR TITLE
Translate pricing page to Danish

### DIFF
--- a/public/pricing.html
+++ b/public/pricing.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>RealDate - Pricing</title>
+  <title>RealDate - Priser</title>
   <style>
     body {
       font-family: Arial, sans-serif;
@@ -50,71 +50,71 @@
 </head>
 <body>
   <header>
-    <h1>RealDate Pricing</h1>
-    <p>Choose the plan that's right for you</p>
-    <a class="cta" href="index.html">Back to Home</a>
+    <h1>RealDate-priser</h1>
+    <p>Vælg den plan, der passer bedst til dig</p>
+    <a class="cta" href="index.html">Tilbage til forsiden</a>
   </header>
   <section>
     <table>
       <tr>
-        <th>Feature</th>
-        <th>Free</th>
-        <th>Silver</th>
-        <th>Gold</th>
-        <th>Platinum</th>
+        <th>Funktion</th>
+        <th>Gratis</th>
+        <th>Sølv</th>
+        <th>Guld</th>
+        <th>Platin</th>
       </tr>
       <tr>
-        <td>Daily profile limit</td>
+        <td>Daglig profilgrænse</td>
         <td>3</td>
         <td>5</td>
         <td>8</td>
         <td>10</td>
       </tr>
       <tr>
-        <td>Group chat based on interests</td>
+        <td>Gruppechat baseret på interesser</td>
         <td>&#10060;</td>
         <td>&#10003;</td>
         <td>&#10003;</td>
         <td>&#10003;</td>
       </tr>
       <tr>
-        <td>Ratings</td>
+        <td>Bedømmelser</td>
         <td>&#10060;</td>
         <td>&#10060;</td>
         <td>&#10003;</td>
         <td>&#10003;</td>
       </tr>
       <tr>
-        <td>See who liked you</td>
+        <td>Se, hvem der har syntes om dig</td>
         <td>&#10060;</td>
         <td>&#10060;</td>
         <td>&#10003;</td>
         <td>&#10003;</td>
       </tr>
       <tr>
-        <td>Super like per week</td>
+        <td>Super-like pr. uge</td>
         <td>&#10060;</td>
         <td>1</td>
         <td>3</td>
         <td>5</td>
       </tr>
       <tr>
-        <td>Boost visibility</td>
+        <td>Øg synlighed</td>
         <td>&#10060;</td>
-        <td>1/month</td>
-        <td>2/month</td>
-        <td>4/month</td>
+        <td>1/måned</td>
+        <td>2/måned</td>
+        <td>4/måned</td>
       </tr>
       <tr>
-        <td>Ad-free experience</td>
-        <td>Ads</td>
+        <td>Annoncefri oplevelse</td>
+        <td>Annoncer</td>
         <td>&#10003;</td>
-        <td>&#10003; (priority)</td>
-        <td>&#10003; (priority)</td>
+        <td>&#10003; (prioritet)</td>
+        <td>&#10003; (prioritet)</td>
       </tr>
       <tr>
-        <td><strong>Price (DKK/month)</strong></td>
-        <td><strong>Free</strong></td>
+        <td><strong>Pris (DKK/måned)</strong></td>
+        <td><strong>Gratis</strong></td>
         <td><strong>39</strong></td>
         <td><strong>79</strong></td>
         <td><strong>139</strong></td>


### PR DESCRIPTION
## Summary
- Localized pricing page for RealDate to Danish with translated headers, CTA, and feature table.

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a7753245ac832db6bd8b6e277dbb64