### PR TITLE
Reduce invitation limit from 10 to 3

### DIFF
--- a/src/components/InviteOverlay.jsx
+++ b/src/components/InviteOverlay.jsx
@@ -12,7 +12,7 @@ export default function InviteOverlay({ userId, onClose }) {
   const invitesUsed = invites.filter(inv => inv.gift).length;
   const config = useDoc('config','app') || {};
   const invitesEnabled = config.premiumInvitesEnabled !== false;
-  const remaining = 10 - invitesUsed;
+  const remaining = 3 - invitesUsed;
   const noInvites = invitesEnabled && remaining <= 0;
   const [recipient, setRecipient] = useState('');
   const [link, setLink] = useState('');

--- a/src/components/WelcomeScreen.jsx
+++ b/src/components/WelcomeScreen.jsx
@@ -180,7 +180,7 @@ export default function WelcomeScreen({ onLogin }) {
     if (giftFrom && inviteValid) {
       try {
         const inviterSnap = await getDoc(doc(db, 'profiles', giftFrom));
-        if (!inviterSnap.exists() || (inviterSnap.data().premiumInvitesUsed || 0) >= 10) {
+        if (!inviterSnap.exists() || (inviterSnap.data().premiumInvitesUsed || 0) >= 3) {
           giftFrom = null;
           inviteValid = false;
         }
@@ -316,7 +316,7 @@ export default function WelcomeScreen({ onLogin }) {
     if (giftFrom && inviteValid) {
       try {
         const inviterSnap = await getDoc(doc(db, 'profiles', giftFrom));
-        if (!inviterSnap.exists() || (inviterSnap.data().premiumInvitesUsed || 0) >= 10) {
+        if (!inviterSnap.exists() || (inviterSnap.data().premiumInvitesUsed || 0) >= 3) {
           giftFrom = null;
           inviteValid = false;
         }

--- a/src/functionTestModules.js
+++ b/src/functionTestModules.js
@@ -246,7 +246,7 @@ export const modules = [
         ]
       },
       {
-        title: 'Gift 3 months of premium with up to ten invites',
+        title: 'Gift 3 months of premium with up to three invites',
         expected: [
           'Premium gift enabled when invites are available',
           'Remaining gift count is displayed',

--- a/src/i18n.js
+++ b/src/i18n.js
@@ -126,7 +126,7 @@ inviteAccepted:{ en:"Profile created", da:"Oprettet", sv:"Skapad", es:"Perfil cr
   helpTitle:{ en:'Help', da:'Hjælp', sv:'Hjälp', es:'Ayuda', fr:'Aide', de:'Hilfe' },
   helpLevels:{ en:'On the Daily Life page each profile has three levels. Watch clips to unlock more content.', da:'På siden Dagens liv har hver profil tre niveauer. Se klip for at låse mere op.' },
   helpSupport:{ en:'Need assistance? Choose "Report bug" on the About page to contact support.', da:'Brug for hjælp? Vælg \"Fejlmeld\" på Om RealDate-siden for at kontakte support.' },
-  helpInvites:{ en:'You can send up to ten invitations. Follow each invitation until your friend has created a profile.', da:'Du kan sende op til ti invitationer. Følg hver invitation, indtil din ven har oprettet en profil.' },
+  helpInvites:{ en:'You can send up to three invitations. Follow each invitation until your friend has created a profile.', da:'Du kan sende op til tre invitationer. Følg hver invitation, indtil din ven har oprettet en profil.' },
   dailyHelpLabel:{ en:'Need help?', da:'Brug for hjælp?' },
   dailyHelpTitle:{ en:'Daily Clips Help', da:'Hjælp til Dit feed' },
   dailyHelpText:{


### PR DESCRIPTION
## Summary
- Lower invitation allowance per user from 10 to 3
- Update invitation texts and helper messages to mention three invites
- Adjust function test module to reflect new invite cap

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a85ac4b6c0832d9312704d1923cedb