### PR TITLE
feat: rename settings card to subscription

### DIFF
--- a/docs/marketing/app-pages-da.md
+++ b/docs/marketing/app-pages-da.md
@@ -15,7 +15,7 @@
 - Brugeren kan slette sin profil.
  - Videoklip kan maksimalt vare 10 sekunder (15 sekunder med Gold); en timer tæller ned under optagelsen, og Gold kan tilføje baggrundsmusik.
 - inden en optagelse vises brugerens video illede og der tælles ned 3-2-1.
-- **Indstillinger**
+- **Mit abonnement**
    - Vælg køn og aldersinterval for kandidater. Gold får adgang til alle avancerede filtre.
   - Markér op til fem interesser, der kan bruges i interessechatten og kan øge march score
    - Aktiver incognito-tilstand for anonym browsing (kun Gold).

--- a/src/i18n.js
+++ b/src/i18n.js
@@ -209,7 +209,7 @@ inviteAccepted:{ en:"Profile created", da:"Oprettet", sv:"Skapad", es:"Perfil cr
   gameTitle:{ en:'Guess My Choice', da:'Gæt mit valg' },
   superLike:{ en:'Super like', da:'Super like', sv:'Super like', es:'Súper like', fr:'Super like', de:'Super like' },
   incognitoMode:{ en:'Incognito mode', da:'Incognito-tilstand', sv:'Inkognito-läge', es:'Modo incógnito', fr:'Mode incognito', de:'Inkognito-Modus' },
-  settings:{ en:'Settings', da:'Indstillinger', sv:'Inställningar', es:'Configuración', fr:'Paramètres', de:'Einstellungen' },
+  settings:{ en:'Settings', da:'Mit abonnement', sv:'Inställningar', es:'Configuración', fr:'Paramètres', de:'Einstellungen' },
   addMusic:{ en:'Add music', da:'Tilføj musik', sv:'Lägg till musik', es:'Agregar música', fr:'Ajouter de la musique', de:'Musik hinzufügen' },
   videoTooLong:{ en:'Video may be at most {seconds} seconds', da:'Video må højst være {seconds} sekunder', sv:'Videon får högst vara {seconds} sekunder', es:'El video puede durar como máximo {seconds} segundos', fr:'La vidéo peut durer au maximum {seconds} secondes', de:'Video darf höchstens {seconds} Sekunden lang sein' },
   adminBugReports:{ en:'Bug reports', da:'Fejlmeldinger', sv:'Buggrapporter', es:'Informes de errores', fr:'Rapports de bugs', de:'Fehlermeldungen' },


### PR DESCRIPTION
## Summary
- replace Danish translation for settings card with "Mit abonnement"
- update marketing doc to reflect new subscription heading

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a86e67af20832d8006d835dc722137