### PR TITLE
Remove references to discontinued Silver and Platinum tiers

### DIFF
--- a/docs/marketing/app-pages-da.md
+++ b/docs/marketing/app-pages-da.md
@@ -13,12 +13,12 @@
   - Videoklip 2 og 3
 - En hjælpefunktion i toppen guider brugeren gennem disse skridt.
 - Brugeren kan slette sin profil.
-- Videoklip kan maksimalt vare 10 sekunder (15 sekunder med Gold, 25 sekunder med Platinum); en timer tæller ned under optagelsen, og Gold/Platinum kan tilføje baggrundsmusik.
+ - Videoklip kan maksimalt vare 10 sekunder (15 sekunder med Gold); en timer tæller ned under optagelsen, og Gold kan tilføje baggrundsmusik.
 - inden en optagelse vises brugerens video illede og der tælles ned 3-2-1.
 - **Indstillinger**
-  - Vælg køn og aldersinterval for kandidater. Gold og Platinum får adgang til alle avancerede filtre.
+   - Vælg køn og aldersinterval for kandidater. Gold får adgang til alle avancerede filtre.
   - Markér op til fem interesser, der kan bruges i interessechatten og kan øge march score
-  - Aktiver incognito-tilstand for anonym browsing (kun Platinum).
+   - Aktiver incognito-tilstand for anonym browsing (kun Gold).
 
 ## Dit feed
  - Ved indgang vises listen med kandidatprofiler samt eventuelle likede profiler.
@@ -52,11 +52,11 @@
 - Chat med matchede brugere.
 - Start videokald.
 - Mulighed for at unmatche.
-- Gold og Platinum får læsekvitteringer og skriverindikatorer.
+ - Gold får læsekvitteringer og skriverindikatorer.
 
 ## Interessechat
-- Chat i grupper baseret på valgte interesser (kræver mindst Silver).
-- Gold og Platinum får prioriteret placering i chatlisterne (Platinum med topprioritet).
+ - Chat i grupper baseret på valgte interesser (kræver Gold).
+ - Gold får prioriteret placering i chatlisterne.
 
 ## Notifikationer
 - Viser systembeskeder og invitationer sorteret efter dato.
@@ -68,8 +68,8 @@
   Når en invitation er sendt, følges der med i, om brugeren opretter profil.
 
 ## Du er blevet liket
-- Viser en liste over kandidatprofiler, hvis brugeren har Gold eller Platinum.
-- Uden Gold/Platinum er listen sløret, og brugeren får tilbud om at opgradere.
+ - Viser en liste over kandidatprofiler, hvis brugeren har Gold.
+ - Uden Gold er listen sløret, og brugeren får tilbud om at opgradere.
 
 ## Login og opret bruger
 - Log ind med e-mail eller Google.

--- a/docs/marketing/denmark-market-business-case.md
+++ b/docs/marketing/denmark-market-business-case.md
@@ -3,58 +3,57 @@
 ## Market Overview
 - **Population (2023):** ~5.9 million people
 - **Adults aged 18-65:** ~3.5 million
-- **Single adults (\~50% of adults):** ~1.75 million
-- **Smartphone penetration (\~90%):** ~1.58 million potential mobile users
-- **Dating app adoption among singles (\~40%):** ~0.70 million users familiar with dating apps
+- **Single adults (~50% of adults):** ~1.75 million
+- **Smartphone penetration (~90%):** ~1.58 million potential mobile users
+- **Dating app adoption among singles (~40%):** ~0.70 million users familiar with dating apps
 
 ## Subscription Tiers
-VideoTinder uses a freemium model with three paid membership levels that expand visibility and creative tools. Existing capabilities and planned extensions are summarized below.
+VideoTinder uses a freemium model with a single paid membership level (Gold) that expands visibility and creative tools. Existing capabilities and planned extensions are summarized below.
 
-| Feature | Free | Silver | Gold | Platinum |
-| --- | --- | --- | --- | --- |
-| Daily profile limit | 3 | 5 | 8 | 10 |
-| Group chat based on interests | ❌ | ✓ | ✓ | ✓ |
-| Ratings | ❌ | ❌ | ✓ | ✓ |
-| See who liked you | ❌ | ❌ | ✓ | ✓ |
-| Undo removes | ❌ | last | ✓ | ✓ |
-| Super like per week | ❌ | 1 | 3 | 5 |
-| Boost visibility | ❌ | 1/month | 2/month | 4/month |
-| Advanced filters (gender, age, etc.) | gender, age | gender, age | Full | Full |
-| Incognito mode | ❌ | ❌ | ❌ | ✓ |
-| Video creation tools (music) | ❌ | ❌ | ✓ | ✓ |
-| Longer videos | ❌ | ❌ | 15 sec | 25 sec |
-| Ad-free experience | Ads | ✓ | ✓ (priority) | ✓ (priority) |
-| Advanced profile analytics | ❌ | ❌ | ✓ (basic) | ✓ (advanced) |
+| Feature | Free | Gold |
+| --- | --- | --- |
+| Daily profile limit | 5 | 10 |
+| Group chat based on interests | ❌ | ✓ |
+| Ratings | ❌ | ✓ |
+| See who liked you | ❌ | ✓ |
+| Undo removes | ❌ | ✓ |
+| Super like per week | 1 | 5 |
+| Boost visibility | ❌ | 2/month |
+| Advanced filters (gender, age, etc.) | gender, age | Full |
+| Incognito mode | ❌ | ✓ |
+| Video creation tools (music) | ❌ | ✓ |
+| Longer videos | 10 sec | 15 sec |
+| Ad-free experience | Ads | ✓ |
+| Advanced profile analytics | ❌ | ✓ (basic) |
 
-Daily refers to days where the user is active
+Daily refers to days where the user is active.
 
-Suggested pricing (DKK/month): **Silver 39**, **Gold 79**, **Platinum 139**
+Suggested pricing (DKK/month): **Gold 79**
 
 ## Revenue Projection
 Assumptions:
 - Expected market penetration for VideoTinder: **10%** of dating app users -> **70,000 users**
 - Premium conversion: **10%** of VideoTinder users -> **7,000 paying subscribers**
-- Tier distribution: **60% Silver**, **30% Gold**, **10% Platinum**
 - App Store commission on subscriptions: **30%**
-- Average income pr user pr year: 10% premium conversion × 70% net subscription revenue (after Apple's fee) + banner ads (300 impressions/user/month × 7 DKK CPM) = **69.6 DKK** (≈10 USD)
+- Average income pr user pr year: 10% premium conversion × 70% net subscription revenue (after Apple's fee) + banner ads (300 impressions/user/month × 7 DKK CPM) = **91.6 DKK**
 
 Annual revenue:
-- Subscriptions: 4,200 Silver × 39 DKK × 12 + 2,100 Gold × 79 DKK × 12 + 700 Platinum × 139 DKK × 12 = **5,124,000 DKK**
+- Subscriptions: 7,000 Gold × 79 DKK × 12 = **6,636,000 DKK**
 - Banner ads (bottom placement): 70,000 users × 300 impressions/user/month × 12 months ÷ 1,000 × 7 DKK ≈ **1,764,000 DKK**
-- **Total:** **6,888,000 DKK** (≈0.99M USD)
+- **Total:** **8,400,000 DKK**
 
 ## Cost Estimate
 - Infrastructure and support: **20 DKK** per user per year -> 70,000 × 20 = **1,400,000 DKK**
 - Marketing and user acquisition: **3,000,000 DKK**
 - Operational overhead (staff, legal, admin): **2,000,000 DKK**
-- Payment processing (Apple App Store 30% commission on subscriptions): **1,537,200 DKK**
+- Payment processing (Apple App Store 30% commission on subscriptions): **1,990,800 DKK**
 
-Total estimated annual cost: **7,937,200 DKK**
+Total estimated annual cost: **8,390,800 DKK**
 
 ## Break-even Analysis
-- Estimated annual profit: 6,888,000 − 7,937,200 = **−1,049,200 DKK**
-- Break-even premium users: (7,937,200 − 1,764,000) ÷ (61 × 12 × 0.7) ≈ **12,000 paying users**
-- Break-even total users (at 10% premium conversion): **120,000 users**
+- Estimated annual profit: 8,400,000 − 8,390,800 = **9,200 DKK**
+- Break-even premium users: (8,390,800 − 1,764,000) ÷ (79 × 12 × 0.7) ≈ **10,000 paying users**
+- Break-even total users (at 10% premium conversion): **100,000 users**
 
 ## First Three Years Outlook
 To reach the full penetration and conversion assumptions above, the first few years are expected to ramp up gradually.
@@ -62,33 +61,33 @@ To reach the full penetration and conversion assumptions above, the first few ye
 ### Year 1: Establish the product and gather feedback
 - **Penetration:** 2% of dating app users → **14,000 total users**
 - **Premium conversion:** 5% → **700 paying subscribers**
-- **Annual revenue:** 420 Silver, 210 Gold, 70 Platinum + banner ads (~352,800 DKK) → **865,200 DKK**
-- **Estimated costs:** infrastructure (280,000 DKK), marketing (1,000,000 DKK), overhead (1,500,000 DKK), Apple commission (153,720 DKK)
-- **Net result:** **−2,068,520 DKK** while investing in product-market fit
+- **Annual revenue:** 700 Gold × 79 DKK × 12 + banner ads (~352,800 DKK) → **1,016,400 DKK**
+- **Estimated costs:** infrastructure (280,000 DKK), marketing (1,000,000 DKK), overhead (1,500,000 DKK), Apple commission (199,080 DKK)
+- **Net result:** **−1,962,680 DKK** while investing in product-market fit
 
 ### Year 2: Refine features and begin scaling
 - **Penetration:** 5% → **35,000 total users**
 - **Premium conversion:** 8% → **2,800 paying subscribers**
-- **Annual revenue:** 1,680 Silver, 840 Gold, 280 Platinum + banner ads (~882,000 DKK) → **2,931,600 DKK**
-- **Estimated costs:** infrastructure (700,000 DKK), marketing (2,000,000 DKK), overhead (1,800,000 DKK), Apple commission (614,880 DKK)
-- **Net result:** **−2,183,280 DKK**, moving toward break-even
+- **Annual revenue:** 2,800 Gold × 79 DKK × 12 + banner ads (~882,000 DKK) → **3,536,400 DKK**
+- **Estimated costs:** infrastructure (700,000 DKK), marketing (2,000,000 DKK), overhead (1,800,000 DKK), Apple commission (796,320 DKK)
+- **Net result:** **−1,759,920 DKK**, moving toward break-even
 
 ### Year 3: Expand reach and solidify monetization
 - **Penetration:** 8% → **56,000 total users**
 - **Premium conversion:** 9% → **5,040 paying subscribers**
-- **Annual revenue:** 3,024 Silver, 1,512 Gold, 504 Platinum + banner ads (~1,411,200 DKK) → **5,100,480 DKK**
-- **Estimated costs:** infrastructure (1,120,000 DKK), marketing (2,500,000 DKK), overhead (1,900,000 DKK), Apple commission (1,106,784 DKK)
-- **Net result:** **−1,526,304 DKK** as tiered pricing and ads drive profitability
+- **Annual revenue:** 5,040 Gold × 79 DKK × 12 + banner ads (~1,411,200 DKK) → **6,189,120 DKK**
+- **Estimated costs:** infrastructure (1,120,000 DKK), marketing (2,500,000 DKK), overhead (1,900,000 DKK), Apple commission (1,433,376 DKK)
+- **Net result:** **−764,256 DKK** as subscriptions and ads grow
 
 ## Q1 2025 Revenue Example
 An early projection for the launch quarter illustrates potential income with 10,000–20,000 users and a 5% premium conversion rate.
 
 | Antal brugere | Betalende brugere (5 %) | ARPU (DKK) | Månedsindtægt (DKK) | Indtægt i Q1 (DKK) |
 | --- | --- | --- | --- | --- |
-| 10,000 | 500 | 99 | 49,500 | 148,500 |
-| 20,000 | 1,000 | 99 | 99,000 | 297,000 |
+| 10,000 | 500 | 97 | 48,650 | 145,950 |
+| 20,000 | 1,000 | 97 | 97,300 | 291,900 |
 
-This suggests a quarterly revenue range of **150,000–300,000 DKK**.
+This suggests a quarterly revenue range of **146,000–292,000 DKK**.
 
 ## Strategic Considerations
 - High smartphone usage and a large single population support market entry
@@ -96,3 +95,4 @@ This suggests a quarterly revenue range of **150,000–300,000 DKK**.
 - Successful adoption in Denmark can serve as a springboard to other Nordic countries
 
 *All figures are estimates based on publicly available demographic data and standard SaaS cost assumptions.*
+

--- a/src/components/InterestChatScreen.jsx
+++ b/src/components/InterestChatScreen.jsx
@@ -66,7 +66,7 @@ export default function InterestChatScreen({ userId, onSelectProfile = null }) {
   if(!canUseInterestChat){
     return React.createElement(Card, { className:'p-6 m-4 shadow-xl bg-white/90 flex flex-col items-center text-center' },
       React.createElement(SectionTitle, { title: t('interestChatsTitle') }),
-      React.createElement('p', { className:'text-gray-600 mb-4' }, 'Kræver Sølv, Guld eller Platin'),
+      React.createElement('p', { className:'text-gray-600 mb-4' }, 'Kræver Guld'),
       React.createElement(Button, { className:'bg-pink-500 text-white', onClick:()=>window.dispatchEvent(new CustomEvent('showSubscription')) }, 'Køb abonnement (gratis nu - betaling ikke implementeret)')
     );
   }


### PR DESCRIPTION
## Summary
- Restrict interest chat access message to Gold membership
- Update Danish app pages doc to remove Silver and Platinum references
- Revise Denmark market business case for a single Gold tier

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a85d7f2004832da41d8baad9d372a9