### PR TITLE
Remove read receipts and typing indicators

### DIFF
--- a/FEATURES.txt
+++ b/FEATURES.txt
@@ -1,7 +1,6 @@
 Daily discovery of short video clips
 Three-step episodic flow for each profile (reflection, reaction, connection)
 Basic chat between matched profiles
-Typing indicators show when the other person is composing a message
 Unmatch to remove chat from both users
 Calendar interface for daily reflection notes
 Profile settings with age range filtering

--- a/README.md
+++ b/README.md
@@ -21,7 +21,6 @@ Profiles are presented as short episodes rather than a catalog of faces. Each ep
 * Monthly subscriptions with visible expiration date and stored purchase date
 * Basic chat between matched profiles with option to unmatch
 * Improved chat layout with timestamps for better readability
-* Typing indicators show when the other person is composing a message
 * Celebration overlay when two profiles match
 * Calendar for daily reflections
 * Minimal profile settings and admin mode

--- a/docs/marketing/denmark-market-business-case.md
+++ b/docs/marketing/denmark-market-business-case.md
@@ -24,7 +24,6 @@ VideoTinder uses a freemium model with three paid membership levels that expand 
 | Video creation tools (music) | ❌ | ❌ | ✓ | ✓ |
 | Longer videos | ❌ | ❌ | 15 sec | 25 sec |
 | Ad-free experience | Ads | ✓ | ✓ (priority) | ✓ (priority) |
-| Read receipts & typing indicators | ❌ | ❌ | ✓ | ✓ |
 | Advanced profile analytics | ❌ | ❌ | ✓ (basic) | ✓ (advanced) |
 
 Daily refers to days where the user is active

--- a/src/utils.js
+++ b/src/utils.js
@@ -112,11 +112,6 @@ export function hasAdvancedFilters(user){
   return tier !== 'free';
 }
 
-export function hasReadReceipts(user){
-  const tier = user?.subscriptionTier || 'free';
-  return tier === 'gold';
-}
-
 export function hasRatings(user){
   const tier = user?.subscriptionTier || 'free';
   return tier === 'gold';

--- a/src/utils.test.js
+++ b/src/utils.test.js
@@ -14,7 +14,6 @@ import {
   getMaxVideoSeconds,
   hasInterestChat,
   hasAdvancedFilters,
-  hasReadReceipts,
   hasRatings,
   getWeekId
   ,clearAppCache
@@ -116,11 +115,6 @@ describe('utils', () => {
   test('hasAdvancedFilters requires paid tier', () => {
     expect(hasAdvancedFilters({ subscriptionTier: 'gold' })).toBe(true);
     expect(hasAdvancedFilters({ subscriptionTier: 'free' })).toBe(false);
-  });
-
-  test('hasReadReceipts only for gold tier', () => {
-    expect(hasReadReceipts({ subscriptionTier: 'gold' })).toBe(true);
-    expect(hasReadReceipts({ subscriptionTier: 'free' })).toBe(false);
   });
 
   test('hasRatings only for gold tier', () => {


### PR DESCRIPTION
## Summary
- remove mentions of typing indicators from docs and feature lists
- drop read receipt and typing indicator logic from chat UI
- remove read receipt utility and tests

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a853b0579c832dbed250e8e76ab8a2