### PR TITLE
Increase daily feed limits to 5 and 10 profiles

### DIFF
--- a/docs/marketing/app-pages-da.md
+++ b/docs/marketing/app-pages-da.md
@@ -22,9 +22,9 @@
 
 ## Dit feed
  - Ved indgang vises listen med kandidatprofiler samt eventuelle likede profiler.
-- Listen indeholder aktive profiler fra tidligere dage plus dagens nye (3 gratis, 5 med Silver, 8 med Gold og 10 med Platinum).
+- Listen indeholder aktive profiler fra tidligere dage plus dagens nye (5 gratis og 10 med Guld).
 - Hvis serveren returnerer for få nye profiler, vises kun de profiler, der er tilgængelige.
-- Gratis brugere ser bannerannoncer; Silver og opefter er reklamefri.
+- Gratis brugere ser bannerannoncer; Guld er reklamefri.
  - Brugeren kan skrive en privat refleksion.
  - Refleksioner gemmes for alle og vises sammen med refleksionskalenderen.
 - **Handlinger på kandidatlisten**
@@ -32,7 +32,7 @@
   - Vælg "Like" (kan blive til et match).
   - Vælg "Super like" for at signalere ekstra interesse (1, 3 eller 5 pr. uge afhængigt af abonnement).
     - Vælg "Remove" for at fjerne profilen helt.
-  - Silver kan fortryde den seneste "Remove"; Gold og Platinum kan fortryde flere.
+  - Guld-brugere kan fortryde flere "Remove".
   - Brugeren kan én gang dagligt købe ekstra profiler (gratis nu - betaling ikke implementeret).
 
 ### Offentlig kandidatprofil

--- a/public/pricing.html
+++ b/public/pricing.html
@@ -62,9 +62,9 @@
         <th>Guld</th>
       </tr>
       <tr>
-        <td>Daglig profilgrænse</td>
-        <td>3</td>
-        <td>8</td>
+        <td>Maks profiler i dit feed</td>
+        <td>5</td>
+        <td>10</td>
       </tr>
       <tr>
         <td>Gruppechat baseret på interesser</td>

--- a/src/components/SubscriptionOverlay.jsx
+++ b/src/components/SubscriptionOverlay.jsx
@@ -4,8 +4,8 @@ import { Button } from './ui/button.js';
 
 export default function SubscriptionOverlay({ onClose, onBuy, allowFree = false }) {
   const plans = [
-    ...(allowFree ? [{ tier: 'free', title: 'Freemium', price: '0 kr/md', daily: 3, seconds: 10, boosts: 0 }] : []),
-    { tier: 'gold', title: 'Guld', price: '79 kr/md', daily: 8, seconds: 15, boosts: 2 }
+    ...(allowFree ? [{ tier: 'free', title: 'Freemium', price: '0 kr/md', daily: 5, seconds: 10, boosts: 0 }] : []),
+    { tier: 'gold', title: 'Guld', price: '79 kr/md', daily: 10, seconds: 15, boosts: 2 }
   ];
   const [selected, setSelected] = useState(plans[0].tier);
   return React.createElement('div', { className: 'fixed inset-0 z-50 bg-black/50 flex items-center justify-center' },

--- a/src/utils.js
+++ b/src/utils.js
@@ -80,7 +80,7 @@ export function detectBrowser(){
 
 export function getDailyProfileLimit(user){
   const tier = user?.subscriptionTier || 'free';
-  const limits = { free:3, gold:8 };
+  const limits = { free:5, gold:10 };
   return limits[tier] ?? limits.free;
 }
 

--- a/src/utils.test.js
+++ b/src/utils.test.js
@@ -88,8 +88,8 @@ describe('utils', () => {
   });
 
   test('getDailyProfileLimit respects tier', () => {
-    expect(getDailyProfileLimit({ subscriptionTier: 'gold' })).toBe(8);
-    expect(getDailyProfileLimit({})).toBe(3);
+    expect(getDailyProfileLimit({ subscriptionTier: 'gold' })).toBe(10);
+    expect(getDailyProfileLimit({})).toBe(5);
   });
 
   test('getSuperLikeLimit respects tier', () => {


### PR DESCRIPTION
## Summary
- Update pricing page to show 5 free and 10 gold feed slots
- Adjust subscription overlay and logic to enforce 5/10 daily profile limits
- Refresh marketing docs and tests to match new limits

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a8582ade44832d89aa3a55b83d4664