### PR TITLE
Rename settings card to My subscription

### DIFF
--- a/docs/marketing/app-pages-da.md
+++ b/docs/marketing/app-pages-da.md
@@ -15,9 +15,9 @@
 - Brugeren kan slette sin profil.
  - Videoklip kan maksimalt vare 10 sekunder; en timer tæller ned under optagelsen.
  - inden en optagelse vises brugerens video illede og der tælles ned 3-2-1.
- - **Indstillinger**
+ - **Mit abonnement**
    - Vælg køn og aldersinterval for kandidater. Gold får adgang til alle avancerede filtre.
-  - Markér op til fem interesser, der kan bruges i interessechatten og kan øge march score
+   - Markér op til fem interesser, der kan bruges i interessechatten og kan øge march score
 
 ## Dit feed
  - Ved indgang vises listen med kandidatprofiler samt eventuelle likede profiler.

--- a/src/components/ProfileSettings.jsx
+++ b/src/components/ProfileSettings.jsx
@@ -715,8 +715,8 @@ export default function ProfileSettings({ userId, ageRange, onChangeAgeRange, pu
         'Nye beskeder'
       ),
     ),
-      !publicView && React.createElement(Card, { className:'p-6 m-4 shadow-xl bg-white/90' },
-          React.createElement(SectionTitle, { title: t('settings') }),
+        !publicView && React.createElement(Card, { className:'p-6 m-4 shadow-xl bg-white/90' },
+            React.createElement(SectionTitle, { title: t('mySubscription') }),
           profile.subscriptionExpires && React.createElement('p', {
             className: 'text-center text-sm mt-2 flex items-center justify-center gap-1 ' + (subscriptionActive ? 'text-green-600' : 'text-red-500')
           },

--- a/src/i18n.js
+++ b/src/i18n.js
@@ -207,9 +207,17 @@ inviteAccepted:{ en:"Profile created", da:"Oprettet", sv:"Skapad", es:"Perfil cr
     de:'Keine Interessen ausgewählt. Füge Interessen auf deiner Profilseite hinzu.'
   },
   gameTitle:{ en:'Guess My Choice', da:'Gæt mit valg' },
-  superLike:{ en:'Super like', da:'Super like', sv:'Super like', es:'Súper like', fr:'Super like', de:'Super like' },
-  settings:{ en:'Settings', da:'Indstillinger', sv:'Inställningar', es:'Configuración', fr:'Paramètres', de:'Einstellungen' },
-  videoTooLong:{ en:'Video may be at most {seconds} seconds', da:'Video må højst være {seconds} sekunder', sv:'Videon får högst vara {seconds} sekunder', es:'El video puede durar como máximo {seconds} segundos', fr:'La vidéo peut durer au maximum {seconds} secondes', de:'Video darf höchstens {seconds} Sekunden lang sein' },
+    superLike:{ en:'Super like', da:'Super like', sv:'Super like', es:'Súper like', fr:'Super like', de:'Super like' },
+    settings:{ en:'Settings', da:'Indstillinger', sv:'Inställningar', es:'Configuración', fr:'Paramètres', de:'Einstellungen' },
+    mySubscription:{
+      en:'My subscription',
+      da:'Mit abonnement',
+      sv:'Mitt abonnemang',
+      es:'Mi suscripción',
+      fr:'Mon abonnement',
+      de:'Mein Abonnement'
+    },
+    videoTooLong:{ en:'Video may be at most {seconds} seconds', da:'Video må højst være {seconds} sekunder', sv:'Videon får högst vara {seconds} sekunder', es:'El video puede durar como máximo {seconds} segundos', fr:'La vidéo peut durer au maximum {seconds} secondes', de:'Video darf höchstens {seconds} Sekunden lang sein' },
   adminBugReports:{ en:'Bug reports', da:'Fejlmeldinger', sv:'Buggrapporter', es:'Informes de errores', fr:'Rapports de bugs', de:'Fehlermeldungen' },
   adminBusiness:{ en:'Business and statistics', da:'Business og statistik', sv:'Aff\u00e4r och statistik', es:'Negocios y estad\u00edsticas', fr:'Business et statistiques', de:'Gesch\u00e4ft und Statistik' },
   adminDaily:{ en:'Daily admin', da:'Daglig administration', sv:'Daglig administration', es:'Administraci\u00f3n diaria', fr:'Administration quotidienne', de:'T\u00e4gliche Verwaltung' },


### PR DESCRIPTION
## Summary
- Rename profile settings card heading to translation key `mySubscription`
- Add `mySubscription` translations across supported languages
- Update Danish marketing doc to reflect new "Mit abonnement" section

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a885955550832da459336d31b96ffe