### PR TITLE
Remove Android instructions from FAQ

### DIFF
--- a/public/faq.html
+++ b/public/faq.html
@@ -29,7 +29,7 @@
       </div>
       <div>
         <h2 class="font-semibold">Hvordan får jeg notifikationer?</h2>
-        <p>For at få notifikationer skal du installere RealDate på din hjemmeskærm. På Android: Åbn RealDate i Chrome, tryk på menuen og vælg <strong>Tilføj til hjemmeskærm</strong> eller <strong>Installer app</strong>, og bekræft. På iOS: Åbn siden i Safari, tryk på delingsknappen og vælg <strong>Føj til hjemmeskærm</strong>. Når appen åbnes fra hjemmeskærmen, skal du tillade notifikationer, når du bliver spurgt.</p>
+        <p>For at få notifikationer på iPhone skal du installere RealDate på din hjemmeskærm. Åbn siden i Safari, tryk på delingsknappen og vælg <strong>Føj til hjemmeskærm</strong>. Når appen åbnes fra hjemmeskærmen, skal du tillade notifikationer, når du bliver spurgt.</p>
       </div>
     </div>
     <a href="./index.html" class="block mt-6 text-center text-pink-600 font-semibold">Tilbage til forsiden</a>


### PR DESCRIPTION
## Summary
- remove Android notification instructions from FAQ, focusing on iPhone

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a86eaebb8c832db7df4f90839b2433